### PR TITLE
Update tutorial code block

### DIFF
--- a/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
@@ -20,7 +20,7 @@ do {
 	  .move(points.right)
 	  .curve(points.rightCp1, points.bottomCp2, points.bottom)
 
-	delta = paths.neck.length() - target
+	delta = paths.quarterNeck.length() - target
   if (delta > 0) tweak = tweak * 0.99
   else tweak = tweak * 1.02
 } while (Math.abs(delta) > 1)


### PR DESCRIPTION
I was seeing this error in my browser while going through the pattern design tutorial:
![Screenshot_2022-01-12_16-52-02](https://user-images.githubusercontent.com/1550506/149229036-634d09ac-80b5-4126-a373-6f53d0a20a55.png)

Fixed the code block in the tutorial to refer to the quarterNeck that had been created beforehand and it did the trick.



