### PR TITLE
Update link on reuse-measurements page

### DIFF
--- a/markdown/dev/guides/best-practices/reuse-measurements/en.md
+++ b/markdown/dev/guides/best-practices/reuse-measurements/en.md
@@ -9,10 +9,10 @@ certain measurements differently.
 
 <Tip>
 
-######  See our models packages for standard measurement names
+######  See our measurements page for standard measurement names
 
-The [@freesewing/models](/reference/packages/models/)
-package contains all our standard measurement names.
+The [measurements reference page](/reference/measurements/)
+contains all our standard measurement names.
 
 </Tip>
 


### PR DESCRIPTION
I ran across [this page](https://freesewing.dev/guides/best-practices/reuse-measurements) while going through the design pattern tutorial. The original link to the @freesewing/models package threw a 404. I opted to update it with a link to the measurements reference page instead.