### PR TITLE
Fix broken macros documentation link

### DIFF
--- a/markdown/dev/howtos/code/macros/en.md
+++ b/markdown/dev/howtos/code/macros/en.md
@@ -11,6 +11,6 @@ Macros are provided by [plugins](/reference/plugins/). Here are some examples:
 
 <Example pattern="rendertest" options={{ colors: false, circles: false, snippets: false, text: false, widthHd: false }}/>
 
-Refer to [macro documentation](/reference/api/macro/) for details on how to use macros,
+Refer to the [macros documentation](/reference/api/macros/) for details on how to use macros,
 and the [plugins](/reference/plugins/) documentation for info on how to create your
 own macros.


### PR DESCRIPTION
Just a quick pull request to fix a broken link I encountered while reading the documentation.