### PR TITLE
add(docs) Missing Simon(e) Pattern Options

### DIFF
--- a/markdown/org/docs/patterns/simon/options/yokeheight/en.md
+++ b/markdown/org/docs/patterns/simon/options/yokeheight/en.md
@@ -1,11 +1,8 @@
----
----
 
-<Fixme>
+Controls the height of the yoke seam.
 
-Document this option
-
-</Fixme>
+- Increase this option to lower the height and lengthen the yoke
+- Decrease this option to raise the height and shorten the yoke
 
 
 ## Effect of this option on the pattern

--- a/markdown/org/docs/patterns/simone/options/bustdartangle/en.md
+++ b/markdown/org/docs/patterns/simone/options/bustdartangle/en.md
@@ -1,11 +1,8 @@
----
----
 
-<Fixme>
+Controls the angle by which the (side) bust dart slopes downward.
 
-Document this option
-
-</Fixme>
+- Increase this option to angle the bust darts downwards and towards the floor
+- Decrease this option to angle the bust darts upwards and towards the armscye
 
 
 ## Effect of this option on the pattern

--- a/markdown/org/docs/patterns/simone/options/bustdartlength/en.md
+++ b/markdown/org/docs/patterns/simone/options/bustdartlength/en.md
@@ -1,11 +1,8 @@
----
----
 
-<Fixme>
+Controls how close the bust dart approaches the bust point.
 
-Document this option
-
-</Fixme>
+- Increase this option to lengthen the bust dart moving it closer to the bust point
+- Decrease this option to shorten the bust dart moving it further away from the bust point
 
 
 ## Effect of this option on the pattern

--- a/markdown/org/docs/patterns/simone/options/bustdartlength/en.md
+++ b/markdown/org/docs/patterns/simone/options/bustdartlength/en.md
@@ -1,8 +1,8 @@
 
-Controls how close the bust dart approaches the bust point.
+Controls how close the **bust darts** approach the bust points.
 
-- Increase this option to lengthen the bust dart moving it closer to the bust point
-- Decrease this option to shorten the bust dart moving it further away from the bust point
+- Increase this option to lengthen the bust darts moving them closer to the bust points
+- Decrease this option to shorten the bust darts moving them further away from the bust points
 
 
 ## Effect of this option on the pattern

--- a/markdown/org/docs/patterns/simone/options/contour/en.md
+++ b/markdown/org/docs/patterns/simone/options/contour/en.md
@@ -1,11 +1,8 @@
----
----
 
-<Fixme>
+Controls how sharply the extra room for breasts is removed again below the chest.
 
-Document this option
-
-</Fixme>
+- Increase this option to sharpen the curve below the bust darts
+- Decrease this option to loosen the curve below the bust darts
 
 
 ## Effect of this option on the pattern

--- a/markdown/org/docs/patterns/simone/options/frontdartlength/en.md
+++ b/markdown/org/docs/patterns/simone/options/frontdartlength/en.md
@@ -1,12 +1,8 @@
----
----
 
-<Fixme>
+Controls how close the **front waist darts** approach the bust points.
 
-Document this option
-
-</Fixme>
-
+- Increase this option to lengthen the front waist darts moving them closer to the bust points
+- Decrease this option to shorten the front waist darts moving them further away from the bust points
 
 ## Effect of this option on the pattern
 ![This image shows the effect of this option by superimposing several variants that have a different value for this option](simone_frontdartlength_sample.svg "Effect of this option on the pattern")

--- a/markdown/org/docs/patterns/simone/options/frontdarts/en.md
+++ b/markdown/org/docs/patterns/simone/options/frontdarts/en.md
@@ -1,11 +1,5 @@
----
----
 
-<Fixme>
-
-Document this option
-
-</Fixme>
+Whether to include front waist darts or not.
 
 
 ## Effect of this option on the pattern

--- a/markdown/org/docs/patterns/simone/options/yokeheight/en.md
+++ b/markdown/org/docs/patterns/simone/options/yokeheight/en.md
@@ -1,11 +1,8 @@
----
----
 
-<Fixme>
+Controls the height of the yoke seam.
 
-Document this option
-
-</Fixme>
+- Increase this option to lower the height and lengthen the yoke
+- Decrease this option to raise the height and shorten the yoke
 
 
 ## Effect of this option on the pattern


### PR DESCRIPTION
Added
- Simon(e) Yoke Height
- Simone Front Darts
- Simone Contour
- Simone Bust dart length
- Simone Bust dart angle
- Simone front dart Length

Upon re-looking through the options to compile the list of incorrect pattern options I stumbled upon these ones missing and was like oh crap they weren't on the list so quickly added to the list and made.