### PR TITLE
Fix some broken image links.

### DIFF
--- a/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/de.md
+++ b/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/de.md
@@ -1,4 +1,4 @@
-![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfonrtfactory.svg)
+![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfrontfactory.svg)
 
 Diese Option steuert die vertikale Positionierung der Ärmelschaltung an der Vorderseite des Ärmels.
 

--- a/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/en.md
+++ b/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/en.md
@@ -1,4 +1,4 @@
-![The vertical location of the front inflection point](./sleevecapfonrtfactory.svg)
+![The vertical location of the front inflection point](./sleevecapfrontfactory.svg)
 
 This option controls the vertical placement of the sleevecap inflection point at the front of the sleeve.
 

--- a/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/es.md
+++ b/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/es.md
@@ -1,4 +1,4 @@
-![La posición vertical del punto de inflexión frontal](./sleevecapfonrtfactory.svg)
+![La posición vertical del punto de inflexión frontal](./sleevecapfrontfactory.svg)
 
 Esta opción controla la colocación vertical del punto de inflexión de manga en la parte frontal de la manga.
 

--- a/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/fr.md
+++ b/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/fr.md
@@ -1,4 +1,4 @@
-![L'emplacement vertical du point d'inflexion avant](./sleevecapfonrtfactory.svg)
+![L'emplacement vertical du point d'inflexion avant](./sleevecapfrontfactory.svg)
 
 Cette option contrôle la position verticale du point d'inflexion de la tête de manche sur le devant de la manche.
 

--- a/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/nl.md
+++ b/markdown/org/docs/patterns/breanna/options/sleevecapfrontfactory/nl.md
@@ -1,4 +1,4 @@
-![De verticale locatie van het tussenpunt vooraan](./sleevecapfonrtfactory.svg)
+![De verticale locatie van het tussenpunt vooraan](./sleevecapfrontfactory.svg)
 
 Deze optie bepaalt de verticale plaatsing van het tussenpunt aan de voorkant van de mouw.
 

--- a/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/de.md
+++ b/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/de.md
@@ -1,4 +1,4 @@
-![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfonrtfactory.svg)
+![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfrontfactory.svg)
 
 Diese Option steuert die vertikale Positionierung der Ärmelschaltung an der Vorderseite des Ärmels.
 

--- a/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/en.md
+++ b/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/en.md
@@ -1,4 +1,4 @@
-![The vertical location of the front inflection point](./sleevecapfonrtfactory.svg)
+![The vertical location of the front inflection point](./sleevecapfrontfactory.svg)
 
 This option controls the vertical placement of the sleevecap inflection point at the front of the sleeve.
 

--- a/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/es.md
+++ b/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/es.md
@@ -1,4 +1,4 @@
-![La posición vertical del punto de inflexión frontal](./sleevecapfonrtfactory.svg)
+![La posición vertical del punto de inflexión frontal](./sleevecapfrontfactory.svg)
 
 Esta opción controla la colocación vertical del punto de inflexión de manga en la parte frontal de la manga.
 

--- a/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/fr.md
+++ b/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/fr.md
@@ -1,4 +1,4 @@
-![L'emplacement vertical du point d'inflexion avant](./sleevecapfonrtfactory.svg)
+![L'emplacement vertical du point d'inflexion avant](./sleevecapfrontfactory.svg)
 
 Cette option contrôle la position verticale du point d'inflexion de la tête de manche sur le devant de la manche.
 

--- a/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/nl.md
+++ b/markdown/org/docs/patterns/brian/options/sleevecapfrontfactory/nl.md
@@ -1,4 +1,4 @@
-![De verticale locatie van het tussenpunt vooraan](./sleevecapfonrtfactory.svg)
+![De verticale locatie van het tussenpunt vooraan](./sleevecapfrontfactory.svg)
 
 Deze optie bepaalt de verticale plaatsing van het tussenpunt aan de voorkant van de mouw.
 

--- a/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/de.md
+++ b/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/de.md
@@ -1,4 +1,4 @@
-![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfonrtfactory.svg)
+![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfrontfactory.svg)
 
 Diese Option steuert die vertikale Positionierung der Ärmelschaltung an der Vorderseite des Ärmels.
 

--- a/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/en.md
+++ b/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/en.md
@@ -1,4 +1,4 @@
-![The vertical location of the front inflection point](./sleevecapfonrtfactory.svg)
+![The vertical location of the front inflection point](./sleevecapfrontfactory.svg)
 
 This option controls the vertical placement of the sleevecap inflection point at the front of the sleeve.
 

