### PR TITLE
Title re-formatting, Lunetius, Tiberius and Walburga pattern options

### DIFF
--- a/markdown/org/docs/patterns/lunetius/options/length/en.md
+++ b/markdown/org/docs/patterns/lunetius/options/length/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Length
 
 Choose from the different length styles
 

--- a/markdown/org/docs/patterns/lunetius/options/lengthratio/en.md
+++ b/markdown/org/docs/patterns/lunetius/options/lengthratio/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Length ratio
 
 Controls the length of the garment
 

--- a/markdown/org/docs/patterns/lunetius/options/widthratio/en.md
+++ b/markdown/org/docs/patterns/lunetius/options/widthratio/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Width ratio
 
 Controls the width of the garment
 

--- a/markdown/org/docs/patterns/tiberius/options/armholedrop/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/armholedrop/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Armhole drop
 
 Controls the depth of the armhole
 

--- a/markdown/org/docs/patterns/tiberius/options/clavi/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/clavi/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Clavi
 
 Whether or not to include guides for clavi
 

--- a/markdown/org/docs/patterns/tiberius/options/clavuslocation/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/clavuslocation/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Clavus location
 
 Controls the location of the clavi
 

--- a/markdown/org/docs/patterns/tiberius/options/clavuswidth/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/clavuswidth/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Clavus width
 
 Controls the width of the clavi
 

--- a/markdown/org/docs/patterns/tiberius/options/forcewidth/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/forcewidth/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Force width
 
 Apply width settings regardless of constraints
 

--- a/markdown/org/docs/patterns/tiberius/options/headratio/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/headratio/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Head ratio
 
 Controls the size of the head opening
 

--- a/markdown/org/docs/patterns/tiberius/options/length/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/length/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Length
 
 Controls the length of the garment
 

--- a/markdown/org/docs/patterns/tiberius/options/lengthbonus/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/lengthbonus/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Length bonus
 
 Allows variation of the length of the garment
 

--- a/markdown/org/docs/patterns/tiberius/options/width/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/width/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Width
 
 Controls the width of the garment
 

--- a/markdown/org/docs/patterns/tiberius/options/widthbonus/en.md
+++ b/markdown/org/docs/patterns/tiberius/options/widthbonus/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Width bonus
 
 Allows variation of the width of the garment
 

--- a/markdown/org/docs/patterns/walburga/options/headratio/en.md
+++ b/markdown/org/docs/patterns/walburga/options/headratio/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Head ratio
 
 Controls the size of the head opening
 

--- a/markdown/org/docs/patterns/walburga/options/length/en.md
+++ b/markdown/org/docs/patterns/walburga/options/length/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Length
 
 Controls the length of the garment
 

--- a/markdown/org/docs/patterns/walburga/options/lengthbonus/en.md
+++ b/markdown/org/docs/patterns/walburga/options/lengthbonus/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Length bonus
 
 Allows variation of the length of the garment
 

--- a/markdown/org/docs/patterns/walburga/options/neckline/en.md
+++ b/markdown/org/docs/patterns/walburga/options/neckline/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Neckline
 
 Controls whether or not to draft a neck opening
 

--- a/markdown/org/docs/patterns/walburga/options/neckoratio/en.md
+++ b/markdown/org/docs/patterns/walburga/options/neckoratio/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Neck opening shape
 
 controls the shape of the neck opening
 

--- a/markdown/org/docs/patterns/walburga/options/widthbonus/en.md
+++ b/markdown/org/docs/patterns/walburga/options/widthbonus/en.md
@@ -1,6 +1,3 @@
-***
-
-## title: Width bonus
 
 Allows variation of the width of the garment
 


### PR DESCRIPTION
Noticed that the pattern options for Lunetius, Tiberius and Walburga had title formats that were redundant. This simply removes them.