### PR TITLE
Enable conditional display of options (Use in Simon)

### DIFF
--- a/packages/components/src/DraftConfigurator/OptionGroup/index.js
+++ b/packages/components/src/DraftConfigurator/OptionGroup/index.js
@@ -66,13 +66,19 @@ const OptionGroup = (props) => {
 
   return (
     <>
-      {props.options.map((name) => {
+      {props.options.map(nameOrGroup => {
         let output = []
-        if (typeof name === 'object') {
+        if (typeof nameOrGroup === 'object') {
+          const group = nameOrGroup
           // Subgroup
-          for (let subGroup of Object.keys(name)) {
+          for (const subGroup in group) {
             let children = []
-            for (let option of name[subGroup]) children.push(renderOption(option, true))
+            for (const name of group[subGroup]) {
+              const option = props.config.options[name]
+              if (!option.hide(props.pattern.settings.options)) {
+                children.push(renderOption(name, true))
+              }
+            }
             output.push(
               <OptionSubGroup
                 title={<FormattedMessage id={'optiongroups.' + subGroup} />}
@@ -81,7 +87,13 @@ const OptionGroup = (props) => {
               />
             )
           }
-        } else output.push(renderOption(name))
+        } else {
+          const name = nameOrGroup
+          const option = props.config.options[name]
+          if (!option.hide(props.pattern.settings.options)) {
+            output.push(renderOption(name))
+          }
+        }
 
         return output
       })}

--- a/packages/components/src/Workbench/DraftConfig/index.js
+++ b/packages/components/src/Workbench/DraftConfig/index.js
@@ -122,6 +122,7 @@ const DraftPattern = (props) => {
         updatePatternData={props.updateGist}
         raiseEvent={props.raiseEvent}
         freesewing={props.freesewing}
+        pattern={props.pattern}
         units={props.units || 'metric'}
       />
       <li className='zoombox'>

--- a/packages/simon/config/index.js
+++ b/packages/simon/config/index.js
@@ -167,10 +167,12 @@ export default {
     buttonPlacketStyle: {
       list: ['classic', 'seamless'],
       dflt: 'classic',
+      hide: options => options.seperateButtonPlacket
     },
     buttonholePlacketStyle: {
       list: ['classic', 'seamless'],
       dflt: 'seamless',
+      hide: options => options.seperateButtonholePlacket
     },
     cuffStyle: {
       list: [

--- a/packages/simon/src/buttonholeplacket.js
+++ b/packages/simon/src/buttonholeplacket.js
@@ -17,7 +17,7 @@ export default (part) => {
     store,
   } = part.shorthand()
 
-  if (!options.seperateButtonholePlacket || options.buttonholePlacketStyle !== 'classic') {
+  if (!options.seperateButtonholePlacket) {
     part.paths = {}
     part.snippets = {}
     part.points = {}

--- a/packages/simon/src/buttonplacket.js
+++ b/packages/simon/src/buttonplacket.js
@@ -17,7 +17,7 @@ export default (part) => {
     store,
   } = part.shorthand()
 
-  if (!options.seperateButtonPlacket || options.buttonPlacketStyle !== 'classic') {
+  if (!options.seperateButtonPlacket) {
     part.paths = {}
     part.snippets = {}
     part.points = {}

--- a/packages/simon/src/frontleft.js
+++ b/packages/simon/src/frontleft.js
@@ -15,9 +15,13 @@ export default (part) => {
     })
   }
 
-  return options.buttonholePlacketStyle === 'seamless'
-    ? frontLeftSeamless(part)
-    : options.seperateButtonholePlacket
-    ? frontLeftClassicSeperate(part)
-    : frontLeftClassicCuton(part)
+  if (options.seperateButtonholePlacket) {
+    return frontLeftClassicSeperate(part)
+  } else if (options.buttonholePlacketStyle === 'seamless') {
+    return frontLeftSeamless(part)
+  } else if (options.buttonholePlacketStyle === 'classic') {
+    return frontLeftClassicCuton(part)
+  } else {
+    throw `Unexpected buttonholePlacketStyle: ${options.buttonholePlacketStyle}`
+  }
 }

--- a/packages/simon/src/frontright.js
+++ b/packages/simon/src/frontright.js
@@ -23,9 +23,13 @@ export default (part) => {
     }
   }
 
-  return options.buttonPlacketStyle === 'seamless'
-    ? frontRightSeamless(part)
-    : options.seperateButtonPlacket
-    ? frontRightClassicSeperate(part)
-    : frontRightClassicCuton(part)
+  if (options.seperateButtonPlacket) {
+    return frontRightClassicSeperate(part)
+  } else if (options.buttonPlacketStyle === 'seamless') {
+    return frontRightSeamless(part)
+  } else if (options.buttonPlacketStyle === 'classic') {
+    return frontRightClassicCuton(part)
+  } else {
+    throw `Unexpected buttonPlacketStyle: ${options.buttonPlacketStyle}`
+  }
 }


### PR DESCRIPTION
See #1723

![conditional-options-simon](https://user-images.githubusercontent.com/9117775/152301876-43b76ef5-6470-46f5-b691-59ce5edc224c.gif)

- Update Simon to always honor `seperateButtonPlacket` and `seperateButtonholePlacket`.
- Update `DraftConfig` to pass the pattern to `DraftConfigurator` so that it can be used when configuring options to display.
- Update `OptionGroup` to hide options based on configuration.
- Update Simon to hide `buttonPlacketStyle` and `buttonholePlacketStyle` based on `seperateButtonPlacket` and `seperateButtonholePlacket`.

If this approach ends up being reasonable, I think the next steps will be to:
- Add tests (I couldn't figure out where to do this).
- Maybe add this functionality to other patterns which would benefit.
- Update the options docs to describe this functionality.