### PR TITLE
Adds eslint to dependencies and resolves code to match rules

### DIFF
--- a/packages/create-freesewing-pattern/template/freesewing/config/index.js
+++ b/packages/create-freesewing-pattern/template/freesewing/config/index.js
@@ -19,10 +19,10 @@ export default {
     'parametric design',
     '{{type}}',
     'sewing',
-    'sewing pattern',
+    'sewing pattern'
   ],
   optionGroups: {
-    fit: ['size'],
+    fit: ['size']
   },
   measurements: [],
   dependencies: {},
@@ -30,6 +30,6 @@ export default {
   hide: [],
   parts: ['box'],
   options: {
-    size: { pct: 50, min: 10, max: 100 },
-  },
+    size: { pct: 50, min: 10, max: 100 }
+  }
 }

--- a/packages/create-freesewing-pattern/template/freesewing/example/src/App.js
+++ b/packages/create-freesewing-pattern/template/freesewing/example/src/App.js
@@ -10,12 +10,11 @@ import Pattern from './pattern/src/index.js'
  * Without it, we can't import the pattern as a local file
  * since create-react-app does not allow imports outside ./src
  * If it's imported as a dependency, webpack will cache the
- * build and there will be no hot-relaoding of changes
+ * build and there will be no hot-reloading of changes
  */
 
-
 const App = (props) => {
-  // You can use this to add transations
+  // You can use this to add translations
   /*
   let translations = {
     JSON: 'JSON',
@@ -26,17 +25,19 @@ const App = (props) => {
   // Adds support for loading an external pattern configuration
   let recreate = false
   if (window) recreate = window.location.pathname.substr(1).split('/')
-  if (recreate.length === 3 && recreate[0] === 'recreate')
+  if (recreate.length === 3 && recreate[0] === 'recreate') {
     recreate = { from: recreate[1], id: recreate[2] }
-  else recreate = false
+  } else {
+    recreate = false
+  }
 
   return (
     <Workbench
       freesewing={freesewing}
       Pattern={Pattern}
-      userLanguage="{{language}}"
+      userLanguage="en"
       recreate={recreate}
-      //translations={translations}
+      // translations={translations}
     />
   )
 }

--- a/packages/create-freesewing-pattern/template/freesewing/example/src/App.js
+++ b/packages/create-freesewing-pattern/template/freesewing/example/src/App.js
@@ -35,7 +35,7 @@ const App = (props) => {
     <Workbench
       freesewing={freesewing}
       Pattern={Pattern}
-      userLanguage="en"
+      userLanguage="{{language}}"
       recreate={recreate}
       // translations={translations}
     />

--- a/packages/create-freesewing-pattern/template/freesewing/package.json
+++ b/packages/create-freesewing-pattern/template/freesewing/package.json
@@ -49,6 +49,11 @@
     "axios": "0.21.1",
     "react-intl": "5.17.6",
     "prop-types": "15.7.2",
-    "file-saver": "^2.0.5"
+    "file-saver": "^2.0.5",
+    "eslint": "^7.27.0",
+    "eslint-config-standard": "^16.0.3",
+    "eslint-config-standard-react": "^11.0.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0"
   }
 }

--- a/packages/create-freesewing-pattern/template/freesewing/rollup.config.js
+++ b/packages/create-freesewing-pattern/template/freesewing/rollup.config.js
@@ -5,22 +5,20 @@ import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import { terser } from 'rollup-plugin-terser'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
-//import postcss from 'rollup-plugin-postcss'
-import { name, version, description, author, license } from './package.json'
-
-import pkg from './package.json'
+// import postcss from 'rollup-plugin-postcss'
+import { main, module, name, version, description, author, license } from './package.json'
 
 export default {
   input: 'src/index.js',
   output: [
     {
-      file: pkg.main,
+      file: main,
       format: 'cjs',
       sourcemap: true,
       exports: 'default'
     },
     {
-      file: pkg.module,
+      file: module,
       format: 'es',
       sourcemap: true,
       exports: 'default'
@@ -28,9 +26,7 @@ export default {
   ],
   plugins: [
     peerDepsExternal(),
-    //postcss({
-    //  modules: true
-    //}),
+    // postcss({ modules: true }),
     url({ exclude: ['**/*.svg'] }),
     babel({
       exclude: 'node_modules/**'

--- a/packages/create-freesewing-pattern/template/freesewing/src/box.js
+++ b/packages/create-freesewing-pattern/template/freesewing/src/box.js
@@ -1,5 +1,5 @@
 export default function (part) {
-  let {
+  const {
     options,
     Point,
     Path,
@@ -10,10 +10,10 @@ export default function (part) {
     complete,
     sa,
     paperless,
-    macro,
+    macro
   } = part.shorthand()
 
-  let w = 500 * options.size
+  const w = 500 * options.size
   points.topLeft = new Point(0, 0)
   points.topRight = new Point(w, 0)
   points.bottomLeft = new Point(0, w / 2)
@@ -47,12 +47,12 @@ export default function (part) {
     macro('hd', {
       from: points.bottomLeft,
       to: points.bottomRight,
-      y: points.bottomLeft.y + sa + 15,
+      y: points.bottomLeft.y + sa + 15
     })
     macro('vd', {
       from: points.bottomRight,
       to: points.topRight,
-      x: points.topRight.x + sa + 15,
+      x: points.topRight.x + sa + 15
     })
   }
 


### PR DESCRIPTION
Add eslint to the dev dependencies for create-freesewing-pattern templates. When firing up a new pattern I was getting some eslint errors/warnings -- because the dependencies weren't clear, and so I've added the relevant plugins and standard configurations.

After installing the eslint dependencies, I resolved any violations that I found.