### PR TITLE
Add optional measurements to Workbench for pattern testing

### DIFF
--- a/packages/components/src/Workbench/Measurements/index.js
+++ b/packages/components/src/Workbench/Measurements/index.js
@@ -148,6 +148,16 @@ const Measurements = (props) => {
             updateValue={props.updateMeasurement}
           />
         ))}
+        {props.optional.map((m) => (
+          <FormFieldMeasurement
+            key={m}
+            name={m}
+            units={props.units}
+            value={getValue(m)}
+            label={'measurements.' + m}
+            updateValue={props.updateMeasurement}
+          />
+        ))}
       </div>
     </div>
   )

--- a/packages/components/src/Workbench/index.js
+++ b/packages/components/src/Workbench/index.js
@@ -283,6 +283,7 @@ const Workbench = ({
         <Measurements
           measurements={measurements}
           required={config.measurements}
+          optional={config.optionalMeasurements}
           units={units}
           updateMeasurement={updateMeasurement}
           preloadMeasurements={preloadMeasurements}


### PR DESCRIPTION
Untested! Because I did not know how to link the pattern example folder to the monorepo.

Add form fields for optional measurements to Workbench for pattern testing.