### PR TITLE
Fix typo in freesewing.lab

### DIFF
--- a/packages/freesewing.lab/package.json
+++ b/packages/freesewing.lab/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "freesewing.dev",
+  "name": "freesewing.lab",
   "version": "2.19.9",
   "private": true,
   "scripts": {


### PR DESCRIPTION
This was breaking for me with:
```
error There are more than one workspace with name "freesewing.dev"
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```