### PR TITLE
chore: Make author info consistent with other patterns

### DIFF
--- a/packages/albert/config/index.js
+++ b/packages/albert/config/index.js
@@ -3,8 +3,8 @@ import { version } from '../package.json'
 export default {
   name: 'albert',
   version,
-  design: 'WouterVdub',
-  code: 'WouterVdub',
+  design: 'Wouter Van Wageningen',
+  code: 'Wouter Van Wageningen',
   department: 'unisex',
   type: 'pattern',
   difficulty: 3,


### PR DESCRIPTION
This change updates the config file of Albert to use the same
name as other patterns by @woutervdub

I literally copy-pasted in the relevant lines from the
Benjamin config file