### PR TITLE
Updated showcase issue template with new how-to link and credit text

### DIFF
--- a/.github/ISSUE_TEMPLATE/showcase-template.md
+++ b/.github/ISSUE_TEMPLATE/showcase-template.md
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 - Content:  Provide a link here to where we can find the content
- - Permission: 
+ - Permission:
    - [ ] I am the original author, and hereby grant permission to repost this content
    - [ ] I am not the original author, please ask permission from them
- - Username: Please enter the FreeSewing username of the orignal author (if you know it)
+ - Credit: Please enter the FreeSewing, Instagram, Twitter, or other username of the original author (if you know it and they want to be credited)
 
-Looking to tackle this issue? We have [a how-to that shows how to add a showcase to the site]( https://freesewing.dev/editors/showcase/).
+Looking to tackle this issue? We have [a how-to that shows how to add a showcase to the site](https://freesewing.dev/editors/howtos/showcase/).


### PR DESCRIPTION
@joostdecock let me know that we no longer list the FreeSewing username on the showcase but we can still give credit to Instagram, Twitter, Discord, or wherever the picture is from. I'm suggesting changes to the issue template based on this.

I also updated the link to the showcase how-to.