### PR TITLE
Add smoke test for create-freesewing-pattern.

### DIFF
--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -22,6 +22,8 @@ create-freesewing-pattern:
   modulebuild: '!'
   cibuild_step1: '!'
   build: '!'
+  test: 'BABEL_ENV=production ../../node_modules/.bin/_mocha tests/*.test.mjs'
+  testci: 'BABEL_ENV=production ../../node_modules/.bin/_mocha tests/*.test.mjs'
 css-theme:
   cibuild_step1: 'npx node-sass --output-style compressed src/theme.scss dist/theme.css'
   build: 'npx node-sass --output-style compressed src/theme.scss dist/theme.css'

--- a/packages/create-freesewing-pattern/package.json
+++ b/packages/create-freesewing-pattern/package.json
@@ -21,11 +21,12 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "echo \"create-freesewing-pattern: No tests configured. Perhaps you'd like to do this?\" && exit 0",
+    "test": "BABEL_ENV=production ../../node_modules/.bin/_mocha tests/*.test.mjs",
     "pubtest": "npm publish --registry http://localhost:6662",
     "pubforce": "npm publish",
     "symlink": "mkdir -p ./node_modules/@freesewing && cd ./node_modules/@freesewing && ln -s -f ../../../* . && cd -",
-    "start": "rollup -c -w"
+    "start": "rollup -c -w",
+    "testci": "BABEL_ENV=production ../../node_modules/.bin/_mocha tests/*.test.mjs"
   },
   "peerDependencies": {},
   "dependencies": {

--- a/packages/create-freesewing-pattern/tests/cli.test.mjs
+++ b/packages/create-freesewing-pattern/tests/cli.test.mjs
@@ -1,0 +1,17 @@
+import chai from 'chai'
+import { spawnSync } from 'child_process'
+
+describe('CLI help', () => {
+  it("Should run successfully", () => {
+    const result = spawnSync('node', ['./lib/cli.js', '-h'])
+    if (result.status != 0) {
+      console.log('Command failed: node ./lib/cli.js -h');
+      console.log('status: ' + result.status);
+      console.log('stdout:')
+      console.log(result.stdout.toString('utf8'));
+      console.log('stderr:')
+      console.log(result.stderr.toString('utf8'));
+      chai.assert.fail();
+    }
+  })
+})


### PR DESCRIPTION
#1891 breaks the `create-freesewing-pattern` package but All Tests is green. Adding a test which simply runs `node ./lib/cli.js -h` and asserts that the command runs successfully.