### PR TITLE
Honor scale setting in scalebox.

### DIFF
--- a/packages/plugin-scalebox/src/miniscale.js
+++ b/packages/plugin-scalebox/src/miniscale.js
@@ -17,8 +17,25 @@ export default function (so) {
     for (let id of ['__miniscaleMetric', '__miniscaleImperial']) delete this.paths[id]
     return true
   }
-  const m = 12.5
-  const i = 12.7
+
+  const scale = this.context.settings.scale
+
+  // Convert scale to a value between 0 and 5, inclusive.
+  const scaleIndex = Math.ceil(6 * Math.max(0.1, Math.min(1, this.context.settings.scale))) - 1
+
+  // Metric size in mm / display value and imperial size in mm / display value for each scale index.
+  const sizes = [
+    [10, "1cm",   25.4 * 0.375, '⅜″'],
+    [13, "1.3cm", 25.4 * 0.5,   '½″'],
+    [16, "1.6cm", 25.4 * 0.625, '⅝″'],
+    [19, "1.9cm", 25.4 * 0.75,  '¾″'],
+    [22, "2.2cm", 25.4 * 0.875, '⅞″'],
+    [25, "2.5cm", 25.4 * 1,     '1″'],
+  ]
+  const m = sizes[scaleIndex][0] / 2
+  const i = sizes[scaleIndex][2] / 2
+  const metricDisplaySize = sizes[scaleIndex][1]
+  const imperialDisplaySize = sizes[scaleIndex][3]
   // Box points
   this.points.__miniscaleMetricTopLeft = new this.Point(so.at.x - m, so.at.y - m)
   this.points.__miniscaleMetricTopRight = new this.Point(so.at.x + m, so.at.y - m)
