### PR TITLE
Initial test of markdown linting (and auto-fixing)

### DIFF
--- a/markdown/.remarkrc.yaml
+++ b/markdown/.remarkrc.yaml
@@ -1,6 +1,7 @@
 settings:
   bullet: "-"
 plugins:
+  - remark-frontmatter
   - remark-preset-lint-consistent
   - remark-preset-lint-recommended
   - - remark-lint-list-item-indent

--- a/markdown/dev/guides/best-practices/go-counter-clockwise/en.md
+++ b/markdown/dev/guides/best-practices/go-counter-clockwise/en.md
@@ -13,12 +13,11 @@ Obviously, the order in which you add points to your code needs to take a backse
 to the logic of your code. But typically what you're doing is constructing an outline
 of (a part of) a garment.
 
-So pick a point, and make your way around counter-clockwise. 
+So pick a point, and make your way around counter-clockwise.
 
 When naming control points for curves, re-use the name of the point they are attached to
 and add `Cp1` to the control point before and `Cp2` to the control point after the point if
 , once again, you'd follow your path counter-clockwise.
-
 
 For example:
 

--- a/markdown/dev/guides/best-practices/respect-draft-settings/en.md
+++ b/markdown/dev/guides/best-practices/respect-draft-settings/en.md
@@ -19,7 +19,7 @@ Its goal is to determine whether we should draft a *complete* pattern, or merely
 
 The [paperless](/reference/api/settings#paperless) setting is a boolean that is either true or false.
 
-A *paperless* pattern is a pattern that has extra dimensions so users can trace the 
+A *paperless* pattern is a pattern that has extra dimensions so users can trace the
 paper on fabric or paper without having the need to print it.
 
 ## Seam allowance
@@ -62,4 +62,3 @@ export default function(part) {
   return part
 }
 ```
-

--- a/markdown/dev/guides/best-practices/reuse-measurements/en.md
+++ b/markdown/dev/guides/best-practices/reuse-measurements/en.md
@@ -9,10 +9,9 @@ certain measurements differently.
 
 <Tip>
 
-######  See our measurements page for standard measurement names
+###### See our measurements page for standard measurement names
 
 The [measurements reference page](/reference/measurements/)
 contains all our standard measurement names.
 
 </Tip>
-

--- a/markdown/dev/guides/best-practices/reuse-options/en.md
+++ b/markdown/dev/guides/best-practices/reuse-options/en.md
@@ -3,10 +3,9 @@ title: Re-use options
 order: 20
 ---
 
-The same arguments for re-using measurements are also (somewhat) true for options. 
+The same arguments for re-using measurements are also (somewhat) true for options.
 
 While your pattern may require some very specific
 options, there's probably a bunch that are similar to other patterns. Re-use those names.
 
 As in, `bicepsEase` exists. So don't go creating an `upperArmEase` option.
-

--- a/markdown/dev/guides/best-practices/use-percentages/en.md
+++ b/markdown/dev/guides/best-practices/use-percentages/en.md
@@ -5,22 +5,22 @@ order: 50
 
 When designing patterns, you should refrain from using absolute values.
 
-That 6cm ease you add might be fine for all scenarios you tested, 
-but then somebody comes around who is twice your size, or who is making clothes for a doll, 
+That 6cm ease you add might be fine for all scenarios you tested,
+but then somebody comes around who is twice your size, or who is making clothes for a doll,
 and things will go off the rails.
 
-Don't be tempted to add absolute values to your patterns, as they don't scale. 
+Don't be tempted to add absolute values to your patterns, as they don't scale.
 Instead, embrace percentages as options.
 
 <Tip>
 
 ##### Use the antperson tests
 
-To check how well your pattern scales, you can 
+To check how well your pattern scales, you can
 use the *antperson* test by sampling the pattern for 2 models:
 
- - A model with measurements of avarage person (the person)
- - A model with measurements 1/10th of an average person (the ant)
+-   A model with measurements of avarage person (the person)
+-   A model with measurements 1/10th of an average person (the ant)
 
 A well-designed pattern will scale a factor 10 down and hold its shape.
 If your pattern makes assumptions about size, this test will show that.
@@ -29,4 +29,3 @@ FreeSewing's development environment provides these tests out of the box,
 so you can see their results at the click of a button.
 
 </Tip>
-

--- a/markdown/dev/guides/best-practices/use-translation-keys/en.md
+++ b/markdown/dev/guides/best-practices/use-translation-keys/en.md
@@ -5,14 +5,14 @@ order: 60
 
 Don't insert literal text in your patterns. Instead, insert a key that can then be translated.
 
-For example, if you want to put *Finish with bias tape* on your pattern, don't be 
+For example, if you want to put *Finish with bias tape* on your pattern, don't be
 tempted to do this:
 
 ```js
 path.seam.attr("data-text", "Finish with bias tape");
 ```
 
-That (English) string is now hard-coded in your pattern. As freesewing supports 
+That (English) string is now hard-coded in your pattern. As freesewing supports
 translation out of the box, it would be a real shame not to make use of it.
 
 Instead, insert a key to identify the string:

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "jsonfile": "^6.1.0",
     "postcss": "^8.4.5",
     "remark-cli": "^10.0.1",
+    "remark-frontmatter": "^4.0.1",
     "remark-lint-emphasis-marker": "^3.1.1",
     "remark-lint-list-item-indent": "^3.1.1",
     "remark-preset-lint-consistent": "^5.1.1",


### PR DESCRIPTION
So after the initial setup of markdown linting (see #1867) I did some tests, and we need the `remark-frontmatter` plugin since frontmatter is not part of standard markdown, so without this plugin, it will causes all sort of false positives.

After that, I did a small test (small because I limited it to markdown under `markdown/dev/guides/best-practices`) to auto-fix the markdown.
That commit is in this PR (along with the installed plugin) and I think it looks good.
But before running this over more markdown content, I'd like a second opinion :)

Thanks to @stsydow for the initial legwork for setting this up and @nicholasdower for creating an issue for it.