### PR TITLE
Use 2:1 overlap to underlap ratio for Simon sleeve placket

### DIFF
--- a/packages/simon/src/sleeveplacket-underlap.js
+++ b/packages/simon/src/sleeveplacket-underlap.js
@@ -15,7 +15,7 @@ export default (part) => {
     store,
   } = part.shorthand()
 
-  const width = store.get('sleevePlacketWidth') > 20 ? 10 : store.get('sleevePlacketWidth') / 4
+  const width = Math.min(store.get('sleevePlacketWidth') / 2, 10)
   const length = measurements.shoulderToWrist * options.sleevePlacketLength
 
   points.midLeft = new Point(0, 0)


### PR DESCRIPTION
Opening this as a draft since I have low confidence I am doing the right thing.

## Problem

I recently created a Simon shirt for myself. It had the following sleeve placket underlap and overlap:
![image](https://user-images.githubusercontent.com/9117775/149623942-a8965233-750c-47e2-abab-48f6ac726f42.png)

Next I started working on a Simone for my wife. It had the following sleeve placket underlap and overlap:
![image](https://user-images.githubusercontent.com/9117775/149623976-22e27f44-be30-4049-bc20-e452939215c3.png)

The difference in the ratio between the underlap and overlap was very surprising to me and I found the underlap very hard to work with given its size. Looking at [the code](https://github.com/freesewing/freesewing/blob/develop/packages/simon/src/sleeveplacket-underlap.js#L18), I wondered whether maybe this was a bug:

```javascript
const width = store.get('sleevePlacketWidth') > 20 ? 10 : store.get('sleevePlacketWidth') / 4
```

This results in the following relationships:
![image](https://user-images.githubusercontent.com/9117775/149625379-ad64ba15-6359-4370-91fd-11b3e88194c6.png)


My best guess was that the intention was to cap the max at 10 but maintain a ratio of 2 to 1 below that:
![image](https://user-images.githubusercontent.com/9117775/149626502-686e96ce-2ee5-48a3-8dd0-f13bdd598304.png)