@@ -29,8 +46,8 @@ export default function (so) {
   this.points.__miniscaleImperialBottomLeft = new this.Point(so.at.x - i, so.at.y + i)
   this.points.__miniscaleImperialBottomRight = new this.Point(so.at.x + i, so.at.y + i)
   // Text anchor points
-  this.points.__miniscaleMetric = new this.Point(so.at.x, so.at.y - 2)
-  this.points.__miniscaleImperial = new this.Point(so.at.x, so.at.y + 8)
+  this.points.__miniscaleMetric = new this.Point(so.at.x, so.at.y - 2 * scale)
+  this.points.__miniscaleImperial = new this.Point(so.at.x, so.at.y + 8 * scale)
   // Rotation
   if (so.rotate) {
     let points = [
@@ -70,9 +87,9 @@ export default function (so) {
     .close()
   // Text
   this.points.__miniscaleMetric = this.points.__miniscaleMetric
-    .attr('data-text', '2.5cm x 2.5cm')
+    .attr('data-text', `${metricDisplaySize} x ${metricDisplaySize}`)
     .attr('data-text-class', 'text-xs center')
   this.points.__miniscaleImperial = this.points.__miniscaleImperial
-    .attr('data-text', '1" x 1"')
+    .attr('data-text', `${imperialDisplaySize} x ${imperialDisplaySize}`)
     .attr('data-text-class', 'text-xs center ')
 }

--- a/packages/plugin-scalebox/src/scalebox.js
+++ b/packages/plugin-scalebox/src/scalebox.js
@@ -21,22 +21,66 @@ export default function (so) {
     for (let id of ['__scaleboxMetric', '__scaleboxImperial']) delete this.paths[id]
     return true
   }
+
+  const scale = this.context.settings.scale
+
+  // Convert scale to a value between 0 and 9, inclusive.
+  const scaleIndex = Math.round(10 * Math.max(0.1, Math.min(1, this.context.settings.scale))) - 1
+
+  // Metric width and height in mm and display width and height for each scale index.
+  const metricSizes = [
+    [ 10, 5,  "1cm",  "0.5cm"],
+    [ 20, 10, "2cm",  "1cm"],
+    [ 30, 15, "3cm",  "1.5cm"],
+    [ 40, 20, "4cm",  "2cm"],
+    [ 50, 25, "5cm",  "2.5cm"],
+    [ 60, 30, "6cm",  "3cm"],
+    [ 70, 35, "7cm",  "3.5cm"],
+    [ 80, 40, "8cm",  "4cm"],
+    [ 90, 45, "9cm",  "4.5cm"],
+    [100, 50, "10cm", "5cm"],
+  ]
+
+  const metricWidth         = metricSizes[scaleIndex][0]
+  const metricHeight        = metricSizes[scaleIndex][1]
+  const metricDisplayWidth  = metricSizes[scaleIndex][2]
+  const metricDisplayHeight = metricSizes[scaleIndex][3]
+
+  // Imperial width and height in mm and display width and heigth for each scale index.
+  const imperialSizes = [
+    [25.4 * 0.5,   25.4 * 0.25,  '½″',   '¼″'],
+    [25.4 * 0.875, 25.4 * 0.5,   '⅞″',   '½″'],
+    [25.4 * 1.25,  25.4 * 0.625, '1 ¼″', '⅝″'],
+    [25.4 * 1.625, 25.4 * 0.875, '1 ⅝″', '⅞″'],
+    [25.4 * 2,     25.4 * 1,     '2″',   '1″'],
+    [25.4 * 2.375, 25.4 * 1.25,  '2 ⅜″', '1 ¼″'],
+    [25.4 * 2.875, 25.4 * 1.5,   '2 ⅞″', '1 ½″'],
+    [25.4 * 3.25,  25.4 * 1.625, '3 ¼″', '1 ⅝″'],
+    [25.4 * 3.625, 25.4 * 1.875, '3 ⅝″', '1 ⅞″'],
+    [25.4 * 4,     25.4 * 2,     '4″',   '2″'],
+  ]
+
+  const imperialWidth         = imperialSizes[scaleIndex][0]
+  const imperialHeight        = imperialSizes[scaleIndex][1]
+  const imperialDisplayWidth  = imperialSizes[scaleIndex][2]
+  const imperialDisplayHeight = imperialSizes[scaleIndex][3]
+
   // Box points
-  this.points.__scaleboxMetricTopLeft = new this.Point(so.at.x - 50, so.at.y - 25)
-  this.points.__scaleboxMetricTopRight = new this.Point(so.at.x + 50, so.at.y - 25)
-  this.points.__scaleboxMetricBottomLeft = new this.Point(so.at.x - 50, so.at.y + 25)
-  this.points.__scaleboxMetricBottomRight = new this.Point(so.at.x + 50, so.at.y + 25)
-  this.points.__scaleboxImperialTopLeft = new this.Point(so.at.x - 50.8, so.at.y - 25.4)
-  this.points.__scaleboxImperialTopRight = new this.Point(so.at.x + 50.8, so.at.y - 25.4)
-  this.points.__scaleboxImperialBottomLeft = new this.Point(so.at.x - 50.8, so.at.y + 25.4)
-  this.points.__scaleboxImperialBottomRight = new this.Point(so.at.x + 50.8, so.at.y + 25.4)
+  this.points.__scaleboxMetricTopLeft = new this.Point(so.at.x - metricWidth / 2, so.at.y - metricHeight / 2)
+  this.points.__scaleboxMetricTopRight = new this.Point(so.at.x + metricWidth / 2, so.at.y - metricHeight / 2)
+  this.points.__scaleboxMetricBottomLeft = new this.Point(so.at.x - metricWidth / 2, so.at.y + metricHeight / 2)
+  this.points.__scaleboxMetricBottomRight = new this.Point(so.at.x + metricWidth / 2, so.at.y + metricHeight / 2)
+  this.points.__scaleboxImperialTopLeft = new this.Point(so.at.x - imperialWidth / 2, so.at.y - imperialHeight / 2)
+  this.points.__scaleboxImperialTopRight = new this.Point(so.at.x + imperialWidth / 2, so.at.y - imperialHeight / 2)
+  this.points.__scaleboxImperialBottomLeft = new this.Point(so.at.x - imperialWidth / 2, so.at.y + imperialHeight / 2)
+  this.points.__scaleboxImperialBottomRight = new this.Point(so.at.x + imperialWidth / 2, so.at.y + imperialHeight / 2)
   // Text anchor points
-  this.points.__scaleboxLead = new this.Point(so.at.x - 45, so.at.y - 15)
-  this.points.__scaleboxTitle = this.points.__scaleboxLead.shift(-90, 10)
-  this.points.__scaleboxText = this.points.__scaleboxTitle.shift(-90, 12)
-  this.points.__scaleboxLink = this.points.__scaleboxText.shift(-90, 5)
-  this.points.__scaleboxMetric = new this.Point(so.at.x, so.at.y + 20)
-  this.points.__scaleboxImperial = new this.Point(so.at.x, so.at.y + 24)
+  this.points.__scaleboxLead = new this.Point(so.at.x - 45 * scale, so.at.y - 15 * scale)
+  this.points.__scaleboxTitle = this.points.__scaleboxLead.shift(-90, 10 * scale)
+  this.points.__scaleboxText = this.points.__scaleboxTitle.shift(-90, 12 * scale)
+  this.points.__scaleboxLink = this.points.__scaleboxText.shift(-90, 5 * scale)
+  this.points.__scaleboxMetric = new this.Point(so.at.x, so.at.y + 20 * scale)
+  this.points.__scaleboxImperial = new this.Point(so.at.x, so.at.y + 24 * scale)
   // Rotation
   if (so.rotate) {
     let points = [
@@ -103,14 +147,14 @@ export default function (so) {
   // Instructions
   this.points.__scaleboxMetric = this.points.__scaleboxMetric
     .attr('data-text', 'theWhiteInsideOfThisBoxShouldMeasure')
-    .attr('data-text', '10cm')
+    .attr('data-text', `${metricDisplayWidth}`)
     .attr('data-text', 'x')
-    .attr('data-text', '5cm')
+    .attr('data-text', `${metricDisplayHeight}`)
     .attr('data-text-class', 'text-xs center')
   this.points.__scaleboxImperial = this.points.__scaleboxImperial
     .attr('data-text', 'theBlackOutsideOfThisBoxShouldMeasure')
-    .attr('data-text', '4"')
+    .attr('data-text', `${imperialDisplayWidth}`)
     .attr('data-text', 'x')
-    .attr('data-text', '2"')
+    .attr('data-text', `${imperialDisplayHeight}`)
     .attr('data-text-class', 'text-xs center ')
 }

--- a/packages/plugin-scalebox/tests/plugin.test.mjs
+++ b/packages/plugin-scalebox/tests/plugin.test.mjs
@@ -187,4 +187,34 @@ describe('Scalebox Plugin Tests', () => {
     expect(p.__scaleboxImperial.attributes.get('data-text'))
       .to.equal("theBlackOutsideOfThisBoxShouldMeasure 2″ x 1″")
   });
+
+  it("Should apply scale to the miniscale macro", () => {
+    const pattern = new freesewing.Pattern().use(plugin)
+    pattern.settings.scale = 0.5
+    pattern.parts.test = new pattern.Part();
+    pattern.parts.test.points.anchor = new pattern.Point(100, 200);
+    const { macro } = pattern.parts.test.shorthand()
+    macro("miniscale", {
+      at: pattern.parts.test.points.anchor
+    });
+    let p = pattern.parts.test.points;
+    expect(p.__miniscaleMetricTopLeft.x).to.equal(92);
+    expect(p.__miniscaleMetricTopLeft.y).to.equal(192);
+    expect(p.__miniscaleMetricTopRight.x).to.equal(108);
+    expect(p.__miniscaleMetricTopRight.y).to.equal(192);
+    expect(p.__miniscaleMetricBottomLeft.x).to.equal(92);
+    expect(p.__miniscaleMetricBottomLeft.y).to.equal(208);
+    expect(p.__miniscaleMetricBottomRight.x).to.equal(108);
+    expect(p.__miniscaleMetricBottomRight.y).to.equal(208);
+    expect(p.__miniscaleImperialTopLeft.x).to.equal(92.0625);
+    expect(p.__miniscaleImperialTopLeft.y).to.equal(192.0625);
+    expect(p.__miniscaleImperialTopRight.x).to.equal(107.9375);
+    expect(p.__miniscaleImperialTopRight.y).to.equal(192.0625);
+    expect(p.__miniscaleImperialBottomLeft.x).to.equal(92.0625);
+    expect(p.__miniscaleImperialBottomLeft.y).to.equal(207.9375);
+    expect(p.__miniscaleImperialBottomRight.x).to.equal(107.9375);
+    expect(p.__miniscaleImperialBottomRight.y).to.equal(207.9375);
+    expect(p.__miniscaleMetric.attributes.get('data-text')).to.equal("1.6cm x 1.6cm")
+    expect(p.__miniscaleImperial.attributes.get('data-text')).to.equal("⅝″ x ⅝″")
+  });
 })

--- a/packages/plugin-scalebox/tests/plugin.test.mjs
+++ b/packages/plugin-scalebox/tests/plugin.test.mjs
@@ -155,4 +155,36 @@ describe('Scalebox Plugin Tests', () => {
     expect(p.get("data-text-class")).to.equal("text-xs");
     expect(p.get("data-text-lineheight")).to.equal("4");
   })
+
+  it("Should apply scale to the scalebox macro", () => {
+    const pattern = new freesewing.Pattern().use(plugin)
+    pattern.settings.scale = 0.5
+    pattern.parts.test = new pattern.Part();
+    pattern.parts.test.points.anchor = new pattern.Point(100, 200);
+    const { macro } = pattern.parts.test.shorthand()
+    macro("scalebox", {
+      at: pattern.parts.test.points.anchor
+    });
+    let p = pattern.parts.test.points;
+    expect(p.__scaleboxMetricTopLeft.x).to.equal(75);
+    expect(p.__scaleboxMetricTopLeft.y).to.equal(187.5);
+    expect(p.__scaleboxMetricTopRight.x).to.equal(125);
+    expect(p.__scaleboxMetricTopRight.y).to.equal(187.5);
+    expect(p.__scaleboxMetricBottomLeft.x).to.equal(75);
+    expect(p.__scaleboxMetricBottomLeft.y).to.equal(212.5);
+    expect(p.__scaleboxMetricBottomRight.x).to.equal(125);
+    expect(p.__scaleboxMetricBottomRight.y).to.equal(212.5);
+    expect(p.__scaleboxImperialTopLeft.x).to.equal(74.6);
+    expect(p.__scaleboxImperialTopLeft.y).to.equal(187.3);
+    expect(p.__scaleboxImperialTopRight.x).to.equal(125.4);
+    expect(p.__scaleboxImperialTopRight.y).to.equal(187.3);
+    expect(p.__scaleboxImperialBottomLeft.x).to.equal(74.6);
+    expect(p.__scaleboxImperialBottomLeft.y).to.equal(212.7);
+    expect(p.__scaleboxImperialBottomRight.x).to.equal(125.4);
+    expect(p.__scaleboxImperialBottomRight.y).to.equal(212.7);
+    expect(p.__scaleboxMetric.attributes.get('data-text'))
+      .to.equal("theWhiteInsideOfThisBoxShouldMeasure 5cm x 2.5cm")
+    expect(p.__scaleboxImperial.attributes.get('data-text'))
+      .to.equal("theBlackOutsideOfThisBoxShouldMeasure 2″ x 1″")
+  });
 })


### PR DESCRIPTION
## Approach
 1. Bound scale to the nearest of the following: 0.1, 0.2, 0.3, 0.4, 0.5. 0.6. 0.7, 0.8, 0.9, 1.0. 
 2. Choose an appropriate metric and imperial scalebox size, limited to half centimeter / eighth inch precision. 

[minibox-plus-scalebox.pdf](https://github.com/freesewing/freesewing/files/7908784/minibox-plus-scalebox.pdf)