### PR TITLE
Fix for #1381 listing Charlie as a block rather than a pattern

### DIFF
--- a/packages/charlie/config/index.js
+++ b/packages/charlie/config/index.js
@@ -6,7 +6,7 @@ export default {
   design: 'Joost De Cock',
   code: 'Joost De Cock',
   department: 'bottoms',
-  type: 'block',
+  type: 'pattern',
   difficulty: 3,
   optionGroups: {
     fit: ['seatEase', 'kneeEase', 'waistEase', 'waistbandCurve'],


### PR DESCRIPTION
Just a minor change to the config index changing block to pattern.