### PR TITLE
Fix for #1467 Titan Waist Height not Working

### DIFF
--- a/packages/titan/src/back.js
+++ b/packages/titan/src/back.js
@@ -195,7 +195,7 @@ export default (part) => {
   if (options.waistHeight < 1 || absoluteOptions.waistbandWidth > 0) {
     points.styleWaistOut = drawOutseam()
       .reverse()
-      .shiftAlong(measurements.waistToHips + absoluteOptions.waistbandWidth)
+      .shiftAlong(measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth)
     points.styleWaistIn = utils.beamsIntersect(
       points.styleWaistOut,
       points.styleWaistOut.shift(points.waistOut.angle(points.waistIn), 10),

--- a/packages/titan/src/front.js
+++ b/packages/titan/src/front.js
@@ -273,7 +273,7 @@ export default (part) => {
   // Only now style the waist lower if requested
   if (options.waistHeight < 1 || absoluteOptions.waistbandWidth > 0) {
     points.styleWaistOut = drawOutseam().shiftAlong(
-      measurements.waistToHips *(1 - options.waistHeight) + absoluteOptions.waistbandWidth
+      measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth
     )
     points.styleWaistIn = utils.beamsIntersect(
       points.styleWaistOut,

--- a/packages/titan/src/front.js
+++ b/packages/titan/src/front.js
@@ -273,7 +273,7 @@ export default (part) => {
   // Only now style the waist lower if requested
   if (options.waistHeight < 1 || absoluteOptions.waistbandWidth > 0) {
     points.styleWaistOut = drawOutseam().shiftAlong(
-      measurements.waistToHips + absoluteOptions.waistbandWidth
+      measurements.waistToHips *(1 - options.waistHeight) + absoluteOptions.waistbandWidth
     )
     points.styleWaistIn = utils.beamsIntersect(
       points.styleWaistOut,


### PR DESCRIPTION
Fix for Issue #1467 
On inspection found the option had been removed from front.js and back.js in commit 8252b12 
Made a comment on the commit but decided it was just best to make a pull request with the fix and have it be closed if the removal of the option was intentional.
This just undoes the removal of the options on front.js and back.js

Hope this helps.