### PR TITLE
dev docs: change dx(), dy(), dist() examples -- code

### DIFF
--- a/packages/examples/src/point_dist.js
+++ b/packages/examples/src/point_dist.js
@@ -1,13 +1,18 @@
 export default (part) => {
-  let { Point, points, macro } = part.shorthand()
+    let { Point, points, Path, paths} = part.shorthand()
 
   points.from = new Point(10, 10)
-  points.to = new Point(90, 40)
+  points.to = new Point(80, 70)
 
-  macro('ld', {
-    from: points.from,
-    to: points.to,
-  })
-
-  return part
+points.text = points.from
+	.shiftFractionTowards(points.to, 0.6)
+	.attr("data-text", points.from.dist(points.to)+"mm")
+	.attr("data-text-class", "text-sm fill-note center");
+    
+    paths.line = new Path()
+	.move(points.from)
+	.line(points.to)
+	.attr("class", "dashed");
+    
+    return part
 }

--- a/packages/examples/src/point_dist.js
+++ b/packages/examples/src/point_dist.js
@@ -1,18 +1,19 @@
 export default (part) => {
-    let { Point, points, Path, paths} = part.shorthand()
 
-  points.from = new Point(10, 10)
-  points.to = new Point(80, 70)
+let { Point, points, Path, paths } = part.shorthand()
+
+points.from = new Point(10, 10)
+points.to = new Point(80, 70)
 
 points.text = points.from
-	.shiftFractionTowards(points.to, 0.6)
-	.attr("data-text", points.from.dist(points.to)+"mm")
-	.attr("data-text-class", "text-sm fill-note center");
+  .shiftFractionTowards(points.to, 0.6)
+  .attr("data-text", points.from.dist(points.to)+"mm")
+  .attr("data-text-class", "text-sm fill-note center")
     
-    paths.line = new Path()
-	.move(points.from)
-	.line(points.to)
-	.attr("class", "dashed");
-    
-    return part
+paths.line = new Path()
+  .move(points.from)
+  .line(points.to)
+  .attr("class", "dashed")
+
+return part
 }

--- a/packages/examples/src/point_dx.js
+++ b/packages/examples/src/point_dx.js
@@ -1,14 +1,31 @@
 export default (part) => {
-  let { Point, points, macro } = part.shorthand()
+    let { Point, points, Path, paths} = part.shorthand()
 
   points.from = new Point(10, 10)
-  points.to = new Point(90, 40)
+  points.to = new Point(80, 70)
+    
+    paths.line = new Path()
+	.move(points.from)
+	.line(points.to)
+	.attr("class", "dashed");
 
-  macro('hd', {
-    from: points.from,
-    to: points.to,
-    y: 25,
-  })
+    points.totop = points.from.shift(0,points.from.dx(points.to))
 
-  return part
+    points.text_dx = points.from
+	.shiftFractionTowards(points.totop, 0.6)
+	.shiftFractionTowards(points.to,0.1)
+	.attr("data-text", points.from.dx(points.to)+"mm")
+	.attr("data-text-class", "text-sm fill-note center");
+
+    paths.line_dx = new Path()
+	.move(points.from)
+	.line(points.totop)
+	.attr("class", "dashed");
+    
+    paths.line_dy = new Path()
+	.move(points.to)
+	.line(points.totop)
+	.attr("class", "dashed");
+  
+    return part
 }

--- a/packages/examples/src/point_dx.js
+++ b/packages/examples/src/point_dx.js
@@ -1,31 +1,32 @@
 export default (part) => {
-    let { Point, points, Path, paths} = part.shorthand()
 
-  points.from = new Point(10, 10)
-  points.to = new Point(80, 70)
+let { Point, points, Path, paths } = part.shorthand()
+
+points.from = new Point(10, 10)
+points.to = new Point(80, 70)
     
-    paths.line = new Path()
-	.move(points.from)
-	.line(points.to)
-	.attr("class", "dashed");
+paths.line = new Path()
+  .move(points.from)
+  .line(points.to)
+  .attr("class", "dashed")
 
-    points.totop = points.from.shift(0,points.from.dx(points.to))
+points.totop = points.from.shift(0,points.from.dx(points.to))
 
-    points.text_dx = points.from
-	.shiftFractionTowards(points.totop, 0.6)
-	.shiftFractionTowards(points.to,0.1)
-	.attr("data-text", points.from.dx(points.to)+"mm")
-	.attr("data-text-class", "text-sm fill-note center");
+points.text_dx = points.from
+  .shiftFractionTowards(points.totop, 0.6)
+  .shiftFractionTowards(points.to,0.1)
+  .attr("data-text", points.from.dx(points.to)+"mm")
+  .attr("data-text-class", "text-sm fill-note center")
 
-    paths.line_dx = new Path()
-	.move(points.from)
-	.line(points.totop)
-	.attr("class", "dashed");
+paths.line_dx = new Path()
+  .move(points.from)
+  .line(points.totop)
+  .attr("class", "dashed")
     
-    paths.line_dy = new Path()
-	.move(points.to)
-	.line(points.totop)
-	.attr("class", "dashed");
+paths.line_dy = new Path()
+  .move(points.to)
+  .line(points.totop)
+  .attr("class", "dashed")
   
-    return part
+return part
 }

