### PR TITLE
fix(workbench): Type-check optionalMeasurements. Closes #1918

### DIFF
--- a/packages/components/src/Workbench/Measurements/index.js
+++ b/packages/components/src/Workbench/Measurements/index.js
@@ -148,7 +148,7 @@ const Measurements = (props) => {
             updateValue={props.updateMeasurement}
           />
         ))}
-        {props.optional.map((m) => (
+        {props.optional && props.optional.map((m) => (
           <FormFieldMeasurement
             key={m}
             name={m}


### PR DESCRIPTION
This fixes a regression bug introduced in 283fa4f884dce01b007f11a84718da870ed6feb8 and in doing so will close #1918.

The issue is that we just copied the code block from the required measurements.
But those are always set, whereas `optionalMeasurements` is not.

We could do the whole of making sure they are always set, but I went for the simple solution by just adding a check here.
My reasons for doing so is that once the new website is up, the entire `components` package will get deprecated and dropped :fire: 