### PR TITLE
Updated tests for individual part drafting (aka the content option)

### DIFF
--- a/packages/css-theme/src/components/_pattern.scss
+++ b/packages/css-theme/src/components/_pattern.scss
@@ -72,6 +72,12 @@ svg.freesewing.pattern {
   .stroke-2xl {
     stroke-width: calc(var(--freesewing-pattern-scale) * 4);
   }
+  .stroke-3xl {
+    stroke-width: calc(var(--freesewing-pattern-scale) * 6);
+  }
+  .stroke-4xl {
+    stroke-width: calc(var(--freesewing-pattern-scale) * 10);
+  }
 
   .sa {
     stroke-dasharray: 1, 3;

--- a/packages/freesewing.shared/styles/svg-freesewing-draft.css
+++ b/packages/freesewing.shared/styles/svg-freesewing-draft.css
@@ -22,6 +22,9 @@ svg.freesewing.pattern {
   .stroke-lg { stroke-width: calc(var(--pattern-stroke-lg) * var(--pattern-scale)); }
   .stroke-xl { stroke-width: calc(var(--pattern-stroke-xl) * var(--pattern-scale)); }
   .stroke-2xl { stroke-width: calc(var(--pattern-stroke-2xl) * var(--pattern-scale)); }
+  .stroke-3xl { stroke-width: calc(var(--pattern-stroke-3xl) * var(--pattern-scale)); }
+  .stroke-4xl { stroke-width: calc(var(--pattern-stroke-4xl) * var(--pattern-scale)); }
+  .stroke-5xl { stroke-width: calc(var(--pattern-stroke-5xl) * var(--pattern-scale)); }
 
   /* Stroke dasharray utility classes */
   .sa { stroke-dasharray: 1, 3; }

--- a/packages/freesewing.shared/themes/dark.js
+++ b/packages/freesewing.shared/themes/dark.js
@@ -98,4 +98,6 @@ module.exports = {
   '--pattern-stroke-lg': "1.3px",
   '--pattern-stroke-xl': "2px",
   '--pattern-stroke-2xl': "4px",
+  '--pattern-stroke-3xl': "6px",
+  '--pattern-stroke-4xl': "8px",
 }

--- a/packages/freesewing.shared/themes/hax0r.js
+++ b/packages/freesewing.shared/themes/hax0r.js
@@ -100,4 +100,6 @@ module.exports = {
   '--pattern-stroke-lg': "1.3px",
   '--pattern-stroke-xl': "2px",
   '--pattern-stroke-2xl': "4px",
+  '--pattern-stroke-3xl': "6px",
+  '--pattern-stroke-4xl': "8px",
 }

--- a/packages/freesewing.shared/themes/lgbtq.js
+++ b/packages/freesewing.shared/themes/lgbtq.js
@@ -102,5 +102,7 @@ module.exports = {
   '--pattern-stroke-lg': "1.3px",
   '--pattern-stroke-xl': "2px",
   '--pattern-stroke-2xl': "4px",
+  '--pattern-stroke-3xl': "6px",
+  '--pattern-stroke-4xl': "8px",
 }
 

--- a/packages/freesewing.shared/themes/light.js
+++ b/packages/freesewing.shared/themes/light.js
@@ -240,6 +240,10 @@ module.exports = {
   '--pattern-stroke-lg': "1.3px",
   // Pattern xl stroke width
   '--pattern-stroke-xl': "2px",
-  // Pattern xxl stroke width
+  // Pattern 2xl stroke width
   '--pattern-stroke-2xl': "4px",
+  // Pattern 3xl stroke width
+  '--pattern-stroke-3xl': "6px",
+  // Pattern 4xl stroke width
+  '--pattern-stroke-4xl': "8px",
 }

--- a/packages/freesewing.shared/themes/trans.js
+++ b/packages/freesewing.shared/themes/trans.js
@@ -103,5 +103,7 @@ module.exports = {
   '--pattern-stroke-lg': "1.3px",
   '--pattern-stroke-xl': "2px",
   '--pattern-stroke-2xl': "4px",
+  '--pattern-stroke-3xl': "6px",
+  '--pattern-stroke-4xl': "8px",
 }
 

--- a/packages/plugin-theme/src/lib/draft.js
+++ b/packages/plugin-theme/src/lib/draft.js
@@ -64,8 +64,15 @@ export default (scale) => `
   svg.freesewing .stroke-xl {
     stroke-width: ${round(1*scale)};
   }
-  svg.freesewing .stroke-xxl {
+  svg.freesewing .stroke-xxl,
+  svg.freesewing .stroke-2xl {
     stroke-width: ${round(2*scale)};
+  }
+  svg.freesewing .stroke-3xl {
+    stroke-width: ${round(3*scale)};
+  }
+  svg.freesewing .stroke-4xl {
+    stroke-width: ${round(4*scale)};
   }
 
   svg.freesewing .sa {

--- a/tests/patterns/drafting.mjs
+++ b/tests/patterns/drafting.mjs
@@ -101,18 +101,14 @@ export const testPatternDrafting = (design, Pattern, expect, models, patterns, l
    * Draft parts individually
    */
   it('Draft parts individually:', () => true)
-  let parts = isGarment(design)
-    ? patterns.parts[design]
-    : Pattern.config.parts
-  for (let name of parts) {
-    it(`  - ${name} should draft on its own`, () => {
+  const parts = new Pattern().draftOrder()
+  for (const part of parts) {
+    it(`  - Drafting only the ${part} part`, () => {
       expect(
         doesItDraft(
           new Pattern({
             measurements,
-            settings: {
-              only: [name]
-            }
+            only: [part]
           }), log
         )
       ).to.equal(true)

--- a/tests/patterns/drafting.mjs
+++ b/tests/patterns/drafting.mjs
@@ -129,11 +129,6 @@ export const testPatternDrafting = (design, Pattern, expect, models, patterns, l
               complete: false,
               paperless: true,
               sa,
-              settings: {
-              complete: false,
-              paperless: true,
-              sa,
-              }
             }), log
           )
         ).to.equal(true)


### PR DESCRIPTION
This is inspired by @nicholasdower 's work on #1768

 - Step 1: Realize we should have unit tests to check that all individual patterns draft
 - Step 2: Realize you already added such tests
 - Step 3: Realize you configured them wrong
 
Submitting this as a PR because this breaks a bunch of tests. And while that is a good thing (1) it would not be great of we're stuck for the foreseeable future with a bunch of tests failing and people shrugging it off because *it's those `only` tests*

(1) Good in the sense that we can start chipping away at fixing those patterns that don't have their part dependencies properly configured (which is always the reason for this to fail)

**Does this catch all problems?**

Nick mentioned he wanted to use this with Simon, and it did not work as expected. Yet simon does not throw any errors.
Which makes me wonder if there's perhaps more to this than the draft failing.

Perhaps he can clarify what he expected and what happened instead.