### PR TITLE
Missing letter. Carlton Options en.md

### DIFF
--- a/markdown/org/docs/patterns/carlton/options/en.md
+++ b/markdown/org/docs/patterns/carlton/options/en.md
@@ -1,5 +1,5 @@
 ---
 ---
 
-<PatternOptions pattern='carlon' />
+<PatternOptions pattern='carlton' />
 


### PR DESCRIPTION
I am hoping this will fix the issue of Carlton displaying Carlita's svg option images.
On inspection I found that all the files are there but for some reason the page kept drawing from carlita's option docs rather than carlton's
I'm hoping this is why but it probably isn't. Either way this still nees fixing.