--- a/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/es.md
+++ b/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/es.md
@@ -1,4 +1,4 @@
-![La posición vertical del punto de inflexión frontal](./sleevecapfonrtfactory.svg)
+![La posición vertical del punto de inflexión frontal](./sleevecapfrontfactory.svg)
 
 Esta opción controla la colocación vertical del punto de inflexión de manga en la parte frontal de la manga.
 

--- a/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/fr.md
+++ b/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/fr.md
@@ -1,4 +1,4 @@
-![L'emplacement vertical du point d'inflexion avant](./sleevecapfonrtfactory.svg)
+![L'emplacement vertical du point d'inflexion avant](./sleevecapfrontfactory.svg)
 
 Cette option contrôle la position verticale du point d'inflexion de la tête de manche sur le devant de la manche.
 

--- a/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/nl.md
+++ b/markdown/org/docs/patterns/diana/options/sleevecapfrontfactory/nl.md
@@ -1,4 +1,4 @@
-![De verticale locatie van het tussenpunt vooraan](./sleevecapfonrtfactory.svg)
+![De verticale locatie van het tussenpunt vooraan](./sleevecapfrontfactory.svg)
 
 Deze optie bepaalt de verticale plaatsing van het tussenpunt aan de voorkant van de mouw.
 

--- a/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/de.md
+++ b/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/de.md
@@ -1,4 +1,4 @@
-![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfonrtfactory.svg)
+![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfrontfactory.svg)
 
 Diese Option steuert die vertikale Positionierung der Ärmelschaltung an der Vorderseite des Ärmels.
 

--- a/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/en.md
+++ b/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/en.md
@@ -1,4 +1,4 @@
-![The vertical location of the front inflection point](./sleevecapfonrtfactory.svg)
+![The vertical location of the front inflection point](./sleevecapfrontfactory.svg)
 
 This option controls the vertical placement of the sleevecap inflection point at the front of the sleeve.
 

--- a/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/es.md
+++ b/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/es.md
@@ -1,4 +1,4 @@
-![La posición vertical del punto de inflexión frontal](./sleevecapfonrtfactory.svg)
+![La posición vertical del punto de inflexión frontal](./sleevecapfrontfactory.svg)
 
 Esta opción controla la colocación vertical del punto de inflexión de manga en la parte frontal de la manga.
 

--- a/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/fr.md
+++ b/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/fr.md
@@ -1,4 +1,4 @@
-![L'emplacement vertical du point d'inflexion avant](./sleevecapfonrtfactory.svg)
+![L'emplacement vertical du point d'inflexion avant](./sleevecapfrontfactory.svg)
 
 Cette option contrôle la position verticale du point d'inflexion de la tête de manche sur le devant de la manche.
 

--- a/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/nl.md
+++ b/markdown/org/docs/patterns/huey/options/sleevecapfrontfactory/nl.md
@@ -1,4 +1,4 @@
-![De verticale locatie van het tussenpunt vooraan](./sleevecapfonrtfactory.svg)
+![De verticale locatie van het tussenpunt vooraan](./sleevecapfrontfactory.svg)
 
 Deze optie bepaalt de verticale plaatsing van het tussenpunt aan de voorkant van de mouw.
 

--- a/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/de.md
+++ b/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/de.md
@@ -1,4 +1,4 @@
-![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfonrtfactory.svg)
+![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfrontfactory.svg)
 
 Diese Option steuert die vertikale Positionierung der Ärmelschaltung an der Vorderseite des Ärmels.
 

--- a/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/en.md
+++ b/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/en.md
@@ -1,4 +1,4 @@
-![The vertical location of the front inflection point](./sleevecapfonrtfactory.svg)
+![The vertical location of the front inflection point](./sleevecapfrontfactory.svg)
 
 This option controls the vertical placement of the sleevecap inflection point at the front of the sleeve.
 

--- a/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/es.md
+++ b/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/es.md
@@ -1,4 +1,4 @@
-![La posición vertical del punto de inflexión frontal](./sleevecapfonrtfactory.svg)
+![La posición vertical del punto de inflexión frontal](./sleevecapfrontfactory.svg)
 
 Esta opción controla la colocación vertical del punto de inflexión de manga en la parte frontal de la manga.
 

