### PR TITLE
Improves the css around box sizing and horizontal scrolling

### DIFF
--- a/packages/create-freesewing-pattern/template/freesewing/example/src/layout.css
+++ b/packages/create-freesewing-pattern/template/freesewing/example/src/layout.css
@@ -1,3 +1,9 @@
+* {
+  box-sizing: border-box;
+}
+.MuiToolbar-root {
+  overflow-y: auto;
+}
 div.layout-wrapper {
   width: 100%;
   margin: 0;

--- a/packages/create-freesewing-pattern/template/freesewing/example/src/layout.scss
+++ b/packages/create-freesewing-pattern/template/freesewing/example/src/layout.scss
@@ -1,5 +1,13 @@
 @import '../../../../../../node_modules/open-color/open-color.scss';
 
+// Global style overrides
+* {
+  box-sizing: border-box;
+}
+.MuiToolbar-root {
+  overflow-y: auto;
+}
+
 // Main page content layout
 div.layout-wrapper {
   width: 100%;


### PR DESCRIPTION
Before:

<img width="753" alt="Screen Shot 2021-06-04 at 6 52 31 PM" src="https://user-images.githubusercontent.com/13765/120874931-31eec600-c566-11eb-9c88-0e54ac5e8a1f.png">

After:

<img width="753" alt="Screen Shot 2021-06-04 at 6 53 05 PM" src="https://user-images.githubusercontent.com/13765/120874937-387d3d80-c566-11eb-9df0-738981e0c553.png">
