### PR TITLE
Chore: Update `Point` dev docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ scripts/verdaccio.sh
 
 # Local Netlify folder
 .netlify
+
+# Don't ignore the specific Points.dist() docs folder
+!markdown/dev/reference/api/point/dist

--- a/markdown/dev/reference/api/point/angle/en.md
+++ b/markdown/dev/reference/api/point/angle/en.md
@@ -1,14 +1,15 @@
 ---
-title: angle()
+title: Point.angle()
 ---
+
+A point's `angle()` method returns the angle (in degrees) between this point and
+the point passed into the method. An angle of 0° points to the right, and the angle increases counterclockwise.
 
 ```js
 float point.angle(Point point)
-``` 
+```
 
-Returns the angle made by a line from this point to the point you pass it.
-
-<Example 
+<Example
   part="point_angle"
   caption="An example of the Point.angle() method"
 />
@@ -28,4 +29,3 @@ paths.line = new Path()
   .line(points.moon)
   .attr("class", "dashed");
 ```
-

--- a/markdown/dev/reference/api/point/angle/en.md
+++ b/markdown/dev/reference/api/point/angle/en.md
@@ -5,9 +5,13 @@ title: Point.angle()
 A point's `angle()` method returns the angle (in degrees) between this point and
 the point passed into the method. An angle of 0° points to the right, and the angle increases counterclockwise.
 
+## Point.angle() signature
+
 ```js
-float point.angle(Point point)
+float point.angle(Point pointB)
 ```
+
+## Point.angle() Example
 
 <Example
   part="point_angle"

--- a/markdown/dev/reference/api/point/attr/en.md
+++ b/markdown/dev/reference/api/point/attr/en.md
@@ -1,6 +1,9 @@
 ---
-title: attr()
+title: Point.attr()
 ---
+
+A point's `attr()` method adds an attribute to the point, and returns the point. Setting the third parameter
+to `true` will replace the value of the attribute instead of adding it.
 
 ```js
 Point point.attr(
@@ -10,12 +13,12 @@ Point point.attr(
 )
 ```
 
-This `Point.attr()` method calls `this.attributes.add()` under the hood, but returns the Point object.
+The `Point.attr()` method calls [`this.attributes.add()`](/reference/api/attributes/add/) under the hood, but returns the `Point` object.
 This allows you to chain different calls together as in the example below.
 
-If the third parameter is set to `true` it will call `this.attributes.set()` instead, thereby overwriting the value of the attribute.
+If the third parameter is set to `true` it will call [`this.attributes.set()`](/reference/api/attributes/set/) instead, thereby overwriting the value of the attribute.
 
-<Example 
+<Example
   part="point_attr"
   caption="An example of the Point.attr() method"
 />