--- a/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/fr.md
+++ b/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/fr.md
@@ -1,4 +1,4 @@
-![L'emplacement vertical du point d'inflexion avant](./sleevecapfonrtfactory.svg)
+![L'emplacement vertical du point d'inflexion avant](./sleevecapfrontfactory.svg)
 
 Cette option contrôle la position verticale du point d'inflexion de la tête de manche sur le devant de la manche.
 

--- a/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/nl.md
+++ b/markdown/org/docs/patterns/simon/options/sleevecapfrontfactory/nl.md
@@ -1,4 +1,4 @@
-![De verticale locatie van het tussenpunt vooraan](./sleevecapfonrtfactory.svg)
+![De verticale locatie van het tussenpunt vooraan](./sleevecapfrontfactory.svg)
 
 Deze optie bepaalt de verticale plaatsing van het tussenpunt aan de voorkant van de mouw.
 

--- a/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/de.md
+++ b/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/de.md
@@ -1,4 +1,4 @@
-![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfonrtfactory.svg)
+![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfrontfactory.svg)
 
 Diese Option steuert die vertikale Positionierung der Ärmelschaltung an der Vorderseite des Ärmels.
 

--- a/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/en.md
+++ b/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/en.md
@@ -1,4 +1,4 @@
-![The vertical location of the front inflection point](./sleevecapfonrtfactory.svg)
+![The vertical location of the front inflection point](./sleevecapfrontfactory.svg)
 
 This option controls the vertical placement of the sleevecap inflection point at the front of the sleeve.
 

--- a/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/es.md
+++ b/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/es.md
@@ -1,4 +1,4 @@
-![La posición vertical del punto de inflexión frontal](./sleevecapfonrtfactory.svg)
+![La posición vertical del punto de inflexión frontal](./sleevecapfrontfactory.svg)
 
 Esta opción controla la colocación vertical del punto de inflexión de manga en la parte frontal de la manga.
 

--- a/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/fr.md
+++ b/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/fr.md
@@ -1,4 +1,4 @@
-![L'emplacement vertical du point d'inflexion avant](./sleevecapfonrtfactory.svg)
+![L'emplacement vertical du point d'inflexion avant](./sleevecapfrontfactory.svg)
 
 Cette option contrôle la position verticale du point d'inflexion de la tête de manche sur le devant de la manche.
 

--- a/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/nl.md
+++ b/markdown/org/docs/patterns/simone/options/sleevecapfrontfactory/nl.md
@@ -1,4 +1,4 @@
-![De verticale locatie van het tussenpunt vooraan](./sleevecapfonrtfactory.svg)
+![De verticale locatie van het tussenpunt vooraan](./sleevecapfrontfactory.svg)
 
 Deze optie bepaalt de verticale plaatsing van het tussenpunt aan de voorkant van de mouw.
 

--- a/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/de.md
+++ b/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/de.md
@@ -1,4 +1,4 @@
-![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfonrtfactory.svg)
+![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfrontfactory.svg)
 
 Diese Option steuert die vertikale Positionierung der Ärmelschaltung an der Vorderseite des Ärmels.
 

--- a/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/en.md
+++ b/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/en.md
@@ -1,4 +1,4 @@
-![The vertical location of the front inflection point](./sleevecapfonrtfactory.svg)
+![The vertical location of the front inflection point](./sleevecapfrontfactory.svg)
 
 This option controls the vertical placement of the sleevecap inflection point at the front of the sleeve.
 

--- a/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/es.md
+++ b/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/es.md
@@ -1,4 +1,4 @@
-![La posición vertical del punto de inflexión frontal](./sleevecapfonrtfactory.svg)
+![La posición vertical del punto de inflexión frontal](./sleevecapfrontfactory.svg)
 
 Esta opción controla la colocación vertical del punto de inflexión de manga en la parte frontal de la manga.
 

--- a/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/fr.md
+++ b/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/fr.md
@@ -1,4 +1,4 @@
-![L'emplacement vertical du point d'inflexion avant](./sleevecapfonrtfactory.svg)
+![L'emplacement vertical du point d'inflexion avant](./sleevecapfrontfactory.svg)
 
 Cette option contrôle la position verticale du point d'inflexion de la tête de manche sur le devant de la manche.
 

--- a/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/nl.md
+++ b/markdown/org/docs/patterns/sven/options/sleevecapfrontfactory/nl.md
@@ -1,4 +1,4 @@
-![De verticale locatie van het tussenpunt vooraan](./sleevecapfonrtfactory.svg)
+![De verticale locatie van het tussenpunt vooraan](./sleevecapfrontfactory.svg)
 
 Deze optie bepaalt de verticale plaatsing van het tussenpunt aan de voorkant van de mouw.
 

