### PR TITLE
Add deps from some Simon parts to back part.

### DIFF
--- a/packages/simon/config/index.js
+++ b/packages/simon/config/index.js
@@ -122,6 +122,12 @@ export default {
     sleeve: ['sleeveBase', 'front', 'back'],
     frontRight: ['back'],
     frontLeft: ['back'],
+    sleevePlacketUnderlap: ['back'],
+    sleevePlacketOverlap: ['back'],
+    collar: ['back'],
+    collarStand: ['back'],
+    buttonPlacket: ['back'],
+    buttonholePlacket: ['back'],
   },
   inject: {
     frontBase: 'base',


### PR DESCRIPTION
I like to use the custom contents option but it doesn't work for all parts in Simon. I believe this is due to the fact that the back part sets values in the Store which other parts need. I first thought about setting these values in shared but some of them are complex, for example backArmholeToArmholePitch.