### PR TITLE
Add base .gitignore to create-freesewing-pattern template

### DIFF
--- a/packages/create-freesewing-pattern/template/freesewing/.gitignore
+++ b/packages/create-freesewing-pattern/template/freesewing/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/


### PR DESCRIPTION
When I initially generated a pattern, and wanted to add my initial commit, I needed to create a `.gitignore` and add the `node_modules/` and `dist/` paths.

This simply adds a base one so others don't need to do this, and if they're not using git, they can remove it. =)

Note: This new `.gitignore` file needed to be "hard" added, since it's ignored in the [root `.gitignore`](https://github.com/freesewing/freesewing/blob/6163deb1c97dc098cd28ea27e186f78a8666ec99/.gitignore#L87).