--- a/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/de.md
+++ b/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/de.md
@@ -1,4 +1,4 @@
-![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfonrtfactory.svg)
+![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfrontfactory.svg)
 
 Diese Option steuert die vertikale Positionierung der Ärmelschaltung an der Vorderseite des Ärmels.
 

--- a/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/en.md
+++ b/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/en.md
@@ -1,4 +1,4 @@
-![The vertical location of the front inflection point](./sleevecapfonrtfactory.svg)
+![The vertical location of the front inflection point](./sleevecapfrontfactory.svg)
 
 This option controls the vertical placement of the sleevecap inflection point at the front of the sleeve.
 

--- a/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/es.md
+++ b/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/es.md
@@ -1,4 +1,4 @@
-![La posición vertical del punto de inflexión frontal](./sleevecapfonrtfactory.svg)
+![La posición vertical del punto de inflexión frontal](./sleevecapfrontfactory.svg)
 
 Esta opción controla la colocación vertical del punto de inflexión de manga en la parte frontal de la manga.
 

--- a/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/fr.md
+++ b/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/fr.md
@@ -1,4 +1,4 @@
-![La position verticale du point de flexion avant](./sleevecapfonrtfactory.svg)
+![La position verticale du point de flexion avant](./sleevecapfrontfactory.svg)
 
 Cette option contrôle la position verticale du point de flexion du tête de manche à l'avant de la manche.
 

--- a/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/nl.md
+++ b/markdown/org/docs/patterns/teagan/options/sleevecapfrontfactory/nl.md
@@ -1,4 +1,4 @@
-![De verticale locatie van het tussenpunt vooraan](./sleevecapfonrtfactory.svg)
+![De verticale locatie van het tussenpunt vooraan](./sleevecapfrontfactory.svg)
 
 Deze optie bepaalt de verticale plaatsing van het tussenpunt aan de voorkant van de mouw.
 

--- a/markdown/org/docs/patterns/trayvon/options/tipwidth/de.md
+++ b/markdown/org/docs/patterns/trayvon/options/tipwidth/de.md
@@ -1,4 +1,4 @@
-![Spitzenbreite](topwidth.svg)
+![Spitzenbreite](tipwidth.svg)
 
 Die Breite der Spitze ist die Breite an der Spitze der Krawatte.
 

--- a/markdown/org/docs/patterns/trayvon/options/tipwidth/en.md
+++ b/markdown/org/docs/patterns/trayvon/options/tipwidth/en.md
@@ -1,4 +1,4 @@
-![Tip width](topwidth.svg)
+![Tip width](tipwidth.svg)
 
 The tip width is the width at the tip of the tie.
 

--- a/markdown/org/docs/patterns/trayvon/options/tipwidth/es.md
+++ b/markdown/org/docs/patterns/trayvon/options/tipwidth/es.md
@@ -1,4 +1,4 @@
-![Ancho de la punta](topwidth.svg)
+![Ancho de la punta](tipwidth.svg)
 
 El ancho de la punta es el ancho en la punta del empate.
 

--- a/markdown/org/docs/patterns/trayvon/options/tipwidth/fr.md
+++ b/markdown/org/docs/patterns/trayvon/options/tipwidth/fr.md
@@ -1,4 +1,4 @@
-![Largeur de la pointe](topwidth.svg)
+![Largeur de la pointe](tipwidth.svg)
 
 La largeur de la pointe est la largeur à la pointe de la cravate.
 

--- a/markdown/org/docs/patterns/trayvon/options/tipwidth/nl.md
+++ b/markdown/org/docs/patterns/trayvon/options/tipwidth/nl.md
@@ -1,4 +1,4 @@
-![Breedte punt](topwidth.svg)
+![Breedte punt](tipwidth.svg)
 
 De breedte van de punt is de breedte aan de punt van de das.
 

--- a/markdown/org/docs/patterns/waralee/options/hemwidth/de.md
+++ b/markdown/org/docs/patterns/waralee/options/hemwidth/de.md
@@ -3,4 +3,4 @@ Höhe des Saums am unteren Rand der Hose
 
 
 ## Effekt dieser Option auf das Schnittmuster
