### PR TITLE
fix(create-freesewing-pattern): remove old departments

### DIFF
--- a/packages/create-freesewing-pattern/lib/prompt-library-params.js
+++ b/packages/create-freesewing-pattern/lib/prompt-library-params.js
@@ -97,19 +97,19 @@ module.exports = async opts => {
         message: info => strings[info.language]['filter.department.title'],
         choices: info => [
           {
-            name: strings[info.language]['filter.department.menswear'],
-            value: 'menswear'
+            name: strings[info.language]['filter.department.tops'],
+            value: 'tops'
           },
           {
-            name: strings[info.language]['filter.department.womenswear'],
-            value: 'womenswear'
+            name: strings[info.language]['filter.department.bottoms'],
+            value: 'bottoms'
           },
           {
             name: strings[info.language]['filter.department.accessories'],
             value: 'accessories'
           }
         ],
-        default: 'womenswear'
+        default: 'tops'
       },
       {
         type: 'input',


### PR DESCRIPTION
removed old departments from initial create-freesewing-pattern prompt and replaced with `tops` and `bottoms`

Not sure if anything else depends on those values, so kindly requesting review from @joostdecock once he is back from his code vacation :)

(Also: Not sure what the changelog policy is, so I didn't touch it for now.)