### PR TITLE
Add template for documentation/content updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-update.md
+++ b/.github/ISSUE_TEMPLATE/documentation-update.md
@@ -1,0 +1,16 @@
+---
+name: Documentation/content update
+about: Suggest updates to FreeSewing documentation or site content
+title: Documentation/content update
+labels: "\U0001F44D good first issue, \U0001F4D6 documentation"
+assignees: ''
+
+---
+
+- Page link:  Provide a link here to the page (or pages) to be updated. If the page provides an anchor link to the section of interest (indicated by a chain icon next to a heading) please copy that link if possible.
+- Relevant section: If a specific section needs to be updated and you are unable to provide an anchor link, what's the heading or area of interest?
+- Suggested content: Do you have any changes you'd like to suggest to improve the documentation?
+- Permission:
+  - [ ] I understand that content on the FreeSewing website falls under the [freesewing/markdown license](https://github.com/freesewing/markdown/blob/develop/LICENSE), any changes I suggest which are incorporated into the documentation/site content will be covered by the same license.
+
+Looking to tackle this issue? Check out our [documentation for editors](https://freesewing.dev/editors/) to learn how to contribute updates.

--- a/.github/ISSUE_TEMPLATE/documentation-update.md
+++ b/.github/ISSUE_TEMPLATE/documentation-update.md
@@ -10,7 +10,5 @@ assignees: ''
 - Page link:  Provide a link here to the page (or pages) to be updated. If the page provides an anchor link to the section of interest (indicated by a chain icon next to a heading) please copy that link if possible.
 - Relevant section: If a specific section needs to be updated and you are unable to provide an anchor link, what's the heading or area of interest?
 - Suggested content: Do you have any changes you'd like to suggest to improve the documentation?
-- Permission:
-  - [ ] I understand that content on the FreeSewing website falls under the [freesewing/markdown license](https://github.com/freesewing/markdown/blob/develop/LICENSE), any changes I suggest which are incorporated into the documentation/site content will be covered by the same license.
 
 Looking to tackle this issue? Check out our [documentation for editors](https://freesewing.dev/editors/) to learn how to contribute updates.


### PR DESCRIPTION
Might be too dry? Happy to have the wording/format changed. I based this off the showcase template as that appeared most suitable for content changes.

Addresses https://github.com/freesewing/freesewing/issues/754

I haven't updated the changelog as I'm not sure what the convention is with keeping that up to date (do it before or after the merge?) or what you'd classify this sort of change as...