--- a/packages/examples/src/point_dy.js
+++ b/packages/examples/src/point_dy.js
@@ -1,31 +1,31 @@
 export default (part) => {
-    let { Point, points, Path, paths} = part.shorthand()
 
-  points.from = new Point(10, 10)
-  points.to = new Point(80, 70)
+let { Point, points, Path, paths } = part.shorthand()
+
+points.from = new Point(10, 10)
+points.to = new Point(80, 70)
     
-    paths.line = new Path()
-	.move(points.from)
-	.line(points.to)
-	.attr("class", "dashed");
+paths.line = new Path()
+  .move(points.from)
+  .line(points.to)
+  .attr("class", "dashed")
 
-    points.totop = points.from.shift(0,points.from.dx(points.to))
+points.totop = points.from.shift(0,points.from.dx(points.to))
 
-    paths.line_dx = new Path()
-	.move(points.from)
-	.line(points.totop)
-	.attr("class", "dashed");
+paths.line_dx = new Path()
+  .move(points.from)
+  .line(points.totop)
+  .attr("class", "dashed")
 
-        points.text_dy = points.totop
-	.shiftFractionTowards(points.to, 0.4)
-	.attr("data-text", points.from.dy(points.to)+"mm")
-	.attr("data-text-class", "text-sm fill-note right");
-
-    
-    paths.line_dy = new Path()
-	.move(points.to)
-	.line(points.totop)
-	.attr("class", "dashed");
+points.text_dy = points.totop
+  .shiftFractionTowards(points.to, 0.4)
+  .attr("data-text", points.from.dy(points.to)+"mm")
+  .attr("data-text-class", "text-sm fill-note right")
   
-    return part
+paths.line_dy = new Path()
+  .move(points.to)
+  .line(points.totop)
+  .attr("class", "dashed")
+  
+return part
 }

--- a/packages/examples/src/point_dy.js
+++ b/packages/examples/src/point_dy.js
@@ -1,14 +1,31 @@
 export default (part) => {
-  let { Point, points, macro } = part.shorthand()
+    let { Point, points, Path, paths} = part.shorthand()
 
   points.from = new Point(10, 10)
-  points.to = new Point(90, 40)
+  points.to = new Point(80, 70)
+    
+    paths.line = new Path()
+	.move(points.from)
+	.line(points.to)
+	.attr("class", "dashed");
 
-  macro('vd', {
-    from: points.to,
-    to: points.from,
-    x: 50,
-  })
+    points.totop = points.from.shift(0,points.from.dx(points.to))
 
-  return part
+    paths.line_dx = new Path()
+	.move(points.from)
+	.line(points.totop)
+	.attr("class", "dashed");
+
+        points.text_dy = points.totop
+	.shiftFractionTowards(points.to, 0.4)
+	.attr("data-text", points.from.dy(points.to)+"mm")
+	.attr("data-text-class", "text-sm fill-note right");
+
+    
+    paths.line_dy = new Path()
+	.move(points.to)
+	.line(points.totop)
+	.attr("class", "dashed");
+  
+    return part
 }


### PR DESCRIPTION
As mentioned in issue #1111, I have rewritten the examples given in the `dist()`, `dx()` and `dy()` dev docs to show the usage of these methods. It doesn't look as nice as before, but is hopefully useful as an example.

This is the corresponding PR for `freesewing`. (PR for `markdown` [here](https://github.com/freesewing/markdown/pull/246))

Feedback and improvements welcome :)