### PR TITLE
Enable tests in i18n. Add missing testci to core.

### DIFF
--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -38,11 +38,14 @@ components:
 core:
   testonly: 'BABEL_ENV=production mocha tests/*.test.js'
   test: 'BABEL_ENV=production nyc -x node_modules -x tests/fixtures -x bin-pack mocha tests/*.test.js'
+  testci: 'BABEL_ENV=production nyc -x node_modules -x tests/fixtures -x bin-pack mocha tests/*.test.js'
   report: 'BABEL_ENV=production nyc report --reporter=html'
   coverage: 'BABEL_ENV=production nyc npm test && nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'
 i18n:
   # react-scripts doesn't handle .mjs files correctly
   modulebuild: '!'
+  test: 'BABEL_ENV=production ../../node_modules/.bin/_mocha tests/*.test.js --require @babel/register'
+  testci: 'BABEL_ENV=production ../../node_modules/.bin/_mocha tests/*.test.js --require @babel/register'
 pattern-info:
   cibuild_step1: '!'
   cibuild_step2: 'node src/prebuild.js && rollup -c'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "symlink": "mkdir -p ./node_modules/@freesewing && cd ./node_modules/@freesewing && ln -s -f ../../../* . && cd -",
     "start": "rollup -c -w",
     "testonly": "BABEL_ENV=production mocha tests/*.test.js",
+    "testci": "BABEL_ENV=production nyc -x node_modules -x tests/fixtures -x bin-pack mocha tests/*.test.js",
     "report": "BABEL_ENV=production nyc report --reporter=html",
     "coverage": "BABEL_ENV=production nyc npm test && nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov"
   },

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -26,11 +26,12 @@
     "clean": "rimraf dist",
     "build": "rollup -c",
     "cibuild_step1": "rollup -c",
-    "test": "echo \"i18n: No tests configured. Perhaps you'd like to do this?\" && exit 0",
+    "test": "BABEL_ENV=production ../../node_modules/.bin/_mocha tests/*.test.js --require @babel/register",
     "pubtest": "npm publish --registry http://localhost:6662",
     "pubforce": "npm publish",
     "symlink": "mkdir -p ./node_modules/@freesewing && cd ./node_modules/@freesewing && ln -s -f ../../../* . && cd -",
-    "start": "rollup -c -w"
+    "start": "rollup -c -w",
+    "testci": "BABEL_ENV=production ../../node_modules/.bin/_mocha tests/*.test.js --require @babel/register"
   },
   "peerDependencies": {
     "@freesewing/pattern-info": "^2.20.4"


### PR DESCRIPTION
Randomly noticed there were tests in the i18n dir that couldn't be run. Also core was missing a testci script.