### PR TITLE
Remove extra space in svg group translate

### DIFF
--- a/packages/core/src/pattern.js
+++ b/packages/core/src/pattern.js
@@ -464,7 +464,7 @@ Pattern.prototype.pack = function () {
     let size = pack(bins, { inPlace: true })
     for (let bin of bins) {
       let part = this.parts[bin.id]
-      if (bin.x !== 0 || bin.y !== 0) part.attr('transform', `translate (${bin.x}, ${bin.y})`)
+      if (bin.x !== 0 || bin.y !== 0) part.attr('transform', `translate(${bin.x}, ${bin.y})`)
     }
     this.width = size.width
     this.height = size.height


### PR DESCRIPTION
Closes #692 

There was an extra space in the second `translate(x, y)` for SVG group tags, causing Illustrator to ignore that translation and render all pattern pieces in the same spot.