### PR TITLE
Address misaligned match lines on Simon front and left pieces

### DIFF
--- a/packages/simon/src/frontleft-classic-cuton.js
+++ b/packages/simon/src/frontleft-classic-cuton.js
@@ -52,8 +52,12 @@ export default (part) => {
       .move(points.placketBottomOuterEdgeOver)
       .line(points.placketTopOuterEdgeOver)
       .attr('class', 'dotted')
-      .attr('data-text', 'matchHere')
-      .attr('data-text-class', 'text-xs center')
+    if (!options.seperateButtonPlacket) {
+      // Match lines are only displayed on attached plackets
+      paths.placketOuterEdgeOver
+        .attr('data-text', 'matchHere')
+        .attr('data-text-class', 'text-xs center')
+    }
     paths.placketOuterEdgeUnder = new Path()
       .move(points.placketTopOuterEdgeUnder)
       .line(points.placketBottomOuterEdgeUnder)

--- a/packages/simon/src/frontleft-classic-cuton.js
+++ b/packages/simon/src/frontleft-classic-cuton.js
@@ -32,6 +32,12 @@ export default (part) => {
       .move(points.placketCfNeck)
       .line(points.placketCfHem)
       .attr('class', 'help')
+    if (!options.seperateButtonPlacket) {
+      // Match lines are only displayed on attached plackets
+      paths.frontCenter
+        .attr('data-text', 'matchHere')
+        .attr('data-text-class', 'text-xs center')
+    }
     paths.placketInnerEdgeFold = new Path()
       .move(points.placketTopInnerEdgeFold)
       .line(points.placketBottomInnerEdgeFold)
@@ -52,12 +58,6 @@ export default (part) => {
       .move(points.placketBottomOuterEdgeOver)
       .line(points.placketTopOuterEdgeOver)
       .attr('class', 'dotted')
-    if (!options.seperateButtonPlacket) {
-      // Match lines are only displayed on attached plackets
-      paths.placketOuterEdgeOver
-        .attr('data-text', 'matchHere')
-        .attr('data-text-class', 'text-xs center')
-    }
     paths.placketOuterEdgeUnder = new Path()
       .move(points.placketTopOuterEdgeUnder)
       .line(points.placketBottomOuterEdgeUnder)

--- a/packages/simon/src/frontleft-seamless.js
+++ b/packages/simon/src/frontleft-seamless.js
@@ -21,8 +21,12 @@ export default (part) => {
       .move(points.placketBottomFold1)
       .line(points.placketTopFold1)
       .attr('class', 'dotted')
-      .attr('data-text', 'matchHere')
-      .attr('data-text-class', 'text-xs center')
+    if (!options.seperateButtonPlacket) {
+      // Match lines are only displayed on attached plackets
+      paths.placketFold1
+        .attr('data-text', 'matchHere')
+        .attr('data-text-class', 'text-xs center')
+    }
     paths.placketFold2 = new Path()
       .move(points.placketBottomFold2)
       .line(points.placketTopFold2)

--- a/packages/simon/src/frontleft-seamless.js
+++ b/packages/simon/src/frontleft-seamless.js
@@ -17,16 +17,16 @@ export default (part) => {
   if (complete) {
     // Placket help lines
     paths.frontCenter = new Path().move(points.cfNeck).line(points.cfHem).attr('class', 'help')
+    if (!options.seperateButtonPlacket) {
+      // Match lines are only displayed on attached plackets
+      paths.frontCenter
+        .attr('data-text', 'matchHere')
+        .attr('data-text-class', 'text-xs center')
+    }
     paths.placketFold1 = new Path()
       .move(points.placketBottomFold1)
       .line(points.placketTopFold1)
       .attr('class', 'dotted')
-    if (!options.seperateButtonPlacket) {
-      // Match lines are only displayed on attached plackets
-      paths.placketFold1
-        .attr('data-text', 'matchHere')
-        .attr('data-text-class', 'text-xs center')
-    }
     paths.placketFold2 = new Path()
       .move(points.placketBottomFold2)
       .line(points.placketTopFold2)

--- a/packages/simon/src/frontright-classic-cuton.js
+++ b/packages/simon/src/frontright-classic-cuton.js
@@ -42,7 +42,11 @@ export default (part) => {
     macro('sprinkle', {
       snippet: 'notch',
       on: [
+        'placketTopIn',
+        'placketTopOut',
         'cfNeck',
+        'placketBottomIn',
+        'placketBottomOut',
         'cfHem',
       ],
     })

--- a/packages/simon/src/frontright-classic-cuton.js
+++ b/packages/simon/src/frontright-classic-cuton.js
@@ -20,14 +20,16 @@ export default (part) => {
   points.placketBottomEdge = points.cfHem.shift(0, width * 1.5)
 
   const buttonholePlacketWidth = store.get('buttonholePlacketWidth')
-  if (options.buttonholePlacketStyle === 'seamless') {
-    points.placketTopMatch = points.cfNeck.shift(180, buttonholePlacketWidth / 2)
-    points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2)
-  } else {
-    const fold = store.get('buttonholePlacketFoldWidth')
-    points.placketTopMatch = points.cfNeck.shift(180, buttonholePlacketWidth / 2 - fold)
-    points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2 - fold)
-  }
+  const fold = options.buttonholePlacketStyle === 'seamless' ? 0 : store.get('buttonholePlacketFoldWidth')
+  points.placketTopMatch = utils.lineIntersectsCurve(
+    new Point(-(buttonholePlacketWidth / 2 - fold), points.cfNeck.y + 20),
+    new Point(-(buttonholePlacketWidth / 2 - fold), points.cfNeck.y - 20),
+    points.cfNeck,
+    points.cfNeckCp1,
+    points.neckCp2Front,
+    points.neck
+  )
+  points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2 - fold)
 
   paths.seam.line(points.placketTopEdge).line(points.placketBottomEdge).line(points.cfHem).close()
 

--- a/packages/simon/src/frontright-classic-cuton.js
+++ b/packages/simon/src/frontright-classic-cuton.js
@@ -19,30 +19,51 @@ export default (part) => {
   points.placketBottomOut = points.cfHem.shift(0, width / 2)
   points.placketBottomEdge = points.cfHem.shift(0, width * 1.5)
 
+  const buttonholePlacketWidth = store.get('buttonholePlacketWidth')
+  if (options.buttonholePlacketStyle === 'seamless') {
+    points.placketTopMatch = points.cfNeck.shift(180, buttonholePlacketWidth / 2)
+    points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2)
+  } else {
+    const fold = store.get('buttonholePlacketFoldWidth')
+    points.placketTopMatch = points.cfNeck.shift(180, buttonholePlacketWidth / 2 - fold)
+    points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2 - fold)
+  }
+
   paths.seam.line(points.placketTopEdge).line(points.placketBottomEdge).line(points.cfHem).close()
 
   // Complete pattern?
   if (complete) {
     // Placket help lines
     paths.frontCenter = new Path().move(points.cfNeck).line(points.cfHem).attr('class', 'help')
-    paths.placketInnerFold = new Path()
-      .move(points.placketBottomIn)
-      .line(points.placketTopIn)
-      .attr('class', 'dotted')
-      .attr('data-text', 'matchHere')
-      .attr('data-text-class', 'text-xs center')
     paths.placketOuterFold = new Path()
       .move(points.placketTopOut)
       .line(points.placketBottomOut)
       .attr('class', 'dotted')
+    paths.placketInnerFold = new Path()
+      .move(points.placketBottomIn)
+      .line(points.placketTopIn)
+      .attr('class', 'dotted')
+    if (!options.seperateButtonholePlacket) {
+      // Match lines are only displayed on attached plackets
+      if (Math.abs(points.placketTopIn.x - points.placketTopMatch.x) < 0.5) {
+        // Match line is nearly the same as the inner fold line.
+        paths.placketInnerFold
+          .attr('data-text', 'matchHere')
+          .attr('data-text-class', 'text-xs center')
+      } else {
+        // Separate match line and inner fold line.
+        paths.placketMatch = new Path()
+          .move(points.placketBottomMatch)
+          .line(points.placketTopMatch)
+          .attr('class', 'stroke-sm help')
+          .attr('data-text', 'matchHere')
+          .attr('data-text-class', 'text-xs center')
+      }
+    }
     macro('sprinkle', {
       snippet: 'notch',
       on: [
-        'placketTopIn',
-        'placketTopOut',
         'cfNeck',
-        'placketBottomIn',
-        'placketBottomOut',
         'cfHem',
       ],
     })

--- a/packages/simon/src/frontright-classic-cuton.js
+++ b/packages/simon/src/frontright-classic-cuton.js
@@ -19,49 +19,26 @@ export default (part) => {
   points.placketBottomOut = points.cfHem.shift(0, width / 2)
   points.placketBottomEdge = points.cfHem.shift(0, width * 1.5)
 
-  const buttonholePlacketWidth = store.get('buttonholePlacketWidth')
-  const fold = options.buttonholePlacketStyle === 'seamless' ? 0 : store.get('buttonholePlacketFoldWidth')
-  points.placketTopMatch = utils.lineIntersectsCurve(
-    new Point(-(buttonholePlacketWidth / 2 - fold), points.cfNeck.y + 20),
-    new Point(-(buttonholePlacketWidth / 2 - fold), points.cfNeck.y - 20),
-    points.cfNeck,
-    points.cfNeckCp1,
-    points.neckCp2Front,
-    points.neck
-  )
-  points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2 - fold)
-
   paths.seam.line(points.placketTopEdge).line(points.placketBottomEdge).line(points.cfHem).close()
 
   // Complete pattern?
   if (complete) {
     // Placket help lines
     paths.frontCenter = new Path().move(points.cfNeck).line(points.cfHem).attr('class', 'help')
-    paths.placketOuterFold = new Path()
-      .move(points.placketTopOut)
-      .line(points.placketBottomOut)
-      .attr('class', 'dotted')
+    if (!options.seperateButtonholePlacket) {
+      // Match lines are only displayed on attached plackets
+      paths.frontCenter
+        .attr('data-text', 'matchHere')
+        .attr('data-text-class', 'text-xs center')
+    }
     paths.placketInnerFold = new Path()
       .move(points.placketBottomIn)
       .line(points.placketTopIn)
       .attr('class', 'dotted')
-    if (!options.seperateButtonholePlacket) {
-      // Match lines are only displayed on attached plackets
-      if (Math.abs(points.placketTopIn.x - points.placketTopMatch.x) < 0.5) {
-        // Match line is nearly the same as the inner fold line.
-        paths.placketInnerFold
-          .attr('data-text', 'matchHere')
-          .attr('data-text-class', 'text-xs center')
-      } else {
-        // Separate match line and inner fold line.
-        paths.placketMatch = new Path()
-          .move(points.placketBottomMatch)
-          .line(points.placketTopMatch)
-          .attr('class', 'stroke-sm help')
-          .attr('data-text', 'matchHere')
-          .attr('data-text-class', 'text-xs center')
-      }
-    }
+    paths.placketOuterFold = new Path()
+      .move(points.placketTopOut)
+      .line(points.placketBottomOut)
+      .attr('class', 'dotted')
     macro('sprinkle', {
       snippet: 'notch',
       on: [

--- a/packages/simon/src/frontright-seamless.js
+++ b/packages/simon/src/frontright-seamless.js
@@ -1,18 +1,29 @@
 import { addButtons } from './shared'
 
 export default (part) => {
-  const { sa, store, Point, points, Path, paths, complete, paperless, macro } =
+  const { sa, store, Point, points, Path, paths, complete, paperless, macro, options } =
     part.shorthand()
 
   const width = store.get('buttonPlacketWidth')
   points.placketTopFold1 = points.cfNeck.shift(0, width / 2)
   points.placketTopFold2 = points.cfNeck.shift(0, width * 1.5)
   points.placketTopEdge = points.cfNeck.shift(0, width * 2.5)
+  points.placketTopIn = points.cfNeck.shift(180, width / 2)
   points.placketBottomFold1 = points.cfHem.shift(0, width / 2)
   points.placketBottomFold2 = points.cfHem.shift(0, width * 1.5)
   points.placketBottomEdge = points.cfHem.shift(0, width * 2.5)
-  points.placketBottomMatch = points.cfHem.shift(180, width / 2)
-  points.placketTopMatch = points.cfNeck.shift(180, width / 2)
+  points.placketBottomIn = points.cfHem.shift(180, width / 2)
+
+  const buttonholePlacketWidth = store.get('buttonholePlacketWidth')
+  if (options.buttonholePlacketStyle === 'seamless') {
+    points.placketTopMatch = points.cfNeck.shift(180, buttonholePlacketWidth / 2)
+    points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2)
+  } else {
+    const fold = store.get('buttonholePlacketFoldWidth')
+    points.placketTopMatch = points.cfNeck.shift(180, buttonholePlacketWidth / 2 - fold)
+    points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2 - fold)
+  }
+
   paths.seam.line(points.placketTopEdge).line(points.placketBottomEdge).line(points.cfHem).close()
 
   // Complete pattern?
@@ -27,19 +38,31 @@ export default (part) => {
       .move(points.placketTopFold2)
       .line(points.placketBottomFold2)
       .attr('class', 'dotted')
-    paths.placketMatch = new Path()
-      .move(points.placketBottomMatch)
-      .line(points.placketTopMatch)
-      .attr('class', 'stroke-sm help')
-      .attr('data-text', 'matchHere')
-      .attr('data-text-class', 'text-xs center')
+    paths.placketInnerFold = new Path()
+      .move(points.placketBottomIn)
+      .line(points.placketTopIn)
+      .attr('class', 'dotted')
+    if (!options.seperateButtonholePlacket) {
+      // Match lines are only displayed on attached plackets
+      if (Math.abs(points.placketTopIn.x - points.placketTopMatch.x) < 0.5) {
+        // Match line is nearly the same as the inner fold line.
+        paths.placketInnerFold
+          .attr('data-text', 'matchHere')
+          .attr('data-text-class', 'text-xs center')
+      } else {
+        // Separate match line and inner fold line.
+        paths.placketMatch = new Path()
+          .move(points.placketBottomMatch)
+          .line(points.placketTopMatch)
+          .attr('class', 'stroke-sm help')
+          .attr('data-text', 'matchHere')
+          .attr('data-text-class', 'text-xs center')
+      }
+    }
+
     macro('sprinkle', {
       snippet: 'notch',
       on: [
-        'placketTopFold1',
-        'placketTopFold2',
-        'placketBottomFold1',
-        'placketBottomFold2',
         'cfNeck',
         'cfHem',
       ],

--- a/packages/simon/src/frontright-seamless.js
+++ b/packages/simon/src/frontright-seamless.js
@@ -1,7 +1,7 @@
 import { addButtons } from './shared'
 
 export default (part) => {
-  const { sa, store, Point, points, Path, paths, complete, paperless, macro, options } =
+  const { sa, store, Point, points, Path, paths, complete, paperless, macro, options, utils } =
     part.shorthand()
 
   const width = store.get('buttonPlacketWidth')
@@ -15,14 +15,16 @@ export default (part) => {
   points.placketBottomIn = points.cfHem.shift(180, width / 2)
 
   const buttonholePlacketWidth = store.get('buttonholePlacketWidth')
-  if (options.buttonholePlacketStyle === 'seamless') {
-    points.placketTopMatch = points.cfNeck.shift(180, buttonholePlacketWidth / 2)
-    points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2)
-  } else {
-    const fold = store.get('buttonholePlacketFoldWidth')
-    points.placketTopMatch = points.cfNeck.shift(180, buttonholePlacketWidth / 2 - fold)
-    points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2 - fold)
-  }
+  const fold = options.buttonholePlacketStyle === 'seamless' ? 0 : store.get('buttonholePlacketFoldWidth')
+  points.placketTopMatch = utils.lineIntersectsCurve(
+    new Point(-(buttonholePlacketWidth / 2 - fold), points.cfNeck.y + 20),
+    new Point(-(buttonholePlacketWidth / 2 - fold), points.cfNeck.y - 20),
+    points.cfNeck,
+    points.cfNeckCp1,
+    points.neckCp2Front,
+    points.neck
+  )
+  points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2 - fold)
 
   paths.seam.line(points.placketTopEdge).line(points.placketBottomEdge).line(points.cfHem).close()
 

--- a/packages/simon/src/frontright-seamless.js
+++ b/packages/simon/src/frontright-seamless.js
@@ -1,7 +1,7 @@
 import { addButtons } from './shared'
 
 export default (part) => {
-  const { sa, store, Point, points, Path, paths, complete, paperless, macro, options, utils } =
+  const { sa, store, Point, points, Path, paths, complete, paperless, macro, options } =
     part.shorthand()
 
   const width = store.get('buttonPlacketWidth')
@@ -14,24 +14,18 @@ export default (part) => {
   points.placketBottomEdge = points.cfHem.shift(0, width * 2.5)
   points.placketBottomIn = points.cfHem.shift(180, width / 2)
 
-  const buttonholePlacketWidth = store.get('buttonholePlacketWidth')
-  const fold = options.buttonholePlacketStyle === 'seamless' ? 0 : store.get('buttonholePlacketFoldWidth')
-  points.placketTopMatch = utils.lineIntersectsCurve(
-    new Point(-(buttonholePlacketWidth / 2 - fold), points.cfNeck.y + 20),
-    new Point(-(buttonholePlacketWidth / 2 - fold), points.cfNeck.y - 20),
-    points.cfNeck,
-    points.cfNeckCp1,
-    points.neckCp2Front,
-    points.neck
-  )
-  points.placketBottomMatch = points.cfHem.shift(180, buttonholePlacketWidth / 2 - fold)
-
   paths.seam.line(points.placketTopEdge).line(points.placketBottomEdge).line(points.cfHem).close()
 
   // Complete pattern?
   if (complete) {
     // Placket help lines
     paths.frontCenter = new Path().move(points.cfNeck).line(points.cfHem).attr('class', 'help')
+    if (!options.seperateButtonholePlacket) {
+      // Match lines are only displayed on attached plackets
+      paths.frontCenter
+        .attr('data-text', 'matchHere')
+        .attr('data-text-class', 'text-xs center')
+    }
     paths.placketFold1 = new Path()
       .move(points.placketTopFold1)
       .line(points.placketBottomFold1)
@@ -44,24 +38,6 @@ export default (part) => {
       .move(points.placketBottomIn)
       .line(points.placketTopIn)
       .attr('class', 'dotted')
-    if (!options.seperateButtonholePlacket) {
-      // Match lines are only displayed on attached plackets
-      if (Math.abs(points.placketTopIn.x - points.placketTopMatch.x) < 0.5) {
-        // Match line is nearly the same as the inner fold line.
-        paths.placketInnerFold
-          .attr('data-text', 'matchHere')
-          .attr('data-text-class', 'text-xs center')
-      } else {
-        // Separate match line and inner fold line.
-        paths.placketMatch = new Path()
-          .move(points.placketBottomMatch)
-          .line(points.placketTopMatch)
-          .attr('class', 'stroke-sm help')
-          .attr('data-text', 'matchHere')
-          .attr('data-text-class', 'text-xs center')
-      }
-    }
-
     macro('sprinkle', {
       snippet: 'notch',
       on: [

--- a/packages/simon/src/frontright-seamless.js
+++ b/packages/simon/src/frontright-seamless.js
@@ -41,6 +41,10 @@ export default (part) => {
     macro('sprinkle', {
       snippet: 'notch',
       on: [
+        'placketTopFold1',
+        'placketTopFold2',
+        'placketBottomFold1',
+        'placketBottomFold2',
         'cfNeck',
         'cfHem',
       ],


### PR DESCRIPTION
# Background

I recently attempted the Simon pattern and ran into a small issue with pattern matching. As I am very new to sewing and this was my first time ever sewing from a pattern, I think it is likely that I have misunderstood something or made a mistake.  Would you mind reviewing my issue and proposed change to see whether it makes sense?

# Problem Description

The issue is with the pattern matching between the two front pieces. When my shirt is fully buttoned, the pattern alignment is off by around six millimeters:
![image](https://user-images.githubusercontent.com/9117775/148680595-7325f173-3bc6-4ecf-b569-0dde95f9a894.png)

You can see how the pattern should match if I unbutton the shirt and shift the sides:
![image](https://user-images.githubusercontent.com/9117775/148680623-c7d58602-a8bb-4e97-84f3-61af045c42c5.png)

Looking at the generated pattern pieces and aligning the button and buttonhole lines, I see that the match lines are indeed misaligned:
![image](https://user-images.githubusercontent.com/9117775/148681510-738656bc-3ca8-4511-8e7e-272e2b7c9fa2.png)

As far as I can tell, this is caused by the fact that the position of the match line on the front right piece is based solely on the width of the button placket. I believe it should be based on the size of the buttonhole placket.

# Approach 

In this change I have attempted to add a separate match line to the front right piece. It is based on the buttonhole placket width and is usually in a different position that the line marking the edge of the button placket. I have also updated both front pieces to only display match lines if the placket on the other side is not separate. As far as I can tell, match lines are never displayed on separate plackets.

# Testing

I was a little unsure which combinations of plackets I needed to support. I believe there are 16 theoretically possible placket combinations: separate/attached buttonhole * classic/seamless buttonhole * separate/attached button * classic/seamless button. In practice it seems all combinations involving separate plackets can be ignored since they do not include match lines. That leaves the following combinations:

## attached-classic buttonhole, attached-classic-button

![image](https://user-images.githubusercontent.com/9117775/148681139-bd016cb7-c2a5-4c07-bd1d-13c9628c7c41.png)

## attached-classic buttonhole, attached-seamless-button

![image](https://user-images.githubusercontent.com/9117775/148681170-4e02b944-556c-45ac-bc33-6d83bb38f9dc.png)

## attached-seamless buttonhole, attached-classic-button

![image](https://user-images.githubusercontent.com/9117775/148681202-738fa038-604b-4837-b008-8d8230d71020.png)

## attached-seamless buttonhole, attached-seamless-button
![image](https://user-images.githubusercontent.com/9117775/148681226-9f406257-c817-42a3-9d40-c8137b0eb316.png)

## Close lines

I also tested the behavior when the match line and placket edge are very close:
![image](https://user-images.githubusercontent.com/9117775/148681597-39de7a13-3870-4f8f-8b8b-adbea17f497a.png)
![image](https://user-images.githubusercontent.com/9117775/148681608-d0a341c5-1532-4ef0-89a2-11955b6f3b87.png)

# Open Questions

I wasn't sure what to do about notches. I see that notches are normally displayed on the match lines and on the edges of the plackets, but as far as I can tell these notches do not match with any other notches. I have tentatively removed the notches I could not understand from the button placket. I did not remove the corresponding notches from the buttonhole placket.. I could use some guidance here.

~~I didn't find any way to have the match line meet the curve of the neck. Please let me know if there is a way to improve this.~~ (Found `utils.lineIntersectsCurve`. Added a separate commit for this.)

