### PR TITLE
Missing Link Markers for On-The-Fold markdown.

### DIFF
--- a/markdown/org/docs/sewing/on-the-fold/de.md
+++ b/markdown/org/docs/sewing/on-the-fold/de.md
@@ -15,3 +15,5 @@ Die Stoffbruchlinie wird mit einem doppeltem Pfeil markiert, wie in diesem Beisp
 Für eine Übersicht aller Markierungen auf deinem Schnittmuster, siehe [Anleitung für Schnittmuster-Notation][1]
 
 </Tip>
+
+[1]:/docs/various/notation/

--- a/markdown/org/docs/sewing/on-the-fold/es.md
+++ b/markdown/org/docs/sewing/on-the-fold/es.md
@@ -15,3 +15,5 @@ La línea plegable se indica con una doble flecha como en este ejemplo:
 Para una visión general de todos los indicadores en tu patrón, consulta la [guía de notación de patrones][1]
 
 </Tip>
+
+[1]:/docs/various/notation/

--- a/markdown/org/docs/sewing/on-the-fold/fr.md
+++ b/markdown/org/docs/sewing/on-the-fold/fr.md
@@ -15,3 +15,5 @@ La ligne de pli est indiquée avec une double flèche, comme dans cet exemple :
 Pour un aperçu de tous les indicateurs de votre patron, reportez-vous au [guide de notation du patron][1]
 
 </Tip>
+
+[1]:/docs/various/notation/

--- a/markdown/org/docs/sewing/on-the-fold/nl.md
+++ b/markdown/org/docs/sewing/on-the-fold/nl.md
@@ -15,3 +15,5 @@ De vouwlijn wordt aangegeven met een dubbele pijl zoals in dit voorbeeld:
 Voor een overzicht van alle indicatoren op uw patroon, ga naar de [patroonnotatie handleiding][1]
 
 </Tip>
+
+[1]:/docs/various/notation/


### PR DESCRIPTION
After looking at the deploys on the site I noticed that the non-english sites get erroring on the same markdown. I don't know if what I have done here is actually useful but I decided to go checkout the files and found that the non-english files were missing the marker to tell the link where to go. 
Changes
- Added [1]:/docs/various/notation/ to de.md 
- Added [1]:/docs/various/notation/ to es.md 
- Added [1]:/docs/various/notation/ to fr.md 
- Added [1]:/docs/various/notation/ to nl.md 

I don't know if they need to be different for each language.