### PR TITLE
#1843 Use units in css scale var.

### DIFF
--- a/packages/components/src/Workbench/index.js
+++ b/packages/components/src/Workbench/index.js
@@ -320,7 +320,7 @@ const Workbench = ({
   return (
     <MuiThemeProvider theme={createMuiTheme(themes[theme])}>
       <style>
-        {`:root { --freesewing-pattern-scale: ${gist.settings.scale || 1}; }`}
+        {`:root { --freesewing-pattern-scale: ${gist.settings.scale || 1}px; }`}
         {sass}
       </style>
       <div


### PR DESCRIPTION
Attempting to address https://github.com/freesewing/freesewing/issues/1843.

See https://stackoverflow.com/questions/65849051/calc-not-working-with-stroke-dashoffset-in-safari-and-firefox

This might not get us all the way but it at least resulting in paths being rendered in my local Simon. 