-![Dieses Bild zeigt den Effekt dieser Option, indem es mehrere Varianten überlagert, die einen anderen Wert für diese Option haben](waralee_hem_sample.svg "Effekt dieser Option auf das Schnittmuster")
+![Dieses Bild zeigt den Effekt dieser Option, indem es mehrere Varianten überlagert, die einen anderen Wert für diese Option haben](waralee_hemwidth_sample.svg "Effekt dieser Option auf das Schnittmuster")

--- a/markdown/org/docs/patterns/waralee/options/hemwidth/en.md
+++ b/markdown/org/docs/patterns/waralee/options/hemwidth/en.md
@@ -3,4 +3,4 @@ Size of the hem at the bottom of the pants
 
 
 ## Effect of this option on the pattern
-![This image shows the effect of this option by superimposing several variants that have a different value for this option](waralee_hem_sample.svg "Effect of this option on the pattern")
+![This image shows the effect of this option by superimposing several variants that have a different value for this option](waralee_hemwidth_sample.svg "Effect of this option on the pattern")

--- a/markdown/org/docs/patterns/waralee/options/hemwidth/es.md
+++ b/markdown/org/docs/patterns/waralee/options/hemwidth/es.md
@@ -3,4 +3,4 @@ Tamaño de la temperatura en la parte inferior de los pantalones
 
 
 ## Efecto de esta opción en el patrón
-![Esta imagen muestra el efecto de esta opción superponiendo varias variantes que tienen un valor diferente para esta opción](waralee_hem_sample.svg "Efecto de esta opción en el patrón")
+![Esta imagen muestra el efecto de esta opción superponiendo varias variantes que tienen un valor diferente para esta opción](waralee_hemwidth_sample.svg "Efecto de esta opción en el patrón")

--- a/markdown/org/docs/patterns/waralee/options/hemwidth/fr.md
+++ b/markdown/org/docs/patterns/waralee/options/hemwidth/fr.md
@@ -3,4 +3,4 @@ Taille de l'ourlet au bas du pantalon
 
 
 ## Effet de cette option sur le motif