@@ -27,4 +30,3 @@ points.anchor = new Point(100, 25)
   .attr("data-text", "freesewingIsMadeByJoostDeCockAndContributors")
   .attr("data-text-class", "center");
 ```
-

--- a/markdown/dev/reference/api/point/attr/en.md
+++ b/markdown/dev/reference/api/point/attr/en.md
@@ -5,6 +5,8 @@ title: Point.attr()
 Adds an attribute to the point, and returns the original point. Setting the third parameter
 to `true` will replace the value of the attribute instead of adding it.
 
+## Point.attr() signature
+
 ```js
 Point point.attr(
   string name, 
@@ -17,6 +19,8 @@ The `Point.attr()` method calls [`this.attributes.add()`](/reference/api/attribu
 This allows you to chain different calls together as in the example below.
 
 If the third parameter is set to `true` it will call [`this.attributes.set()`](/reference/api/attributes/set/) instead, thereby overwriting the value of the attribute.
+
+## Point.attr() example
 
 <Example
   part="point_attr"

--- a/markdown/dev/reference/api/point/attr/en.md
+++ b/markdown/dev/reference/api/point/attr/en.md
@@ -2,7 +2,7 @@
 title: Point.attr()
 ---
 
-A point's `attr()` method adds an attribute to the point, and returns the point. Setting the third parameter
+Adds an attribute to the point, and returns the original point. Setting the third parameter
 to `true` will replace the value of the attribute instead of adding it.
 
 ```js

--- a/markdown/dev/reference/api/point/clone/en.md
+++ b/markdown/dev/reference/api/point/clone/en.md
@@ -1,23 +1,23 @@
 ---
-title: clone()
+title: Point.clone()
 ---
 
-```
+A point's `clone()` method returns a new `Point` with the same coordinates and attributes as the original point.
+
+```js
 Point point.clone()
 ```
-
-Returns a new point with the same coordinates and attributes as this point.
 
 <Note>
 
 ###### Copy vs clone
 
-The `Point.copy()` method will only copy the point's coordinates, whereas this
+The [`Point.copy()`](reference/api/point/copy/) method will only copy the point's coordinates, whereas this
 `Point.clone()` method will also copy its attributes.
 
 </Note>
 
-<Example 
+<Example
   part="point_clone"
   caption="An example of the Point.clone() method"
 />
@@ -33,4 +33,3 @@ The `Point.copy()` method will only copy the point's coordinates, whereas this
 
   snippets.x = new Snippet("notch", points.A);
 ```
-

--- a/markdown/dev/reference/api/point/clone/en.md
+++ b/markdown/dev/reference/api/point/clone/en.md
@@ -2,7 +2,7 @@
 title: Point.clone()
 ---
 
-A point's `clone()` method returns a new `Point` with the same coordinates and attributes as the original point.
+Returns a new `Point` with the same coordinates and attributes as the original point.
 
 ```js
 Point point.clone()

--- a/markdown/dev/reference/api/point/clone/en.md
+++ b/markdown/dev/reference/api/point/clone/en.md
@@ -4,6 +4,8 @@ title: Point.clone()
 
 Returns a new `Point` with the same coordinates and attributes as the original point.
 
+## Point.clone() signature
+
 ```js
 Point point.clone()
 ```
@@ -16,6 +18,8 @@ The [`Point.copy()`](reference/api/point/copy/) method will only copy the point'
 `Point.clone()` method will also copy its attributes.
 
 </Note>
+
+## Point.clone() example
 
 <Example
   part="point_clone"

--- a/markdown/dev/reference/api/point/copy/en.md
+++ b/markdown/dev/reference/api/point/copy/en.md
@@ -4,6 +4,8 @@ title: Point.copy()
 A point's `copy()` method returns a new point with the same coordinates as the original point.
 This method does _not_ copy any attributes the original point may have.
 
+## Point.copy() signature
+
 ```js
 Point point.copy()
 ```
@@ -16,6 +18,8 @@ this `Point.copy()` method will only copy the point's coordinates.
 To also copy the attributes, use [`Point.clone()`](reference/api/point/clone/) instead.
 
 </Note>
+
+## Point.copy() example
 
 <Example
   part="point_copy"

--- a/markdown/dev/reference/api/point/copy/en.md
+++ b/markdown/dev/reference/api/point/copy/en.md
@@ -1,14 +1,23 @@
 ---
-title: copy()
+title: Point.copy()
 ---
+A point's `copy()` method returns a new point with the same coordinates as the original point.
+This method does _not_ copy any attributes the original point may have.
 
 ```js
 Point point.copy()
 ```
 
-Returns a new point with the same coordinates as this point.
+<Note>
 
-<Example 
+###### Copy vs clone
+
+this `Point.copy()` method will only copy the point's coordinates.
+To also copy the attributes, use [`Point.clone()`](reference/api/point/clone/) instead.
+
+</Note>
+
+<Example
   part="point_copy"
   caption="An example of the Point.copy() method"
 />
@@ -23,4 +32,3 @@ points.B = points.A.copy().attr("data-text", "Point B");
 
 snippets.x = new Snippet("notch", points.A);
 ```
-

--- a/markdown/dev/reference/api/point/dist/en.md
+++ b/markdown/dev/reference/api/point/dist/en.md
@@ -4,9 +4,13 @@ title: Point.dist()
 
 A point's `dist()` method returns the distance (in mm) between this point and the point you pass it.
 
+## Point.dist() signature
+
 ```js
 float point.dist(Point point)
 ```
+
+## Point.dist() example
 
 <Example
   part="point_dist"

--- a/markdown/dev/reference/api/point/dist/en.md
+++ b/markdown/dev/reference/api/point/dist/en.md
@@ -1,0 +1,33 @@
+---
+title: Point.dist()
+---
+
+A point's `dist()` method returns the distance (in mm) between this point and the point you pass it.
+
+```js
+float point.dist(Point point)
+```
+
+<Example
+  part="point_dist"
+  caption="An example of the Point.dist() method"
+/>
+
+```js
+let { Point, points, Path, paths } = part.shorthand()
+
+points.from = new Point(10, 10)
+points.to = new Point(80, 70)
+
+points.text = points.from
+  .shiftFractionTowards(points.to, 0.6)
+  .attr('data-text', points.from.dist(points.to) + 'mm')
+  .attr('data-text-class', 'text-sm fill-note center')
+
+paths.line = new Path()
+  .move(points.from)
+  .line(points.to)
+  .attr('class', 'dashed')
+
+return part
+```

--- a/markdown/dev/reference/api/point/dx/en.md
+++ b/markdown/dev/reference/api/point/dx/en.md
@@ -4,9 +4,13 @@ title: Point.dx()
 
 A point's `dx()` method returns the delta (in mm) along the X-axis between this point and the point you pass it.
 
+## Point.dx() signature
+
 ```js
 float point.dx(Point point)
 ```
+
+## Point.dx() example
 
 <Example
   part="point_dx"

--- a/markdown/dev/reference/api/point/dx/en.md
+++ b/markdown/dev/reference/api/point/dx/en.md
@@ -1,14 +1,14 @@
 ---
-title: dx()
+title: Point.dx()
 ---
+
+A point's `dx()` method returns the delta (in mm) along the X-axis between this point and the point you pass it.
 
 ```js
 float point.dx(Point point)
 ```
 
-Returns the delta along the X-axis between this point and the point you pass it.
-
-<Example 
+<Example
   part="point_dx"
   caption="An example of the Point.dx() method"
 />
@@ -42,4 +42,3 @@ paths.line_dy = new Path()
   .line(points.totop)
   .attr("class", "dashed")
 ```
-

--- a/markdown/dev/reference/api/point/dy/en.md
+++ b/markdown/dev/reference/api/point/dy/en.md
@@ -4,9 +4,13 @@ title: Point.dy()
 
 A point's `dy()` method returns the delta (in mm) along the Y-axis between this point and the point you pass it.
 
+## Point.dy() signature
+
 ```js
 float point.dy(Point point)
 ```
+
+## Point.dy() example
 
 <Example
   part="point_dy"

--- a/markdown/dev/reference/api/point/dy/en.md
+++ b/markdown/dev/reference/api/point/dy/en.md
@@ -1,14 +1,14 @@
 ---
-title: dy()
+title: Point.dy()
 ---
+
+A point's `dy()` method returns the delta (in mm) along the Y-axis between this point and the point you pass it.
 
 ```js
 float point.dy(Point point)
 ```
 
-Returns the delta along the Y-axis between this point and the point you pass it.
-
-<Example 
+<Example
   part="point_dy"
   caption="An example of the Point.dy() method"
 />

--- a/markdown/dev/reference/api/point/flipx/en.md
+++ b/markdown/dev/reference/api/point/flipx/en.md
@@ -1,16 +1,15 @@
 ---
-title: flipX()
+title: Point.flipX()
 ---
+
+A point's `flipX()` method returns a new `Point` that mirrors the original point around the X-value of the point you pass it.
+If you do not pass in a point, it will default to mirroring around an X-value of zero.
 
 ```js
 Point point.flipX(Point mirror = false)
 ```
 
-Returns a new point that mirrors this point around the X-value of the point your pass it.
-
-If you don't pass it a point, it will mirror around an X-value of zero.
-
-<Example 
+<Example
   part="point_flipx"
   caption="An example of the Point.flipX() method"
 />
@@ -61,4 +60,3 @@ paths.mirror = new Path()
   .line(points.bottom)
   .attr("class", "note dashed");
 ```
-

--- a/markdown/dev/reference/api/point/flipx/en.md
+++ b/markdown/dev/reference/api/point/flipx/en.md
@@ -5,9 +5,13 @@ title: Point.flipX()
 A point's `flipX()` method returns a new `Point` that mirrors the original point around the X-value of the point you pass it.
 If you do not pass in a point, it will default to mirroring around an X-value of zero.
 
+## Point.flipX() signature
+
 ```js
 Point point.flipX(Point mirror = false)
 ```
+
+## Point.flipX() example
 
 <Example
   part="point_flipx"

--- a/markdown/dev/reference/api/point/flipy/en.md
+++ b/markdown/dev/reference/api/point/flipy/en.md
@@ -1,18 +1,15 @@
 ---
-title: flipY()
+title: Point.flipY()
 ---
+
+A point's `flipY()` method returns a new `Point` that mirrors the original point around the Y-value of the point you pass it.
+If you do not pass in a point, it will default to mirroring around an Y-value of zero.
 
 ```js
 Point point.flipY(Point mirror = false)
 ```
 
-Returns a new point that mirrors this point around the Y-value of the point your pass it.
-
-If you don't pass it a point, it will mirror around a Y-value of zero.
-
-### Point.flipY() example
-
-<Example 
+<Example
   part="point_flipy"
   caption="An example of the Point.flipY() method"
 />
@@ -68,4 +65,3 @@ paths.skylineTop = new Path()
   .line(points.houseWallRight)
   .line(points.end);
 ```
-

--- a/markdown/dev/reference/api/point/flipy/en.md
+++ b/markdown/dev/reference/api/point/flipy/en.md
@@ -5,9 +5,13 @@ title: Point.flipY()
 A point's `flipY()` method returns a new `Point` that mirrors the original point around the Y-value of the point you pass it.
 If you do not pass in a point, it will default to mirroring around an Y-value of zero.
 
+## Point.flipY() signature
+
 ```js
 Point point.flipY(Point mirror = false)
 ```
+
+## Point.flipY() example
 
 <Example
   part="point_flipy"

--- a/markdown/dev/reference/api/point/rotate/en.md
+++ b/markdown/dev/reference/api/point/rotate/en.md
@@ -1,14 +1,17 @@
 ---
-title: rotate()
+title: Point.rotate()
 ---
+
+A point's `rotate()` method returns a new `Point` that has been rotated by `angle` degrees
+around the point (`center`) that you pass it.
+
+Just like the result of the [`Point.angle()`](reference/api/point/angle/) method, an angle of 0° points right, and the angle increases counterclockwise.
 
 ```js
 Point point.rotate(float angle, Point center)
-``` 
+```
 
-Rotates a point the number of degrees you pass it around the point you pass it.
-
-<Example 
+<Example
   part="point_rotate"
   caption="An example of the Point.rotate() method"
 />

--- a/markdown/dev/reference/api/point/rotate/en.md
+++ b/markdown/dev/reference/api/point/rotate/en.md
@@ -7,9 +7,13 @@ around the point (`center`) that you pass it.
 
 Just like the result of the [`Point.angle()`](reference/api/point/angle/) method, an angle of 0° points right, and the angle increases counterclockwise.
 
+## Point.rotate() signature
+
 ```js
 Point point.rotate(float angle, Point center)
 ```
+
+## Point.rotate() example
 
 <Example
   part="point_rotate"

--- a/markdown/dev/reference/api/point/shift/en.md
+++ b/markdown/dev/reference/api/point/shift/en.md
@@ -5,9 +5,13 @@ title: Point.shift()
 Returns a new `Point` that is `distance` (mm) away in the direction of `angle` (degrees).
 An angle of 0° points to the right, and the angle increases counterclockwise.
 
+## Point.shift() signature
+
 ```js
 Point point.shift(float angle, float distance)
 ```
+
+## Point.shift() example
 
 <Example
   part="point_shift"

--- a/markdown/dev/reference/api/point/shift/en.md
+++ b/markdown/dev/reference/api/point/shift/en.md
@@ -1,14 +1,15 @@
 ---
-title: shift()
+title: Point.shift()
 ---
 
+Returns a new `Point` that is `distance` (mm) away in the direction of `angle` (degrees).
+An angle of 0° points to the right, and the angle increases counterclockwise.
+
 ```js
-Point point.shift(float degrees, float distance)
+Point point.shift(float angle, float distance)
 ```
 
-Returns a point that lies distance in the direction of degrees from this point.
-
-<Example 
+<Example
   part="point_shift"
   caption="An example of the Point.shift() method"
 />

--- a/markdown/dev/reference/api/point/shiftfractiontowards/en.md
+++ b/markdown/dev/reference/api/point/shiftfractiontowards/en.md
@@ -10,9 +10,13 @@ point in the opposite direction.
 
 If you need to move a point by a specific distance instead of a percentage, use [`Point.shiftTowards()`]((reference/api/point/shifttowards/)) or [`Point.shiftOutwards()`](reference/api/point/shiftoutwards/) instead.
 
+## Point.shiftFractionTowards() signature
+
 ```js
 Point point.shiftFractionTowards(Point target, float fraction)
 ```
+
+## Point.shiftFractionTowards() example
 
 <Example
   part="point_shiftfractiontowards"

--- a/markdown/dev/reference/api/point/shiftfractiontowards/en.md
+++ b/markdown/dev/reference/api/point/shiftfractiontowards/en.md
@@ -1,14 +1,20 @@
 ---
-title: shiftFractionTowards()
+title: Point.shiftFractionTowards()
 ---
+
+Returns a new `Point` that is shifted towards the `target` by a `fraction` of the distance between this
+point and the target.
+
+This method accepts values larger than 1 to go beyond the target point, or negative values to shift the
+point in the opposite direction.
+
+If you need to move a point by a specific distance instead of a percentage, use [`Point.shiftTowards()`]((reference/api/point/shifttowards/)) or [`Point.shiftOutwards()`](reference/api/point/shiftoutwards/) instead.
 
 ```js
 Point point.shiftFractionTowards(Point target, float fraction)
 ```
 
-Returns a point that is shifted towards the target by a fraction of the distance between this point and the target.
-
-<Example 
+<Example
   part="point_shiftfractiontowards"
   caption="An example of the Point.shiftFractionTowards() method"
 />

--- a/markdown/dev/reference/api/point/shiftoutwards/en.md
+++ b/markdown/dev/reference/api/point/shiftoutwards/en.md
@@ -4,9 +4,13 @@ title: Point.shiftOutwards()
 
 Returns a new `Point` that is shifted `distance` (mm) beyond the `target` in the direction of the target point.
 
+## Point.shiftOutwards() signature
+
 ```js
 Point point.shiftOutwards(Point target, float distance)
 ```
+
+## Point.shiftOutwards() example
 
 <Example
   part="point_shiftoutwards"

--- a/markdown/dev/reference/api/point/shiftoutwards/en.md
+++ b/markdown/dev/reference/api/point/shiftoutwards/en.md
@@ -1,14 +1,14 @@
 ---
-title: shiftOutwards()
+title: Point.shiftOutwards()
 ---
 
+Returns a new `Point` that is shifted `distance` (mm) beyond the `target` in the direction of the target point.
+
 ```js
-Point point.shiftOutwards(Point direction, float distance)
+Point point.shiftOutwards(Point target, float distance)
 ```
 
-Returns a point that is shifted distance beyond target in the direction of target.
-
-<Example 
+<Example
   part="point_shiftoutwards"
   caption="An example of the Point.shiftOutwards() method"
 />

--- a/markdown/dev/reference/api/point/shifttowards/en.md
+++ b/markdown/dev/reference/api/point/shifttowards/en.md
@@ -1,14 +1,16 @@
 ---
-title: shiftTowards()
+title: Point.shiftTowards()
 ---
+
+Returns a new `Point` that is shifted `distance` (mm) in the direction of the `target`.
+
+If you need to move a point a percentage instead of a specific distance, use [`Point.shiftFractionTowards()`](reference/api/point/shiftfractiontowards/) instead.
 
 ```js
 Point point.shiftTowards(Point target, float distance)
 ```
 
-Returns a point that lies distance in the direction of target.
-
-<Example 
+<Example
   part="point_shifttowards"
   caption="An example of the Point.shiftTowards() method"
 />

--- a/markdown/dev/reference/api/point/shifttowards/en.md
+++ b/markdown/dev/reference/api/point/shifttowards/en.md
@@ -6,9 +6,13 @@ Returns a new `Point` that is shifted `distance` (mm) in the direction of the `t
 
 If you need to move a point a percentage instead of a specific distance, use [`Point.shiftFractionTowards()`](reference/api/point/shiftfractiontowards/) instead.
 
+## Point.shiftTowards() signature
+
 ```js
 Point point.shiftTowards(Point target, float distance)
 ```
+
+## Point.shiftTowards() example
 
 <Example
   part="point_shifttowards"

--- a/markdown/dev/reference/api/point/sitson/en.md
+++ b/markdown/dev/reference/api/point/sitson/en.md
@@ -16,9 +16,13 @@ millimeter, use [`Point.sitsRoughlyOn()`](/reference/api/point/sitsroughlyon/) i
 
 </Note>
 
+## Point.sitsOn() signature
+
 ```js
 bool point.sitsOn(Point check)
 ```
+
+## Point.sitsOn() example
 
 <Example
   part="point_sitson"

--- a/markdown/dev/reference/api/point/sitson/en.md
+++ b/markdown/dev/reference/api/point/sitson/en.md
@@ -1,14 +1,26 @@
 ---
-title: sitsOn()
+title: Point.sitsOn()
 ---
+
+Returns `true` if this point has the _exact_ same coordinates as the point you pass to it.
+
+<Note>
+
+###### Too exact?
+
+This method is _very_ precise, so points with an X-coordinate of `10` and `10.0001`
+are considered to be different.
+
+To check if two points have the same coordinates rounded to the nearest
+millimeter, use [`Point.sitsRoughlyOn()`](/reference/api/point/sitsroughlyon/) instead.
+
+</Note>
 
 ```js
 bool point.sitsOn(Point check)
 ```
 
-Returns true if the point has the same coordinates as the one you pass to it.
-
-<Example 
+<Example
   part="point_sitson"
   caption="An example of the Point.sitsOn() method"
 />

--- a/markdown/dev/reference/api/point/sitsroughlyon/en.md
+++ b/markdown/dev/reference/api/point/sitsroughlyon/en.md
@@ -4,6 +4,8 @@ title: Point.sitsRoughlyOn()
 
 Returns `true` if this point has roughly (rounded to the nearest millimeter) the same coordinates as the one you pass to it.
 
+## Point.sitsRoughlyOn() signature
+
 ```js
 bool point.sitsRoughlyOn(Point check)
 ```
@@ -16,6 +18,8 @@ The difference between this method and [`Point.sitsOn()`](/reference/api/point/s
 that this one rounds things down to the nearest integer (thus mm) before checking.
 
 </Note>
+
+## Point.sitsRoughlyOn() example
 
 <Example 
   part="point_sitsroughlyon"

--- a/markdown/dev/reference/api/point/sitsroughlyon/en.md
+++ b/markdown/dev/reference/api/point/sitsroughlyon/en.md
@@ -1,18 +1,18 @@
 ---
-title: sitsRoughlyOn()
+title: Point.sitsRoughlyOn()
 ---
+
+Returns `true` if this point has roughly (rounded to the nearest millimeter) the same coordinates as the one you pass to it.
 
 ```js
 bool point.sitsRoughlyOn(Point check)
 ```
 
-Returns true is the point has roughly the same coordinates as the one you pass to it.
-
 <Note>
 
 ###### How rough?
 
-The difference between this method and [Point.sitsOn](/reference/api/point/sitson/) is 
+The difference between this method and [`Point.sitsOn()`](/reference/api/point/sitson/) is
 that this one rounds things down to the nearest integer (thus mm) before checking.
 
 </Note>

--- a/markdown/dev/reference/api/point/translate/en.md
+++ b/markdown/dev/reference/api/point/translate/en.md
@@ -1,21 +1,21 @@
 ---
-title: translate()
+title: Point.translate()
 ---
- 
+
+Returns a new `Point` with a [translate transform](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translate) applied.
+
 ```js
 Point point.translate(float deltaX, float deltaY)
 ```
 
-Returns a point with 
-[a translate transform](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translate) 
-applied. 
-
 In other words, this will:
 
- - Add `deltaX` to the point's X-coordinate
- - Add `deltaY` to the point's Y-coordinate
+- Add `deltaX` to the point's X-coordinate
+- Add `deltaY` to the point's Y-coordinate
 
-<Example 
+Positive values for `deltaX` will move the point to the right. Positive values for `deltaY` will move the point downwards.
+
+<Example
   part="point_translate"
   caption="An example of the Point.translate() method"
 />

--- a/markdown/dev/reference/api/point/translate/en.md
+++ b/markdown/dev/reference/api/point/translate/en.md
@@ -4,6 +4,8 @@ title: Point.translate()
 
 Returns a new `Point` with a [translate transform](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translate) applied.
 
+## Point.translate() signature
+
 ```js
 Point point.translate(float deltaX, float deltaY)
 ```
@@ -14,6 +16,8 @@ In other words, this will:
 - Add `deltaY` to the point's Y-coordinate
 
 Positive values for `deltaX` will move the point to the right. Positive values for `deltaY` will move the point downwards.
+
+## Point.translate() example
 
 <Example
   part="point_translate"


### PR DESCRIPTION
- Changed all titles to `Point.method()` instead of just `method()`
- Added a brief first paragraph description of each method
- Added subheadings to divide the page (to match what Joost did for some other docs)
- Added `Point.dist()` docs that got gitignored into oblivion
- Added a bit more detail to some of the docs that were a little confusing to me.

Closes #1426 