### PR TITLE
feat(core): Add a default hide() method to options

### DIFF
--- a/packages/core/src/design.js
+++ b/packages/core/src/design.js
@@ -1,6 +1,20 @@
 import Pattern from './pattern'
 
+// Default hide method for options
+const hide = () => false
+
 export default function Design(config, plugins = false, conditionalPlugins = false) {
+
+  // Add default hide() method to config.options
+  for (const option in config.options) {
+    if (typeof config.options[option] === 'object') {
+      config.options[option] = {
+        hide,
+        ...config.options[option]
+      }
+    }
+  }
+
   const pattern = function (settings) {
     Pattern.call(this, config)
     // Load plugins

--- a/packages/core/tests/design.test.js
+++ b/packages/core/tests/design.test.js
@@ -155,15 +155,29 @@ it("Design constructor should handle Simon", () => {
     hide: ["base", "frontBase", "front", "backBase", "sleeveBase"]
   });
   let pattern = new design();
-  //expect(pattern.config.draftOrder[0]).to.equal("step3");
-  //expect(pattern.config.draftOrder[1]).to.equal("step4");
-  //expect(pattern.config.draftOrder[2]).to.equal("step5");
-  //expect(pattern.config.draftOrder[3]).to.equal("step6");
-  //expect(pattern.config.draftOrder[4]).to.equal("step7");
-  //expect(pattern.config.draftOrder[5]).to.equal("step8");
-  //expect(pattern.config.draftOrder[6]).to.equal("step9");
-  //expect(pattern.config.draftOrder[7]).to.equal("step10");
-  //expect(pattern.config.draftOrder[8]).to.equal("step11");
-  //expect(pattern.config.draftOrder[9]).to.equal("step1");
-  //expect(pattern.config.draftOrder[10]).to.equal("step2");
 });
+
+it("Design constructor should add default hide() method to options", () => {
+  const design = new freesewing.Design({
+    foo: "bar",
+    options: {
+      constant: 2,
+      percentage: { pct: 30, min: 0, max: 100 },
+      degree: { deg: 5, min: 0, max: 10 },
+      withHide: {
+        dflt: 'foo',
+        list: ['foo', 'bar'],
+        hide: ({ options }) => (options.degree < 6)
+      }
+    }
+  })
+
+  const pattern = new design();
+  expect(typeof pattern.config.options.constant === 'number').to.be.true
+  expect(typeof pattern.config.options.percentage === 'object').to.be.true
+  expect(typeof pattern.config.options.degree === 'object').to.be.true
+  expect(typeof pattern.config.options.withHide === 'object').to.be.true
+  expect(pattern.config.options.percentage.hide()).to.be.false
+  expect(pattern.config.options.degree.hide()).to.be.false
+  expect(pattern.config.options.withHide.hide(pattern.settings)).to.be.true
+})


### PR DESCRIPTION
This adds a default `hide()` method to all pattern options
(that are not a constant) which always returns false.

The idea is that this can/will be used for conditional display
of options based on the user's input.

See Issue #1723 and PR #1798 for background info