-![Cette image montre l'effet de cette option en superposant plusieurs variantes qui ont une valeur différente pour cette option](waralee_hem_sample.svg "Effet de cette option sur le motif")
+![Cette image montre l'effet de cette option en superposant plusieurs variantes qui ont une valeur différente pour cette option](waralee_hemwidth_sample.svg "Effet de cette option sur le motif")

--- a/markdown/org/docs/patterns/waralee/options/hemwidth/nl.md
+++ b/markdown/org/docs/patterns/waralee/options/hemwidth/nl.md
@@ -3,4 +3,4 @@ De afmeting van de zoom onderaan de broek
 
 
 ## Effect van deze optie op het patroon
-![Deze afbeelding toont het effect van deze optie door meerdere varianten die een andere waarde hebben voor deze optie te vervangen](waralee_hem_sample.svg "Effect van deze optie op het patroon")
+![Deze afbeelding toont het effect van deze optie door meerdere varianten die een andere waarde hebben voor deze optie te vervangen](waralee_hemwidth_sample.svg "Effect van deze optie op het patroon")

--- a/markdown/org/docs/patterns/waralee/options/waistbandwidth/de.md
+++ b/markdown/org/docs/patterns/waralee/options/waistbandwidth/de.md
@@ -3,4 +3,4 @@ Größe des Taillenbundes
 
 
 ## Effekt dieser Option auf das Schnittmuster
-![Dieses Bild zeigt den Effekt dieser Option, indem es mehrere Varianten überlagert, die einen anderen Wert für diese Option haben](waralee_waistband_sample.svg "Effekt dieser Option auf das Schnittmuster")
+![Dieses Bild zeigt den Effekt dieser Option, indem es mehrere Varianten überlagert, die einen anderen Wert für diese Option haben](waralee_waistbandwidth_sample.svg "Effekt dieser Option auf das Schnittmuster")

--- a/markdown/org/docs/patterns/waralee/options/waistbandwidth/en.md
+++ b/markdown/org/docs/patterns/waralee/options/waistbandwidth/en.md
@@ -3,4 +3,4 @@ Size of the waist band
 
 
 ## Effect of this option on the pattern
-![This image shows the effect of this option by superimposing several variants that have a different value for this option](waralee_waistband_sample.svg "Effect of this option on the pattern")
+![This image shows the effect of this option by superimposing several variants that have a different value for this option](waralee_waistbandwidth_sample.svg "Effect of this option on the pattern")

--- a/markdown/org/docs/patterns/waralee/options/waistbandwidth/es.md
+++ b/markdown/org/docs/patterns/waralee/options/waistbandwidth/es.md
@@ -3,4 +3,4 @@ Tamaño de la banda de cintura
 
 
 ## Efecto de esta opción en el patrón
-![Esta imagen muestra el efecto de esta opción superponiendo varias variantes que tienen un valor diferente para esta opción](waralee_waistband_sample.svg "Efecto de esta opción en el patrón")
+![Esta imagen muestra el efecto de esta opción superponiendo varias variantes que tienen un valor diferente para esta opción](waralee_waistbandwidth_sample.svg "Efecto de esta opción en el patrón")

--- a/markdown/org/docs/patterns/waralee/options/waistbandwidth/fr.md
+++ b/markdown/org/docs/patterns/waralee/options/waistbandwidth/fr.md
@@ -3,4 +3,4 @@ Taille de la bande de taille
 
 
 ## Effet de cette option sur le motif
-![Cette image montre l'effet de cette option en superposant plusieurs variantes qui ont une valeur différente pour cette option](waralee_waistband_sample.svg "Effet de cette option sur le motif")
+![Cette image montre l'effet de cette option en superposant plusieurs variantes qui ont une valeur différente pour cette option](waralee_waistbandwidth_sample.svg "Effet de cette option sur le motif")

--- a/markdown/org/docs/patterns/waralee/options/waistbandwidth/nl.md
+++ b/markdown/org/docs/patterns/waralee/options/waistbandwidth/nl.md
@@ -3,4 +3,4 @@ Grootte van de tailleband
 
 
 ## Effect van deze optie op het patroon
-![Deze afbeelding toont het effect van deze optie door meerdere varianten die een andere waarde hebben voor deze optie te vervangen](waralee_waistband_sample.svg "Effect van deze optie op het patroon")
+![Deze afbeelding toont het effect van deze optie door meerdere varianten die een andere waarde hebben voor deze optie te vervangen](waralee_waistbandwidth_sample.svg "Effect van deze optie op het patroon")

--- a/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/de.md
+++ b/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/de.md
@@ -1,4 +1,4 @@
-![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfonrtfactory.svg)
+![Die vertikale Position des vorderen Durchbiegungspunkts](./sleevecapfrontfactory.svg)
 
 Diese Option steuert die vertikale Positionierung der Ärmelschaltung an der Vorderseite des Ärmels.
 

--- a/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/en.md
+++ b/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/en.md
@@ -1,4 +1,4 @@
-![The vertical location of the front inflection point](./sleevecapfonrtfactory.svg)
+![The vertical location of the front inflection point](./sleevecapfrontfactory.svg)
 
 This option controls the vertical placement of the sleevecap inflection point at the front of the sleeve.
 

--- a/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/es.md
+++ b/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/es.md
@@ -1,4 +1,4 @@
-![La posición vertical del punto de inflexión frontal](./sleevecapfonrtfactory.svg)
+![La posición vertical del punto de inflexión frontal](./sleevecapfrontfactory.svg)
 
 Esta opción controla la colocación vertical del punto de inflexión de manga en la parte frontal de la manga.
 

--- a/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/fr.md
+++ b/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/fr.md
@@ -1,4 +1,4 @@
-![L'emplacement vertical du point d'inflexion avant](./sleevecapfonrtfactory.svg)
+![L'emplacement vertical du point d'inflexion avant](./sleevecapfrontfactory.svg)
 
 Cette option contrôle la position verticale du point d'inflexion de la tête de manche sur le devant de la manche.
 

--- a/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/nl.md
+++ b/markdown/org/docs/patterns/yuri/options/sleevecapfrontfactory/nl.md
@@ -1,4 +1,4 @@
-![De verticale locatie van het tussenpunt vooraan](./sleevecapfonrtfactory.svg)
+![De verticale locatie van het tussenpunt vooraan](./sleevecapfrontfactory.svg)
 
 Deze optie bepaalt de verticale plaatsing van het tussenpunt aan de voorkant van de mouw.
 


### PR DESCRIPTION
There are still at least three broken images where the actual image is missing:

- markdown/org/docs/patterns/huey/options/acrossbackfactor/acrossbackfactor.svg
- markdown/org/docs/patterns/simon/options/extratopbutton/extratopbutton.svg
- markdown/org/docs/patterns/simone/options/extratopbutton/extratopbutton.svg

I thought about simply removing the references to these images but maybe they have already been made and can be easily added.