### PR TITLE
Moved cutting list to top

### DIFF
--- a/markdown/org/docs/patterns/lunetius/cutting/en.md
+++ b/markdown/org/docs/patterns/lunetius/cutting/en.md
@@ -2,10 +2,10 @@
 title: Cutting 
 ---
 
-The way to cut Lunetius is going to depend on what fabric you have chosen to use. If you have enough fabric width you can cut it _on the fold_. If you don’t, you can cut two halves and later sew them together. To not have to later finish the centre back edge you can cut with the centre back edge on the selvage.
-
 - Cut **1 lacerna** part on the fold
 - or Cut **2 lacerna** parts
+
+The way to cut Lunetius is going to depend on what fabric you have chosen to use. If you have enough fabric width you can cut it _on the fold_. If you don’t, you can cut two halves and later sew them together. To not have to later finish the centre back edge you can cut with the centre back edge on the selvage.
 
 A lot of garments were woven to shape in the Roman era, so this is one aspect where you don’t need to worry about historical accuracy at all, unless you would like to weave your Lunetius to shape.
 


### PR DESCRIPTION
Moved the cutting list to the top of the page, as that reads easier than having it interspersed in the text. 