### PR TITLE
Update testall to report all failures. Add All Tests workflow.

### DIFF
--- a/.github/workflows/tests.all.yml
+++ b/.github/workflows/tests.all.yml
@@ -1,0 +1,41 @@
+name: All Tests
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - '**'
+      - '!**/README.md'
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - '**'
+      - '!**/README.md'
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npx lerna bootstrap
+        env:
+          CI: true
+      - name: Build all
+        run: npm run buildall
+      - name: Run all tests
+        run: npm run testall
+

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ scripts/verdaccio.sh
 
 # Don't ignore the specific Points.dist() docs folder
 !markdown/dev/reference/api/point/dist
+
+.test-failures.log

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "reconfigure": "all-contributors generate && node scripts/reconfigure.js",
     "prerelease": "lerna version --no-git-tag-version --no-push && yarn reconfigure && yarn buildall",
     "buildall": "lerna run cibuild_step1 && lerna run cibuild_step2",
-    "testall": "lerna run testci",
+    "testall": "node scripts/testall.js",
     "release": "lerna exec -- npm publish",
     "postrelease": "git add . && git commit -m ':bookmark: v$npm_package_version' && git tag -a v$npm_package_version -m ':bookmark: FreeSewing v$npm_package_version'",
     "ship": "lerna exec --no-bail -- npm publish",

--- a/scripts/test-failure-collector.js
+++ b/scripts/test-failure-collector.js
@@ -1,0 +1,69 @@
+/*
+ * Used to collect test failures in a file. Use by specifying --file to Mocha.
+ *
+ * See https://mochajs.org/#command-line-usage
+ */
+
+const path = require('path');
+const projectRoot = path.normalize(path.join(__dirname, '..'));
+const outputLog = path.join(projectRoot, '.test-failures.log');
+
+const red = function(string) {
+  return `\x1b[31m${string}\x1b[0m`;
+};
+
+const green = function(string) {
+  return `\x1b[32m${string}\x1b[0m`;
+};
+
+const dim = function(string) {
+  return `\x1b[2m${string}\x1b[0m`;
+};
+
+// Mapping of test file name to array of failing tests.
+const failuresPerFile = {};
+
+afterEach(function () {
+  if (this.currentTest.state === "failed") {
+    failuresPerFile[this.currentTest.file] = failuresPerFile[this.currentTest.file] || [];
+    failuresPerFile[this.currentTest.file].push(this.currentTest);
+  }
+});
+
+after(function () {
+  if (Object.keys(failuresPerFile).length === 0) return;
+
+  const fs = require('fs')
+  const logger = fs.createWriteStream(outputLog, { flags: 'a' });
+  const writeLine = (line) => logger.write(`${line}\n`);
+
+  for (let file in failuresPerFile) {
+    const failures = failuresPerFile[file];
+
+    // Remove project root from file path to keep log lines shorter.
+    if (file.startsWith(projectRoot)) {
+      file = file.substr(projectRoot.length + 1, file.length - projectRoot.length - 1)
+    }
+
+    // Print each failure.
+    failures.forEach(function (failure, i) {
+      const stack = failure.err.stack.split('\n');
+      writeLine(`${file}:  ${i + 1}\) ${failure.title}:`);
+      writeLine(`${file}:`);
+      writeLine(`${file}:      ${red(stack[0].trim())}`);
+      writeLine(`${file}:      ${green('+ expected')} ${red('- actual')}`);
+      writeLine(`${file}:`);
+      writeLine(`${file}:      ${red("-" + failure.err.actual)}`);
+      writeLine(`${file}:      ${green("+" + failure.err.expected)}`);
+      writeLine(`${file}:`);
+      stack.slice(1).forEach(function (stackLine) {
+        writeLine(`${file}:      ${dim(stackLine.trim())}`);
+      });
+      if (i < failures.length - 1) {
+        writeLine(`${file}:`);
+      }
+    });
+  }
+
+  logger.end();
+});

--- a/scripts/testall.js
+++ b/scripts/testall.js
@@ -1,0 +1,25 @@
+const fs = require('fs')
+const path = require('path');
+const spawn = require('child_process').spawn
+
+const projectRoot = path.normalize(path.join(__dirname, '..'));
+const outputLog = path.join(projectRoot, '.test-failures.log');
+const collectorScript = path.join(projectRoot, 'scripts', 'test-failure-collector.js');
+
+// Start with a fresh output log on each run.
+if (fs.existsSync(outputLog)) {
+  fs.unlinkSync(outputLog);
+}
+
+// Run all tests, specifying the collector script.
+spawn('lerna', ['run', '--no-bail', 'testci', '--', '--file', `${collectorScript}`], { stdio: 'inherit' })
+  .on('exit', function(code) {
+    // If a failure occurred, the log file will have been created. Print it.
+    if (fs.existsSync(outputLog)) {
+      console.error(fs.readFileSync(outputLog, 'utf8').trim());
+    }
+
+    // Propagate the exit code.
+    process.exit(code);
+  });
+


### PR DESCRIPTION
I recently made a cross-cutting change and needed to run all tests in order to verify the change was safe. While doing this I noticed that the `testall` script exits after one or more tests fail in a single package. This means you must fix issues one package at a time, then rerun all tests to find the next failure. I tried using the `--no-bail` flag to avoid this problem, but that does not make it easy to find which tests failed as failures are buried in thousands of lines of logs.

In this change I am suggesting we do the following:
 - Use the `--no-bail` option by default (all tests only take 50 seconds to run).
 - Introduce a way to aggregate failures from all packages (writing to a file).
 - Print a summary of failures after all tests complete.
 - Introduce an All Tests workflow which essentially runs kickstart and testall.

The output from `yarn testall` would now look like the following when one or more tests fails:
![image](https://user-images.githubusercontent.com/9117775/152531999-c1fd64b6-5422-4dfa-8d89-0a511348dc00.png)

Example success build: https://github.com/freesewing/freesewing/runs/5082640538
![image](https://user-images.githubusercontent.com/9117775/152675248-1ca5609b-4658-4bb0-a510-d4a612e85be5.png)

Example failure build: https://github.com/freesewing/freesewing/runs/5082693681
![image](https://user-images.githubusercontent.com/9117775/152675286-489346d1-58ae-4cc1-bf72-c78cb0da70ad.png)
