### PR TITLE
Fix Aaron armhole drop weirdness

### DIFF
--- a/packages/aaron/src/front.js
+++ b/packages/aaron/src/front.js
@@ -71,11 +71,8 @@ export default function (part) {
   points.hem.x = points.hips.x
 
   // Armhole
-  points.armhole = utils.beamIntersectsY(
-    points.armhole,
-    points.hips,
-    points.armhole.y * (1 + options.armholeDrop)
-  )
+  points.armhole = points.armhole.shiftFractionTowards(points.hips, options.armholeDrop);
+
   points.armholeCorner = utils.beamsIntersect(
     points.armhole,
     points.armhole.shift(180, 10),


### PR DESCRIPTION
See #1206 for more info, but the tl;dr is:

If chest and hip measurements are the same, there can be some floating point weirdness that causes the `beamIntersectsY` call to return an incorrect `y`-coordinate which makes the armhole all weird.

This PR replaces the `beamIntersectsY` call with `shiftFractionTowards` which has (almost?) exactly the same result and none of the nonsense 🎉 
