### PR TITLE
Update path to macros docs in tutorial

### DIFF
--- a/markdown/dev/tutorials/pattern-design/creating-the-closure/en.md
+++ b/markdown/dev/tutorials/pattern-design/creating-the-closure/en.md
@@ -57,7 +57,7 @@ macro("round", {
 })
 ```
 
-<Note> You can find more information on the `round` macro in [the macros docs](/reference/macros/round/).</Note>
+<Note> You can find more information on the `round` macro in [the macros docs](/reference/api/macros/round/).</Note>
 
 <Example pattern="tutorial" part="step7" caption="Pretty good, but how are we going to fit it over the baby's head?" />
 


### PR DESCRIPTION
The link was broken in the docs. I updated it with the current path to the macro docs.