### PR TITLE
Normalise source directory when passing it to globby

### DIFF
--- a/packages/create-freesewing-pattern/lib/create-library.js
+++ b/packages/create-freesewing-pattern/lib/create-library.js
@@ -4,6 +4,7 @@ const handlebars = require('handlebars')
 const execa = require('execa')
 const fs = require('fs')
 const globby = require('globby')
+const normalize = require('normalize-path')
 const mkdirp = require('make-dir')
 const ora = require('ora')
 const path = require('path')
@@ -28,7 +29,8 @@ module.exports = async (info) => {
     template === 'custom'
       ? path.join(process.cwd(), templatePath)
       : path.join(__dirname, '..', 'template', template)
-  const files = await globby(source, {
+
+  const files = await globby(normalize(source), {
     dot: true
   })
 

--- a/packages/create-freesewing-pattern/package.json
+++ b/packages/create-freesewing-pattern/package.json
@@ -38,7 +38,7 @@
     "handlebars": "^4.7.6",
     "inquirer": "^7.3.3",
     "make-dir": "^3.1.0",
-    "normalize-path": "3.0.0",
+    "normalize-path": "^3.0.0",
     "ora": "^4.0.5",
     "p-each-series": "^2.1.0",
     "parse-git-config": "^3.0.0",

--- a/packages/create-freesewing-pattern/package.json
+++ b/packages/create-freesewing-pattern/package.json
@@ -25,6 +25,8 @@
   },
   "peerDependencies": {},
   "dependencies": {
+    "@freesewing/i18n": "^2.11.2",
+    "@freesewing/pattern-info": "^2.11.2",
     "chalk": "^4.1.0",
     "commander": "^6.0.0",
     "conf": "^7.1.1",
@@ -36,13 +38,12 @@
     "handlebars": "^4.7.6",
     "inquirer": "^7.3.3",
     "make-dir": "^3.1.0",
+    "normalize-path": "3.0.0",
     "ora": "^4.0.5",
     "p-each-series": "^2.1.0",
     "parse-git-config": "^3.0.0",
     "validate-npm-package-name": "^3.0.0",
-    "which": "^2.0.2",
-    "@freesewing/i18n": "^2.11.2",
-    "@freesewing/pattern-info": "^2.11.2"
+    "which": "^2.0.2"
   },
   "devDependencies": {},
   "files": [


### PR DESCRIPTION
Fixes https://github.com/freesewing/freesewing/issues/781

globby() expects forward slash characters as path separators, so calling normalize-path transforms backslashes to forward slashes on windows while preserving the drive letter (handles the case where node packages are installed on a different drive to where the command is being run).

The unixify package could be an alternative but in testing it was overly destructive on the path (stripping the drive letter) which caused issues with multi-drive environments.

When run on unix this effectively does nothing, so I didn't bother trying to test for the platform to see if calling normalize was necessary, it works fine in both environments.