### PR TITLE
Add normalize-path dependency to support #781

### DIFF
--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -114,6 +114,7 @@ create-freesewing-pattern:
     'handlebars': '^4.7.6'
     'inquirer': '^7.3.3'
     'make-dir': '^3.1.0'
+    'normalize-path': '^3.0.0'
     'ora': '^4.0.5'
     'p-each-series': '^2.1.0'
     'parse-git-config': '^3.0.0'


### PR DESCRIPTION
The previous pull request manually edited the package.json file, I didn't realise it was autogenerated at the time.