### PR TITLE
Bug fix for crash report.

### DIFF
--- a/packages/penelope/src/utils.js
+++ b/packages/penelope/src/utils.js
@@ -38,7 +38,6 @@ function dartCalc(store, options, seat, seatEase, waist, waistEase) {
   seat += seatEase
   waist += waistEase
   let seatWaistDiff = Math.max(seat - waist, 0)
-  options.seatWaistDiff = seatWaistDiff
 
   let nrOfDarts = options.nrOfDarts
 


### PR DESCRIPTION
This fixes the following crash report:
TypeError: proxy set handler returned false for property '"seatWaistDiff"'