### PR TITLE
chore: Tweaks to remark settings and linter run

### DIFF
--- a/markdown/.remarkignore
+++ b/markdown/.remarkignore
@@ -1,0 +1,5 @@
+# Don't bother with auto-generated files
+de.md
+nl.md
+es.md
+fr.md

--- a/markdown/.remarkrc.yaml
+++ b/markdown/.remarkrc.yaml
@@ -1,5 +1,7 @@
 settings:
   bullet: "-"
+  emphasis: "_"
+  strong: "*"
 plugins:
   - remark-frontmatter
   - remark-preset-lint-consistent

--- a/markdown/.remarkrc.yaml
+++ b/markdown/.remarkrc.yaml
@@ -2,6 +2,7 @@ settings:
   bullet: "-"
   emphasis: "_"
   strong: "*"
+  listItemIndent: one
 plugins:
   - remark-frontmatter
   - remark-preset-lint-consistent

--- a/markdown/dev/guides/best-practices/respect-draft-settings/en.md
+++ b/markdown/dev/guides/best-practices/respect-draft-settings/en.md
@@ -13,13 +13,13 @@ that you should take into account while developing your pattern. They are:
 ## Complete
 
 The [complete](/reference/api/settings#complete) setting is a boolean that is either true or false.
-Its goal is to determine whether we should draft a *complete* pattern, or merely the outline.
+Its goal is to determine whether we should draft a _complete_ pattern, or merely the outline.
 
 ## Paperless
 
 The [paperless](/reference/api/settings#paperless) setting is a boolean that is either true or false.
 
-A *paperless* pattern is a pattern that has extra dimensions so users can trace the
+A _paperless_ pattern is a pattern that has extra dimensions so users can trace the
 paper on fabric or paper without having the need to print it.
 
 ## Seam allowance

--- a/markdown/dev/guides/best-practices/use-percentages/en.md
+++ b/markdown/dev/guides/best-practices/use-percentages/en.md
@@ -17,7 +17,7 @@ Instead, embrace percentages as options.
 ##### Use the antperson tests
 
 To check how well your pattern scales, you can
-use the *antperson* test by sampling the pattern for 2 models:
+use the _antperson_ test by sampling the pattern for 2 models:
 
 -   A model with measurements of avarage person (the person)
 -   A model with measurements 1/10th of an average person (the ant)

--- a/markdown/dev/guides/best-practices/use-percentages/en.md
+++ b/markdown/dev/guides/best-practices/use-percentages/en.md
@@ -19,8 +19,8 @@ Instead, embrace percentages as options.
 To check how well your pattern scales, you can
 use the _antperson_ test by sampling the pattern for 2 models:
 
--   A model with measurements of avarage person (the person)
--   A model with measurements 1/10th of an average person (the ant)
+- A model with measurements of avarage person (the person)
+- A model with measurements 1/10th of an average person (the ant)
 
 A well-designed pattern will scale a factor 10 down and hold its shape.
 If your pattern makes assumptions about size, this test will show that.

--- a/markdown/dev/guides/best-practices/use-translation-keys/en.md
+++ b/markdown/dev/guides/best-practices/use-translation-keys/en.md
@@ -5,7 +5,7 @@ order: 60
 
 Don't insert literal text in your patterns. Instead, insert a key that can then be translated.
 
-For example, if you want to put *Finish with bias tape* on your pattern, don't be
+For example, if you want to put _Finish with bias tape_ on your pattern, don't be
 tempted to do this:
 
 ```js

--- a/markdown/dev/guides/code-of-conduct/enforcement/en.md
+++ b/markdown/dev/guides/code-of-conduct/enforcement/en.md
@@ -6,8 +6,8 @@ order: 50
 Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported to the community leaders responsible for enforcement:
 
--   Joost De Cock (joost@joost.at)
--   Sorcha Ní Dhubhghaill (nidhubhs@gmail.com)
+- Joost De Cock (joost@joost.at)
+- Sorcha Ní Dhubhghaill (nidhubhs@gmail.com)
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/markdown/dev/guides/code-of-conduct/our-standards/en.md
+++ b/markdown/dev/guides/code-of-conduct/our-standards/en.md
@@ -5,16 +5,16 @@ order: 20
 
 Examples of behavior that contributes to a positive environment for our community include:
 
--   Demonstrating empathy and kindness toward other people
--   Being respectful of differing opinions, viewpoints, and experiences
--   Giving and gracefully accepting constructive feedback
--   Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
--   Focusing on what is best not just for us as individuals, but for the overall community
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
--   The use of sexualized language or imagery, and sexual attention or advances of any kind
--   Trolling, insulting or derogatory comments, and personal or political attacks
--   Public or private harassment
--   Publishing others’ private information, such as a physical or email address, without their explicit permission
--   Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting

--- a/markdown/dev/guides/docs/en.md
+++ b/markdown/dev/guides/docs/en.md
@@ -10,10 +10,10 @@ documentation can help you find your feet, and figure out what goes where.
 
 Our documentation is divided into four different types:
 
--   [**Tutorials**](/tutorials) are lessons that lead you through a series of steps to complete a project.
--   [**Guides**](/guides) tell a story to further your understanding of a specific topic.
--   [**Howtos**](/howtos) give you concrete steps to solve a common problem or challenge.
--   [**Reference**](/reference) holds technical descriptions of the underlying technology and how to make use of it.
+- [**Tutorials**](/tutorials) are lessons that lead you through a series of steps to complete a project.
+- [**Guides**](/guides) tell a story to further your understanding of a specific topic.
+- [**Howtos**](/howtos) give you concrete steps to solve a common problem or challenge.
+- [**Reference**](/reference) holds technical descriptions of the underlying technology and how to make use of it.
 
 Each time you write documentation, you have to ask yourself: Is it a tutorial? Is it a Guide?
 Is it a Howto? Or is it Reference documentation.
@@ -24,11 +24,11 @@ where your documentation should go based on what it's trying to accomplish:
 ![A graphic showing a visual representation of our documentation
 structure](docs.png "A visual representation of how our documentation is structured")
 
--   Write a **Tutorial** is your aim is to help people learn the platform
--   Write a **Guide** if your aim is to further people's understanding of a topic by going a bit deeper
--   Write a **Howto** if your ain is to help people accomplish a task
--   Write **Reference** documentation to detail how things work under the hood
--   Refer people to **Discord or Github** for things that are not (yet) covered in our documentation
+- Write a **Tutorial** is your aim is to help people learn the platform
+- Write a **Guide** if your aim is to further people's understanding of a topic by going a bit deeper
+- Write a **Howto** if your ain is to help people accomplish a task
+- Write **Reference** documentation to detail how things work under the hood
+- Refer people to **Discord or Github** for things that are not (yet) covered in our documentation
 
 <Note>
 

--- a/markdown/dev/guides/en.md
+++ b/markdown/dev/guides/en.md
@@ -13,7 +13,7 @@ You can find a list of all FreeSewing guides below:
 
 Guides tell a story to further your understanding of a specific topic.
 
-Guides and howtos are on a spectrum with howtos being terse *do-this-then-that* recipes, whereas
+Guides and howtos are on a spectrum with howtos being terse _do-this-then-that_ recipes, whereas
 guides take more time to explain in-depth what is being done and why.
 
 For more details, refer to [How we structure our documentation](/guides/docs).

--- a/markdown/dev/guides/markdown/code-blocks/en.md
+++ b/markdown/dev/guides/markdown/code-blocks/en.md
@@ -38,11 +38,11 @@ let me = 'you'
 
 The following language codes are supported:
 
--   `js` for Javascript code
--   `markdown` for Markdown
--   `html` for HTML
--   `svg` for SVG
--   `bash` for Bash or shell scripts
--   `mdx` for MDX
--   `jsx` for JSX
--   `json` for JSON
+- `js` for Javascript code
+- `markdown` for Markdown
+- `html` for HTML
+- `svg` for SVG
+- `bash` for Bash or shell scripts
+- `mdx` for MDX
+- `jsx` for JSX
+- `json` for JSON

--- a/markdown/dev/guides/markdown/custom-components/en.md
+++ b/markdown/dev/guides/markdown/custom-components/en.md
@@ -4,7 +4,7 @@ order: 90
 ---
 
 The way we render markdown on our websites is through the use of [MDX](https://mdxjs.com/).\
-This allows us to extend Markdown with our own so-called *custom components*.
+This allows us to extend Markdown with our own so-called _custom components_.
 
 Such custom components allow us to put things in Markdown content that would
 typically require a lot more complexity.

--- a/markdown/dev/guides/markdown/frequent-mistakes/en.md
+++ b/markdown/dev/guides/markdown/frequent-mistakes/en.md
@@ -7,7 +7,7 @@ Some things to keep in mind when working in Markdown are:
 
 ## Use remark-jargon for glossary terms
 
-There is no need to add a *glossary* section to documentation.
+There is no need to add a _glossary_ section to documentation.
 We use a plugin called [remark-jargon][rj] to explain terms.
 Information can be found at the link.
 

--- a/markdown/dev/guides/markdown/italic-and-bold/en.md
+++ b/markdown/dev/guides/markdown/italic-and-bold/en.md
@@ -8,10 +8,10 @@ You can make text *italic* or **bold**
 by wrapping it in 1 or 2 asterisk respectively.
 ```
 
-You can make text *italic* or **bold** by wrapping it in 1 or 2 asterisk respectively:
+You can make text _italic_ or **bold** by wrapping it in 1 or 2 asterisk respectively:
 
 ```md
 Alternatively, you can also use underscores to mark _italic_ or __bold__.
 ```
 
-Alternatively, you can also use underscores to mark *italic* or **bold**.
+Alternatively, you can also use underscores to mark _italic_ or **bold**.

--- a/markdown/dev/guides/markdown/lists/en.md
+++ b/markdown/dev/guides/markdown/lists/en.md
@@ -12,10 +12,10 @@ To make a list, just do as you would in plain text:
   - item
 ```
 
--   a bullet
--   list
-    -   a sublist
-    -   item
+- a bullet
+- list
+  - a sublist
+  - item
 
 If you want an numbered list, just write numbers.
 They don't even have to be the correct numbers:
@@ -27,6 +27,6 @@ They don't even have to be the correct numbers:
 2. Item 3
 ```
 
-1.  Item 1
-2.  Item 2
-3.  Item 3
+1. Item 1
+2. Item 2
+3. Item 3

--- a/markdown/dev/guides/patterns/config/en.md
+++ b/markdown/dev/guides/patterns/config/en.md
@@ -12,9 +12,9 @@ The pattern configuration holds important information about the pattern
 A pattern's [configuration](/reference/config/) is created by the pattern designer
 and details a number of important things about the pattern, like:
 
--   The **measurements** that are required to draft the pattern
--   The different **parts** in the pattern and how they depend on each other
--   The different **options** that are available to tweak the pattern
+- The **measurements** that are required to draft the pattern
+- The different **parts** in the pattern and how they depend on each other
+- The different **options** that are available to tweak the pattern
 
 The configuration is part of the pattern's code. It is created by the designer and
 it is the same for everybody using the pattern.

--- a/markdown/dev/guides/patterns/en.md
+++ b/markdown/dev/guides/patterns/en.md
@@ -19,7 +19,7 @@ If we look at our image, it can be divided into three areas:
 
 -   The left area with the **settings**  box
 -   The middle area with the **Pattern** box and everything in it
--   The right area with the **draft** box and the *SVG* and *React* logos
+-   The right area with the **draft** box and the _SVG_ and _React_ logos
 
 Let's take a closer look at everything that is contained within our central **Pattern** box:
 
@@ -27,7 +27,7 @@ Let's take a closer look at everything that is contained within our central **Pa
 
 <Note>
 
-The left and right parts are all about how to integrate FreeSewing in your *frontend*.
+The left and right parts are all about how to integrate FreeSewing in your _frontend_.
 In other words, how you'll plug it into your website, or online store, or a mobile
 application.
 

--- a/markdown/dev/guides/patterns/en.md
+++ b/markdown/dev/guides/patterns/en.md
@@ -17,9 +17,9 @@ A schematic overview of FreeSewing
 
 If we look at our image, it can be divided into three areas:
 
--   The left area with the **settings**  box
--   The middle area with the **Pattern** box and everything in it
--   The right area with the **draft** box and the _SVG_ and _React_ logos
+- The left area with the **settings**  box
+- The middle area with the **Pattern** box and everything in it
+- The right area with the **draft** box and the _SVG_ and _React_ logos
 
 Let's take a closer look at everything that is contained within our central **Pattern** box:
 

--- a/markdown/dev/guides/patterns/paths/en.md
+++ b/markdown/dev/guides/patterns/paths/en.md
@@ -12,10 +12,10 @@ Paths are the lines and curves that make up your pattern.
 They are made up of a set of drawing operations that together make up the path.
 FreeSewing supports the following types of drawing operations:
 
--   The **move** operation moves our virtual pen but does not draw anything.
--   The **line** operation draws a straight line
--   The **curve** operation draws a [Bézier curve](/guides/overview/about/beziercurves/)
--   The **close** operation closes the path
+- The **move** operation moves our virtual pen but does not draw anything.
+- The **line** operation draws a straight line
+- The **curve** operation draws a [Bézier curve](/guides/overview/about/beziercurves/)
+- The **close** operation closes the path
 
 To crucial thing to keep in mind is that, with the exception of the **move** operation,
 all drawing operations start from wherever you are currently on your virtual sheet of paper.

--- a/markdown/dev/guides/patterns/pattern/en.md
+++ b/markdown/dev/guides/patterns/pattern/en.md
@@ -11,7 +11,7 @@ Last but not least, we've arrived at the level of the pattern itself.
 The pattern is a container that holds all your parts, along with the configuration
 and the store.
 
-In reality, your pattern will be a *constructor* that takes the user's settings as
+In reality, your pattern will be a _constructor_ that takes the user's settings as
 input and will return a new instance of your pattern.
 
 That pattern instance will have a `draft()` method which will do the actual work of

--- a/markdown/dev/guides/patterns/points/en.md
+++ b/markdown/dev/guides/patterns/points/en.md
@@ -16,8 +16,8 @@ FreeSewing pattern, and their role is to store coordinates.
 
 Each point must have:
 
--   A **X-coordinate**
--   A **Y-coordinate**
+- A **X-coordinate**
+- A **Y-coordinate**
 
 Together, these coordinates determine the location of the point in the 2-dimensional plane we're drawing on.
 

--- a/markdown/dev/guides/patterns/snippets/en.md
+++ b/markdown/dev/guides/patterns/snippets/en.md
@@ -12,8 +12,8 @@ They are typically used for things like logos or buttons.
 
 Each snippet must have:
 
--   An anchor point that determine where the snippet will be located
--   The name of the snippet to insert
+- An anchor point that determine where the snippet will be located
+- The name of the snippet to insert
 
 Since our example image does not have any snippets in it, here's another example
 of a `button`, `buttonhole`, and `logo` snippet added to a FreeSewing pattern:

--- a/markdown/dev/guides/plugins/conditionally-loading-build-time-plugins/en.md
+++ b/markdown/dev/guides/plugins/conditionally-loading-build-time-plugins/en.md
@@ -52,9 +52,9 @@ const Pattern = new freesewing.Design(
 Our condition method will return `true` only if the following conditions are met:
 
 -   A `settings` object is passed into the method
--   `settings.options` is *truthy*
--   `settings.options.draftForHighBust` is *truthy*
--   `settings.options.measurements.highBust` is *truthy*
+-   `settings.options` is _truthy_
+-   `settings.options.draftForHighBust` is _truthy_
+-   `settings.options.measurements.highBust` is _truthy_
 
 This is a real-world example from our Teagan pattern. A t-shirt pattern that can be
 drafted to the high bust (rather than the full chest circumference) if the user

--- a/markdown/dev/guides/plugins/conditionally-loading-build-time-plugins/en.md
+++ b/markdown/dev/guides/plugins/conditionally-loading-build-time-plugins/en.md
@@ -51,10 +51,10 @@ const Pattern = new freesewing.Design(
 
 Our condition method will return `true` only if the following conditions are met:
 
--   A `settings` object is passed into the method
--   `settings.options` is _truthy_
--   `settings.options.draftForHighBust` is _truthy_
--   `settings.options.measurements.highBust` is _truthy_
+- A `settings` object is passed into the method
+- `settings.options` is _truthy_
+- `settings.options.draftForHighBust` is _truthy_
+- `settings.options.measurements.highBust` is _truthy_
 
 This is a real-world example from our Teagan pattern. A t-shirt pattern that can be
 drafted to the high bust (rather than the full chest circumference) if the user

--- a/markdown/dev/guides/plugins/hooks/en.md
+++ b/markdown/dev/guides/plugins/hooks/en.md
@@ -5,16 +5,16 @@ order: 60
 
 A **hook** is a lifecycle event. The available hooks are:
 
--   [preRender](/reference/hooks/prerender/): Called at the start of [`Pattern.render()`](/reference/api/pattern#render)
--   [postRender](/reference/hooks/postrender/): Called at the end of [`Pattern.render()`](/reference/api/pattern#render)
--   [insertText](/reference/hooks/inserttext/): Called when inserting text
--   [preDraft](/reference/hooks/predraft/): Called at the start of [`Pattern.draft()`](/reference/api/pattern#draft)
--   [postDraft](/reference/hooks/postdraft/): Called at the end of [`Pattern.draft()`](/reference/api/pattern#draft)
--   [preSample](/reference/hooks/presample/): Called at the start of [`Pattern.sample()`](/reference/api/pattern#sample)
--   [postSample](/reference/hooks/postsample/): Called at the end of [`Pattern.sample()`](/reference/api/pattern#sample)
+- [preRender](/reference/hooks/prerender/): Called at the start of [`Pattern.render()`](/reference/api/pattern#render)
+- [postRender](/reference/hooks/postrender/): Called at the end of [`Pattern.render()`](/reference/api/pattern#render)
+- [insertText](/reference/hooks/inserttext/): Called when inserting text
+- [preDraft](/reference/hooks/predraft/): Called at the start of [`Pattern.draft()`](/reference/api/pattern#draft)
+- [postDraft](/reference/hooks/postdraft/): Called at the end of [`Pattern.draft()`](/reference/api/pattern#draft)
+- [preSample](/reference/hooks/presample/): Called at the start of [`Pattern.sample()`](/reference/api/pattern#sample)
+- [postSample](/reference/hooks/postsample/): Called at the end of [`Pattern.sample()`](/reference/api/pattern#sample)
 
 You can register a method for a hook. When the hook is triggered, your method will be
 called. It will receive two parameters:
 
--   An object relevant to the hook. See the [hooks API reference](/reference/hooks/) for details.
--   Data passed when the hook was registered (optional)
+- An object relevant to the hook. See the [hooks API reference](/reference/hooks/) for details.
+- Data passed when the hook was registered (optional)

--- a/markdown/dev/guides/plugins/macros/en.md
+++ b/markdown/dev/guides/plugins/macros/en.md
@@ -5,8 +5,8 @@ order: 90
 
 Plugin structure for macros is similar, with a few changes:
 
--   Rather than the hook name, you provide the macro name (that you choose yourself)
--   The context (`this`) of a macro method is **always** a [Part](/reference/api/part) object.
+- Rather than the hook name, you provide the macro name (that you choose yourself)
+- The context (`this`) of a macro method is **always** a [Part](/reference/api/part) object.
 
 Apart from these, the structure is very similar:
 

--- a/markdown/dev/guides/plugins/plugin-structure/en.md
+++ b/markdown/dev/guides/plugins/plugin-structure/en.md
@@ -5,8 +5,8 @@ order: 50
 
 Plugins can do two things:
 
--   They can use hooks
--   They can provide macros
+- They can use hooks
+- They can provide macros
 
 Your plugin should export an object with the following structure:
 

--- a/markdown/dev/guides/plugins/types-of-plugins/en.md
+++ b/markdown/dev/guides/plugins/types-of-plugins/en.md
@@ -5,8 +5,8 @@ order: 10
 
 Plugins come in two flavours:
 
--   [Build-time plugins](#build-time-plugins)
--   [Run-time plugins](#run-time-plugins)
+- [Build-time plugins](#build-time-plugins)
+- [Run-time plugins](#run-time-plugins)
 
 When writing a plugin, ask yourself whether it's a run-time or a build-time plugin.
 And if the answer is both, please split them into two plugins.

--- a/markdown/dev/guides/plugins/types-of-plugins/en.md
+++ b/markdown/dev/guides/plugins/types-of-plugins/en.md
@@ -30,7 +30,7 @@ Our [plugin bundle](/reference/plugins/bundle/) bundles build-time plugins that 
 A plugin is a run-time plugin if it can be added after instantiating your pattern.
 Think of it as a plugin to be used in the front-end.
 
-Run-time plugins are not a dependecy of the pattern. They just *add something* to it.
+Run-time plugins are not a dependecy of the pattern. They just _add something_ to it.
 
 Our [theme plugin](/reference/plugins/theme/) is a good example of a run-time plugin.
 If it's missing, your pattern will still work, it just won't look pretty.

--- a/markdown/dev/guides/plugins/using-hooks/en.md
+++ b/markdown/dev/guides/plugins/using-hooks/en.md
@@ -9,8 +9,8 @@ that as the second object.
 
 Remember that:
 
--   The `insertText` hook will receive a locale and string and you should return a string.
--   All other hooks receive an object. You don't need to return anything, but rather modify the object you receive.
+- The `insertText` hook will receive a locale and string and you should return a string.
+- All other hooks receive an object. You don't need to return anything, but rather modify the object you receive.
 
 Let's look at an example:
 
@@ -39,8 +39,8 @@ export default {
 
 This is a complete plugin, ready to be published on NPM. It uses two hooks:
 
--   `preRender` : We add some style and defs to our SVG
--   `insertText` : We transfer all text to UPPERCASE
+- `preRender` : We add some style and defs to our SVG
+- `insertText` : We transfer all text to UPPERCASE
 
 <Note>
 

--- a/markdown/dev/guides/prerequisites/bezier-curves/en.md
+++ b/markdown/dev/guides/prerequisites/bezier-curves/en.md
@@ -12,10 +12,10 @@ popularized their use back in the 1960s.
 
 In FreeSewing, we use so-called cubic Bézier curves which have:
 
--   A start point
--   A first control point that’s linked to the start point
--   A second control point that’s linked to the end point
--   An end point
+- A start point
+- A first control point that’s linked to the start point
+- A second control point that’s linked to the end point
+- An end point
 
 <Example settings_complete="0" part="path_curve">
 An example of a Bézier curve drawn by the Path.curve() method

--- a/markdown/dev/guides/prerequisites/bezier-curves/en.md
+++ b/markdown/dev/guides/prerequisites/bezier-curves/en.md
@@ -21,13 +21,13 @@ In FreeSewing, we use so-called cubic Bézier curves which have:
 An example of a Bézier curve drawn by the Path.curve() method
 </Example>
 
-Bézier curves and their *handles* or *control points* are surprisingly intuitive.
+Bézier curves and their _handles_ or _control points_ are surprisingly intuitive.
 The following illustration does a great job at explaining how they are constructed:
 
 ![How Bézier curves are constructed](bezier.gif)
 
 You don't need understand the mathematics behind Bézier Curves.
-As long as you intuitively *get* how the control points influence the curve, you're good to go.
+As long as you intuitively _get_ how the control points influence the curve, you're good to go.
 
 <Note>
 

--- a/markdown/dev/guides/translation/en.md
+++ b/markdown/dev/guides/translation/en.md
@@ -31,11 +31,11 @@ Bonus: You'll get an `@freesewing.org` email alias
 
 We currently support the following five languages:
 
--   **en** : English
--   **de** : German
--   **es** : Spanish
--   **fr** : French
--   **nl** : Dutch
+- **en** : English
+- **de** : German
+- **es** : Spanish
+- **fr** : French
+- **nl** : Dutch
 
 <Note>
 
@@ -49,8 +49,8 @@ please [come and talk to us on Discord](https://discord.freesewing.org).
 
 We use two different tools to manage our translations, depending on the context:
 
--   Markdown content and code strings in our monorepo are translated within **Crowdin**
--   Blog and showcase posts are translated within **Strapi**
+- Markdown content and code strings in our monorepo are translated within **Crowdin**
+- Blog and showcase posts are translated within **Strapi**
 
 <Tip>
 

--- a/markdown/dev/guides/translation/en.md
+++ b/markdown/dev/guides/translation/en.md
@@ -79,7 +79,7 @@ expect to find the same structure, the same amount of headings, paragraphs and s
 
 ### Strapi
 
-Strapi ([strapi.io](https://strapi.io/)) is a so-called *headless content management system (CMS)*.
+Strapi ([strapi.io](https://strapi.io/)) is a so-called _headless content management system (CMS)_.
 Headless just means that we load the content from it via an API, rather than have it be part of our
 website like a classic CMS (eg. Wordpress).
 

--- a/markdown/dev/howtos/code/adding-instructions/en.md
+++ b/markdown/dev/howtos/code/adding-instructions/en.md
@@ -12,7 +12,7 @@ about: While documentation is good, sometimes you want to add some instructions 
 
 </Note>
 
-Adding instructions to your pattern is *just* a matter of adding text.
+Adding instructions to your pattern is _just_ a matter of adding text.
 The tricky part is to make sure your text can be translated.
 
 Below is a rather involved example from Aaron:

--- a/markdown/dev/howtos/code/adding-instructions/en.md
+++ b/markdown/dev/howtos/code/adding-instructions/en.md
@@ -8,7 +8,7 @@ about: While documentation is good, sometimes you want to add some instructions 
 
 ##### See this example in our source code
 
--   [packages/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/38d101b0415a4cbf3f9f86e006bd8cb7c43c703b/packages/jaeger/src/front.js#L411)
+- [packages/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/38d101b0415a4cbf3f9f86e006bd8cb7c43c703b/packages/jaeger/src/front.js#L411)
 
 </Note>
 

--- a/markdown/dev/howtos/code/adding-paths/en.md
+++ b/markdown/dev/howtos/code/adding-paths/en.md
@@ -9,7 +9,7 @@ After using the [shorthand](/howtos/code/shorthand/) call,
 `Path` contains the path constructor, while `paths` is a reference to `part.paths`,
 which is where you should store your paths.
 
-Things will now *just work* when you do this:
+Things will now _just work_ when you do this:
 
 ```js
 paths.example = new Path()

--- a/markdown/dev/howtos/code/adding-points/en.md
+++ b/markdown/dev/howtos/code/adding-points/en.md
@@ -8,7 +8,7 @@ After using the [shorthand](/howtos/code/shorthand/) call,
 `Point` contains the point constructor, while `points` is a reference to `part.points`,
 which is where you should store your points.
 
-Things will now *just work* when you do this:
+Things will now _just work_ when you do this:
 
 ```js
 points.centerBack  = new Point(0,0);

--- a/markdown/dev/howtos/code/adding-snippets/en.md
+++ b/markdown/dev/howtos/code/adding-snippets/en.md
@@ -8,7 +8,7 @@ After using the [shorthand](/howtos/code/shorthand/) call,
 `Snippet` contains the path constructor, while `snippets` is a reference to `part.snippets`,
 which is where you should store your paths.
 
-Things will now *just work* when you do this:
+Things will now _just work_ when you do this:
 
 ```js
 snippets.logo = new Snippet('logo', points.logoAnchor);

--- a/markdown/dev/howtos/code/adding-snippets/en.md
+++ b/markdown/dev/howtos/code/adding-snippets/en.md
@@ -16,8 +16,8 @@ snippets.logo = new Snippet('logo', points.logoAnchor);
 
 You can scale and rotate a snippet by setting the `data-scale` and `data-rotate` attributes respectively.
 
--   **data-scale** : Either a single scale factor, or a set of 2 scale factors for the X and Y axis respectively. See [the SVG scale transform](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform#Scale) for details.
--   **data-rotate**: A rotation in degrees. The center of the rotation will be the snippet's anchor point
+- **data-scale** : Either a single scale factor, or a set of 2 scale factors for the X and Y axis respectively. See [the SVG scale transform](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform#Scale) for details.
+- **data-rotate**: A rotation in degrees. The center of the rotation will be the snippet's anchor point
 
 <Tip>
 

--- a/markdown/dev/howtos/code/attributes/en.md
+++ b/markdown/dev/howtos/code/attributes/en.md
@@ -16,7 +16,7 @@ paths.example.attributes.add('class', 'lining dashed');
 Because it's so common to set attributes, Points, Paths and Snippets all have
 the `attr()` helper method.
 
-Not only is less more, the method is also *chainable*, which allows you to do this:
+Not only is less more, the method is also _chainable_, which allows you to do this:
 
 ```js
 points.message = new Point(0,0)
@@ -36,7 +36,7 @@ The [adding-text](/concepts/adding-text) documentation explains this in detail.
 When rendering, FreeSewing will output all your attributes. This gives you the
 possiblity to use any valid attribute to control the appearance.
 
-This is also why we use the *data-* prefix for those attributes that have
+This is also why we use the _data-_ prefix for those attributes that have
 special meaning within FreeSewing, such as `data-text`. Adding a `text` attribute
 would result in invalid SVG as there is no such thing as a text attribute. But `data-text`
 is fine because the `data-` prefix indicates it is a [custom attribute](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/data-*).

--- a/markdown/dev/howtos/code/dependencies/en.md
+++ b/markdown/dev/howtos/code/dependencies/en.md
@@ -26,9 +26,9 @@ we need that info to fit the sleevecap to the armhole.
 
 Now if a user requests to draft only the `sleeve` part, FreeSewing will still draft:
 
--   First the `base` part
--   Then the `front` and `back` parts
--   Finally the `sleeve` part
+- First the `base` part
+- Then the `front` and `back` parts
+- Finally the `sleeve` part
 
 but it will only render the `sleeve` part, as that's the only thing the user requested.
 

--- a/markdown/dev/howtos/code/extend-pattern/en.md
+++ b/markdown/dev/howtos/code/extend-pattern/en.md
@@ -8,9 +8,9 @@ about: Shows how to create a variation of a pre-existing design
 
 ##### See this example in our source code
 
--   [packages/aaron/config/index.js](https://github.com/freesewing/freesewing/blob/72f34101792bda4d8e553c3479daa63cb461f3c5/packages/aaron/config/index.js#L34)
--   [packages/aaron/src/index.js](https://github.com/freesewing/freesewing/blob/72f34101792bda4d8e553c3479daa63cb461f3c5/packages/aaron/src/index.js#L2)
--   [packages/carlita/src/index.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/carlita/src/index.js#L25)
+- [packages/aaron/config/index.js](https://github.com/freesewing/freesewing/blob/72f34101792bda4d8e553c3479daa63cb461f3c5/packages/aaron/config/index.js#L34)
+- [packages/aaron/src/index.js](https://github.com/freesewing/freesewing/blob/72f34101792bda4d8e553c3479daa63cb461f3c5/packages/aaron/src/index.js#L2)
+- [packages/carlita/src/index.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/carlita/src/index.js#L25)
 
 </Note>
 
@@ -18,8 +18,8 @@ about: Shows how to create a variation of a pre-existing design
 
 To be able to extend existing patterns, you will have to access them on your local machine. There are two ways to do this:
 
--   add needed dependencies when using `npx create-freesewing-pattern`
--   create your new pattern in a clone of the [freesewing monorepo](https://github.com/freesewing/freesewing)
+- add needed dependencies when using `npx create-freesewing-pattern`
+- create your new pattern in a clone of the [freesewing monorepo](https://github.com/freesewing/freesewing)
 
 ### When using `npx create-freesewing-pattern`
 
@@ -44,16 +44,16 @@ Some packages need more than one dependency. Carlton, for example, is based on B
 
 You can use the power of robots to install the needed dependencies if you work in a clone of the [freesewing monorepo](https://github.com/freesewing/freesewing).
 
--   First, clone the monorepo (or your fork of it) to your local machine.
--   Go to the root and run `yarn kickstart`. This will take a while, so grab a coffee and come back later.
--   Once that is done, edit the file `config/descriptions.yaml` to include the name and description of your new pattern (take care to start the description with `A FreeSewing pattern`).
--   Create a folder for your new pattern in `packages`.
--   Run `yarn reconfigure`. This will read the changes in `config/descriptions.yaml` and create the needed files in your new folder.
--   If you haven't already, now is also a good time to create a feature branch so that you don't work directly in the `develop`-branch of the git-repository: `git checkout -b mycoolnewpattern` (adjust name accordingly).
--   You can now start the actual pattern design work (i.e. editing and adding `src` and `config` files for your pattern.
--   For dependencies, configure them in `config/dependencies.yaml`.
--   Run `yarn reconfigure` again, and the magic will make sure that your `package.json` is updated accordingly.
--   You can set yourself as an author in `config/exceptions.yaml`, and - you guessed it - run `yarn reconfigure` again.
+- First, clone the monorepo (or your fork of it) to your local machine.
+- Go to the root and run `yarn kickstart`. This will take a while, so grab a coffee and come back later.
+- Once that is done, edit the file `config/descriptions.yaml` to include the name and description of your new pattern (take care to start the description with `A FreeSewing pattern`).
+- Create a folder for your new pattern in `packages`.
+- Run `yarn reconfigure`. This will read the changes in `config/descriptions.yaml` and create the needed files in your new folder.
+- If you haven't already, now is also a good time to create a feature branch so that you don't work directly in the `develop`-branch of the git-repository: `git checkout -b mycoolnewpattern` (adjust name accordingly).
+- You can now start the actual pattern design work (i.e. editing and adding `src` and `config` files for your pattern.
+- For dependencies, configure them in `config/dependencies.yaml`.
+- Run `yarn reconfigure` again, and the magic will make sure that your `package.json` is updated accordingly.
+- You can set yourself as an author in `config/exceptions.yaml`, and - you guessed it - run `yarn reconfigure` again.
 
 Now you can work on extending existing patterns into something new and exciting. And the best part about using this method is that making a pull request will be much easier once you're done developing your new pattern.
 

--- a/markdown/dev/howtos/code/hide-paths/en.md
+++ b/markdown/dev/howtos/code/hide-paths/en.md
@@ -8,7 +8,7 @@ about: When you inherit a part, it comes with a bunch of paths. Here'show to hid
 
 ##### See this example in our source code
 
--   [packages/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/develop/packages/aaron/src/front.js#L22)
+- [packages/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/develop/packages/aaron/src/front.js#L22)
 
 </Note>
 

--- a/markdown/dev/howtos/code/inject/en.md
+++ b/markdown/dev/howtos/code/inject/en.md
@@ -15,7 +15,7 @@ inject: {
 }
 ```
 
-The `front` and `back` parts will be *injected* with the `base` part. As a result, both
+The `front` and `back` parts will be _injected_ with the `base` part. As a result, both
 the `front` and `back` parts will be instantiated with a cloned copy of all the points, paths,
 and snippets of the `base` part.
 

--- a/markdown/dev/howtos/code/remove-paths/en.md
+++ b/markdown/dev/howtos/code/remove-paths/en.md
@@ -8,7 +8,7 @@ about: When you inherit a part, it comes with a bunch of paths. Here'show to rem
 
 ##### See this example in our source code
 
--   [packages/carlton/src/back.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/carlton/src/back.js#L62)
+- [packages/carlton/src/back.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/carlton/src/back.js#L62)
 
 </Note>
 

--- a/markdown/dev/howtos/code/shared-dimensions/en.md
+++ b/markdown/dev/howtos/code/shared-dimensions/en.md
@@ -8,8 +8,8 @@ about: Shows how to share dimensions between similar pattern parts
 
 ##### See this example in our source code
 
--   [packages/aaron/src/shared.js](https://github.com/freesewing/freesewing/blob/develop/packages/aaron/src/shared.js)
--   [packages/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/72f34101792bda4d8e553c3479daa63cb461f3c5/packages/aaron/src/front.js#L160)
+- [packages/aaron/src/shared.js](https://github.com/freesewing/freesewing/blob/develop/packages/aaron/src/shared.js)
+- [packages/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/72f34101792bda4d8e553c3479daa63cb461f3c5/packages/aaron/src/front.js#L160)
 
 </Note>
 

--- a/markdown/dev/howtos/code/shared-dimensions/en.md
+++ b/markdown/dev/howtos/code/shared-dimensions/en.md
@@ -48,7 +48,7 @@ import { dimensions } from './shared'
 
 <Note>
 
-Since our shared dimension method is a so-called *named export* we need to
+Since our shared dimension method is a so-called _named export_ we need to
 import it with the syntax you see above.
 
 </Note>

--- a/markdown/dev/howtos/code/storing-path-length/en.md
+++ b/markdown/dev/howtos/code/storing-path-length/en.md
@@ -8,7 +8,7 @@ about: Shows how to store a seam length so you can true the seam of another part
 
 ##### See this example in our source code
 
--   [packages/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/develop/packages/aaron/src/front.js#L103)
+- [packages/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/develop/packages/aaron/src/front.js#L103)
 
 </Note>
 

--- a/markdown/dev/howtos/code/storing-path-length/en.md
+++ b/markdown/dev/howtos/code/storing-path-length/en.md
@@ -12,7 +12,7 @@ about: Shows how to store a seam length so you can true the seam of another part
 
 </Note>
 
-Often when designing patterns, we need to *true a seam* which means to make sure
+Often when designing patterns, we need to _true a seam_ which means to make sure
 that two parts that need to be joined together are the same distance.
 
 The example below is from Aaron and stores the length of the armhole seam:

--- a/markdown/dev/howtos/design/fit-sleeve/en.md
+++ b/markdown/dev/howtos/design/fit-sleeve/en.md
@@ -8,7 +8,7 @@ about: Shows how to adapt the length of the sleevecap to fit your armhole
 
 ##### See this example in our source code
 
--   [packages/bent/src/sleeve.js](https://github.com/freesewing/freesewing/blob/develop/packages/bent/src/sleeve.js)
+- [packages/bent/src/sleeve.js](https://github.com/freesewing/freesewing/blob/develop/packages/bent/src/sleeve.js)
 
 </Note>
 
@@ -25,15 +25,15 @@ This pattern is rather common, and we will unpack an example from Bent below.
 
 Before we dive in, here's a few things to keep in mind:
 
--   In Javascript, you can create a function within your function and call it
--   Bent extends Brian which sets both the `frontArmholeLength` and `backArmholeLength` values in the store with the length of those seams
--   We need to match the length of the sleevecap + sleeve cap ease to the length of the front and back armhole
+- In Javascript, you can create a function within your function and call it
+- Bent extends Brian which sets both the `frontArmholeLength` and `backArmholeLength` values in the store with the length of those seams
+- We need to match the length of the sleevecap + sleeve cap ease to the length of the front and back armhole
 
 Here's how you can handle this in code:
 
--   We create a method that does teh actual drafting of our sleevecap
--   We use a `tweak` value to influence the process, we start with a value of `1`
--   We check the length after every attempt, and adjust the `tweak` value
+- We create a method that does teh actual drafting of our sleevecap
+- We use a `tweak` value to influence the process, we start with a value of `1`
+- We check the length after every attempt, and adjust the `tweak` value
 
 ```js
 export default function (part) {
@@ -81,7 +81,7 @@ export default function (part) {
 
 A few things that are important:
 
--   We check to see how close we are by using `Math.abs(delta)` which gives us the absolute value of our delta
--   We guard against an endless loop by keeping track of the runs and giving up after 25
--   We multiply by `0.99` and `1.02` to respectively decrease and increase our `tweak` factor.
-    This assymetric approach avoids that we end up ping-ponging around our target value and never land somewhere in the middle
+- We check to see how close we are by using `Math.abs(delta)` which gives us the absolute value of our delta
+- We guard against an endless loop by keeping track of the runs and giving up after 25
+- We multiply by `0.99` and `1.02` to respectively decrease and increase our `tweak` factor.
+  This assymetric approach avoids that we end up ping-ponging around our target value and never land somewhere in the middle

--- a/markdown/dev/howtos/design/seam-allowance/en.md
+++ b/markdown/dev/howtos/design/seam-allowance/en.md
@@ -8,7 +8,7 @@ about: Adding seam allowance or hem allowance is easy to do
 
 ##### See this example in our source code
 
--   [packages/bruce/src/inset.js](https://github.com/freesewing/freesewing/blob/develop/packages/bruce/src/inset.js#L34)
+- [packages/bruce/src/inset.js](https://github.com/freesewing/freesewing/blob/develop/packages/bruce/src/inset.js#L34)
 
 </Note>
 
@@ -20,8 +20,8 @@ seam allowance.
 
 In the example below we have two such paths:
 
--   `paths.saBase` is the path that will require regular seam allowance
--   `paths.hemBase` is the path that will require more seam allowance, or hem allowance
+- `paths.saBase` is the path that will require regular seam allowance
+- `paths.hemBase` is the path that will require more seam allowance, or hem allowance
 
 When creating them, we disable rendering, effectively hiding them.
 Then we string together our real path and our seam allowance based on them:

--- a/markdown/dev/howtos/design/slash-spread/en.md
+++ b/markdown/dev/howtos/design/slash-spread/en.md
@@ -8,7 +8,7 @@ about: Slash and spread is easy enough on paper, here's how to do it in code
 
 ##### See this example in our source code
 
--   [packages/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/jaeger/src/front.js#L64)
+- [packages/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/jaeger/src/front.js#L64)
 
 </Note>
 
@@ -17,9 +17,9 @@ around the tip of the triangle.
 
 And that's exactly what we do in code. We just need to know:
 
--   What point we want to rotate around
--   Which points we want to rotate
--   By how much we want to rotate
+- What point we want to rotate around
+- Which points we want to rotate
+- By how much we want to rotate
 
 ```js
 let rotate = [

--- a/markdown/dev/howtos/design/slash-spread/en.md
+++ b/markdown/dev/howtos/design/slash-spread/en.md
@@ -12,7 +12,7 @@ about: Slash and spread is easy enough on paper, here's how to do it in code
 
 </Note>
 
-When we *slash and spread* a pattern, we cut out a triangle, and then rotate it
+When we _slash and spread_ a pattern, we cut out a triangle, and then rotate it
 around the tip of the triangle.
 
 And that's exactly what we do in code. We just need to know:

--- a/markdown/dev/howtos/design/sprinkle-snippets/en.md
+++ b/markdown/dev/howtos/design/sprinkle-snippets/en.md
@@ -8,7 +8,7 @@ about: Adding multiple snippets doesn't need to be a chore with this handy macro
 
 ##### See this example in our source code
 
--   [packages/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/jaeger/src/front.js#L381)
+- [packages/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/jaeger/src/front.js#L381)
 
 </Note>
 

--- a/markdown/dev/howtos/en.md
+++ b/markdown/dev/howtos/en.md
@@ -13,7 +13,7 @@ You can find a list of all FreeSewing hotwtos below:
 
 Howtos give your concrete steps to solve a common problem or challenge.
 
-Guides and howtos are on a spectrum with howtos being terse *do-this-then-that* recipes, whereas
+Guides and howtos are on a spectrum with howtos being terse _do-this-then-that_ recipes, whereas
 guides take more time to explain in-depth what is being done and why.
 
 For more details, refer to [How we structure our documentation](/guides/docs).

--- a/markdown/dev/howtos/environments/browser/en.md
+++ b/markdown/dev/howtos/environments/browser/en.md
@@ -11,7 +11,7 @@ you can generate patterns in the browser with a few lines of Javascript.
 ##### Use FreeSewing.org if you just want a pattern
 
 These instructions are intended for people who want to generate
-their own patterns. If you *just want a sewing pattern* you can
+their own patterns. If you _just want a sewing pattern_ you can
 get all our designs on [FreeSewing.org](https://FreeSewing.org/),
 our website for makers.
 

--- a/markdown/dev/howtos/environments/browser/en.md
+++ b/markdown/dev/howtos/environments/browser/en.md
@@ -21,11 +21,11 @@ our website for makers.
 
 To generate a pattern, you will need to:
 
--   Instantiate the pattern (`new ...`)
--   Pass it the settings and measurements you want to use (`{ ... }`)
--   Load the theme plugin (using `use()`)
--   Draft the pattern (using `draft()`)
--   Render it to SVG  (using `render()`)
+- Instantiate the pattern (`new ...`)
+- Pass it the settings and measurements you want to use (`{ ... }`)
+- Load the theme plugin (using `use()`)
+- Draft the pattern (using `draft()`)
+- Render it to SVG  (using `render()`)
 
 Which can be done as a one-liner since `use()`, `draft()` and
 `render()` are all chainable, as shown below.

--- a/markdown/dev/howtos/environments/nodejs/en.md
+++ b/markdown/dev/howtos/environments/nodejs/en.md
@@ -22,11 +22,11 @@ our website for makers.
 
 To generate a pattern, you will need to:
 
--   Instantiate the pattern (`new ...`)
--   Pass it the settings and measurements you want to use (`{ ... }`)
--   Load the theme plugin (using `use()`)
--   Draft the pattern (using `draft()`)
--   Render it to SVG  (using `render()`)
+- Instantiate the pattern (`new ...`)
+- Pass it the settings and measurements you want to use (`{ ... }`)
+- Load the theme plugin (using `use()`)
+- Draft the pattern (using `draft()`)
+- Render it to SVG  (using `render()`)
 
 Which can be done as a one-liner since `use()`, `draft()` and
 `render()` are all chainable, as shown below.
@@ -64,11 +64,11 @@ console.log(svg)
 
 ##### Remarks on the example code
 
--   We are using `@freesewing/aaron` as the design, but you could use any design
--   You probably want to [use your own measurements](/reference/api/settings/measurements)
-    or you could use `@freesewing/models` to load measurements from [our sizing grid](https://freesewing.org/sizes/)
--   We are using `@freesewing/plugin-theme` to theme our SVG, but you
-    could [pass in your own CSS](/guides/plugins/using-hooks-without-plugin)
+- We are using `@freesewing/aaron` as the design, but you could use any design
+- You probably want to [use your own measurements](/reference/api/settings/measurements)
+  or you could use `@freesewing/models` to load measurements from [our sizing grid](https://freesewing.org/sizes/)
+- We are using `@freesewing/plugin-theme` to theme our SVG, but you
+  could [pass in your own CSS](/guides/plugins/using-hooks-without-plugin)
 
 </Note>
 
@@ -77,11 +77,11 @@ console.log(svg)
 The code above will only work if you've got the required dependencies installed on your system.
 Obviously you need NodeJS, but you will also need the following packages:
 
--   `@freesewing/core`: Our core library
--   `@freesewing/plugin-bundle`: Set of common plugins
--   `@freesewing/aaron` or any design you want to use
--   Any design on which the design you choose is built. In this case, Aaron depends on `@freesewing/brian`
--   `@freesewing/utils`
+- `@freesewing/core`: Our core library
+- `@freesewing/plugin-bundle`: Set of common plugins
+- `@freesewing/aaron` or any design you want to use
+- Any design on which the design you choose is built. In this case, Aaron depends on `@freesewing/brian`
+- `@freesewing/utils`
 
 For the example above, your `package.json` **dependencies** section will look like this:
 

--- a/markdown/dev/howtos/environments/nodejs/en.md
+++ b/markdown/dev/howtos/environments/nodejs/en.md
@@ -12,7 +12,7 @@ generate a pattern.
 ##### Use FreeSewing.org if you just want a pattern
 
 These instructions are intended for people who want to generate
-their own patterns. If you *just want a sewing pattern* you can
+their own patterns. If you _just want a sewing pattern_ you can
 get all our designs on [FreeSewing.org](https://FreeSewing.org/),
 our website for makers.
 

--- a/markdown/dev/howtos/git/save-often/en.md
+++ b/markdown/dev/howtos/git/save-often/en.md
@@ -17,7 +17,7 @@ spending much time to write a meaningful commit message:
 git add . && git commit -m "save"
 ```
 
-The way you can get the best of both worlds is by *rewriting history*.
+The way you can get the best of both worlds is by _rewriting history_.
 Save as many times you want, and when you've gotten to the point where
 you feel like you've hit a good milestone, roll them all back and commit
 anew with a nice commit message that makes it seem you had it all figured

--- a/markdown/dev/howtos/ways-to-contribute/en.md
+++ b/markdown/dev/howtos/ways-to-contribute/en.md
@@ -13,8 +13,8 @@ value a safe and welcoming environment for all members of the FreeSewing communi
 
 To that extend, we impose the following requirements to ensure everyone feels safe and welcome:
 
--   Any member of our community must respect [our community standards](https://freesewing.org/docs/various/community-standards/)
--   As a contributor, you must uphold [our Code of Conduct](/guides/code-of-conduct/)
+- Any member of our community must respect [our community standards](https://freesewing.org/docs/various/community-standards/)
+- As a contributor, you must uphold [our Code of Conduct](/guides/code-of-conduct/)
 
 Go ahead and read those, we'll wait.
 
@@ -22,11 +22,11 @@ Go ahead and read those, we'll wait.
 
 With that out of the way, here's a few more things that are _good to know_:
 
--   Nobody gets paid to work on/for FreeSewing. We are a 100% volunteer organisation.
--   We have patrons who support us financially, but all the money that comes in goes to charity —
-    See our [revenue pledge](https://freesewing.org/docs/various/pledge/) for details
--   FreeSewing follows the [all-contributors](https://allcontributors.org/) specification.
-    Contributions of any kind are welcome.
+- Nobody gets paid to work on/for FreeSewing. We are a 100% volunteer organisation.
+- We have patrons who support us financially, but all the money that comes in goes to charity —
+  See our [revenue pledge](https://freesewing.org/docs/various/pledge/) for details
+- FreeSewing follows the [all-contributors](https://allcontributors.org/) specification.
+  Contributions of any kind are welcome.
 
 ## Where to begin
 

--- a/markdown/dev/howtos/ways-to-contribute/en.md
+++ b/markdown/dev/howtos/ways-to-contribute/en.md
@@ -20,7 +20,7 @@ Go ahead and read those, we'll wait.
 
 ## Good to know
 
-With that out of the way, here's a few more things that are *good to know*:
+With that out of the way, here's a few more things that are _good to know_:
 
 -   Nobody gets paid to work on/for FreeSewing. We are a 100% volunteer organisation.
 -   We have patrons who support us financially, but all the money that comes in goes to charity —

--- a/markdown/dev/howtos/ways-to-contribute/project-management/en.md
+++ b/markdown/dev/howtos/ways-to-contribute/project-management/en.md
@@ -9,6 +9,6 @@ organize milestones, and so on.
 
 This is helpful in more than one way:
 
--   It reduces the cognitive load of the people implementing changes because they don't have to worry about forgetting things
--   It increases transparency by making it clear what sort of things are being worked on
--   It gives us that good feeling of closing the issue when the task is done
+- It reduces the cognitive load of the people implementing changes because they don't have to worry about forgetting things
+- It increases transparency by making it clear what sort of things are being worked on
+- It gives us that good feeling of closing the issue when the task is done

--- a/markdown/dev/howtos/ways-to-contribute/report-bugs/en.md
+++ b/markdown/dev/howtos/ways-to-contribute/report-bugs/en.md
@@ -7,11 +7,11 @@ Create an issue [in our monorepo](https://github.com/freesewing/freesewing/issue
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
--   **Use a clear and descriptive title** for the issue to identify the problem.
--   **Describe the exact steps which reproduce the problem** in as many details as possible.
--   **Include relevant information** such as your username on the site, or the person you drafted a pattern for.
+- **Use a clear and descriptive title** for the issue to identify the problem.
+- **Describe the exact steps which reproduce the problem** in as many details as possible.
+- **Include relevant information** such as your username on the site, or the person you drafted a pattern for.
 
 Provide more context by answering these questions:
 
--   **Did the problem start happening recently** (e.g. it worked fine before but since the latest update it doesn't)
--   **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
+- **Did the problem start happening recently** (e.g. it worked fine before but since the latest update it doesn't)
+- **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.

--- a/markdown/dev/howtos/ways-to-contribute/triage-issues/en.md
+++ b/markdown/dev/howtos/ways-to-contribute/triage-issues/en.md
@@ -4,11 +4,11 @@ title: Triage issues
 
 Triaging issues is a great way to get involved in FreeSewing. You can do tasks such as:
 
--   Making sure issues are properly labeled
--   Ensuring they have a good title that explains the issue in brief
--   Assigning issues to people to make sure they are tended to
--   Keeping an eye on stale issues, and either updating or closing them
--   Assigning issues to milestones so we can plan our releases
+- Making sure issues are properly labeled
+- Ensuring they have a good title that explains the issue in brief
+- Assigning issues to people to make sure they are tended to
+- Keeping an eye on stale issues, and either updating or closing them
+- Assigning issues to milestones so we can plan our releases
 
 All FreeSewing contributors have triage permissions that allows them to do this.
 If you don't have the rights, or bump into any issues, [reach out to us on Discord](https://discord.freesewing.org).

--- a/markdown/dev/reference/api/config/dependencies/en.md
+++ b/markdown/dev/reference/api/config/dependencies/en.md
@@ -33,8 +33,8 @@ dependencies: {
 
 In this example:
 
--   The `front` part depends on the `back` part
--   The `sleeveplacket` part depends on the `sleeve` and `cuff` parts.
+- The `front` part depends on the `back` part
+- The `sleeveplacket` part depends on the `sleeve` and `cuff` parts.
 
 <Tip>
 

--- a/markdown/dev/reference/api/config/hide/en.md
+++ b/markdown/dev/reference/api/config/hide/en.md
@@ -4,7 +4,7 @@ title: hide
 
 The `hide` key in the pattern configuration file allow you to configure
 parts that should be hidden by default.
-*Hidden* means that they will be drafted, but not rendered. This is
+_Hidden_ means that they will be drafted, but not rendered. This is
 typically used for a base part on which other parts are built.
 
 Note that hidden parts will be rendered when the user requests

--- a/markdown/dev/reference/api/config/inject/en.md
+++ b/markdown/dev/reference/api/config/inject/en.md
@@ -4,7 +4,7 @@ title: inject
 
 The `inject` key in the pattern configuration file allow you to configure
 the rules for injecting one part into another.
-By *injecting* we mean that rather than starting out with a fresh part,
+By _injecting_ we mean that rather than starting out with a fresh part,
 you'll get a part that has the points, paths, and snippets of the injected part.
 
 ## Structure

--- a/markdown/dev/reference/api/config/optiongroups/en.md
+++ b/markdown/dev/reference/api/config/optiongroups/en.md
@@ -26,9 +26,9 @@ configuration file.
 
 They hold a plain object where each property can hold:
 
--   An array of strings that are the names of the options to include in the group
--   A plain object whose properties hold an array of strings that are the names
-    of the options to include in the group. (this creates a subgroup)
+- An array of strings that are the names of the options to include in the group
+- A plain object whose properties hold an array of strings that are the names
+  of the options to include in the group. (this creates a subgroup)
 
 ## Example
 
@@ -53,12 +53,12 @@ optionGroups: {
 
 The configuration above will create the following structure:
 
--   **fit**
-    -   `chestEase`
-    -   `waistEase`
--   **style**
-    -   `cuffStyle`
-    -   `hemStyle`
-    -   **collar**
-        -   `collarHeight`
-        -   `collarShape`
+- **fit**
+  - `chestEase`
+  - `waistEase`
+- **style**
+  - `cuffStyle`
+  - `hemStyle`
+  - **collar**
+    - `collarHeight`
+    - `collarShape`

--- a/markdown/dev/reference/api/config/options/bool/en.md
+++ b/markdown/dev/reference/api/config/options/bool/en.md
@@ -9,8 +9,8 @@ or **yes** or **no**, use a boolean option.
 
 A boolean option is a plain object with these properties:
 
--   `bool` : Either `true` or `false` which will be the default
--   `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
+- `bool` : Either `true` or `false` which will be the default
+- `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
 
 [hide]: /reference/api/config/options#optionally-hide-options-by-configuring-a-hide-method
 

--- a/markdown/dev/reference/api/config/options/const/en.md
+++ b/markdown/dev/reference/api/config/options/const/en.md
@@ -26,11 +26,11 @@ options: {
 
 There are typically two use-cases for constant options:
 
--   Rather than define constants in your code, it's good practice to set
-    them in your configuration file.  This way, people who extend your
-    pattern can change them if they would like to.
--   A constant option can be used as a feature-flag. Enabling or disabling
-    parts of the code beyond the control of the end user, but accessible to
-    developers.
+- Rather than define constants in your code, it's good practice to set
+  them in your configuration file.  This way, people who extend your
+  pattern can change them if they would like to.
+- A constant option can be used as a feature-flag. Enabling or disabling
+  parts of the code beyond the control of the end user, but accessible to
+  developers.
 
 </Tip>

--- a/markdown/dev/reference/api/config/options/counter/en.md
+++ b/markdown/dev/reference/api/config/options/counter/en.md
@@ -9,10 +9,10 @@ Counters are for integers only. Things like number of buttons and so on.
 
 Your counter option should be a plain object with these properties:
 
--   `count` : The default integer value
--   `min` : The minimal integer value that's allowed
--   `max` : The maximum integer value that's allowed
--   `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
+- `count` : The default integer value
+- `min` : The minimal integer value that's allowed
+- `max` : The maximum integer value that's allowed
+- `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
 
 [hide]: /reference/api/config/options#optionally-hide-options-by-configuring-a-hide-method
 

--- a/markdown/dev/reference/api/config/options/deg/en.md
+++ b/markdown/dev/reference/api/config/options/deg/en.md
@@ -8,10 +8,10 @@ For angles, use a degree option.
 
 Your degree option should be a plain object with these properties:
 
--   `deg` : The default value in degrees
--   `min` : The minimul that's allowed
--   `max` : The maximum that's allowed
--   `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
+- `deg` : The default value in degrees
+- `min` : The minimul that's allowed
+- `max` : The maximum that's allowed
+- `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
 
 [hide]: /reference/api/config/options#optionally-hide-options-by-configuring-a-hide-method
 

--- a/markdown/dev/reference/api/config/options/en.md
+++ b/markdown/dev/reference/api/config/options/en.md
@@ -26,11 +26,11 @@ possible.
 There are the five option types that an aspiring pattern designer should be
 familiar with:
 
-1.  [**boolean** options][bool] are for yes/no choices
-2.  [**counter** options][count] are for integer values
-3.  [**degree** options][deg] are for degrees
-4.  [**list** options][list] are for a list of possible choices
-5.  [**percentage** options][pct] are for percentages
+1. [**boolean** options][bool] are for yes/no choices
+2. [**counter** options][count] are for integer values
+3. [**degree** options][deg] are for degrees
+4. [**list** options][list] are for a list of possible choices
+5. [**percentage** options][pct] are for percentages
 
 <Tip>
 
@@ -43,10 +43,10 @@ They also have the most features and flexibility.
 
 For the sake of completeness, here are the two other types of options:
 
-6.  [**constant** options][const] are used as
-    [feature flags](https://en.wikipedia.org/wiki/Feature_toggle)
-7.  [**millimeter** options][const] are **deprecated** (in favor of [snapped
-    percentage options][snapped])
+6. [**constant** options][const] are used as
+   [feature flags](https://en.wikipedia.org/wiki/Feature_toggle)
+7. [**millimeter** options][const] are **deprecated** (in favor of [snapped
+   percentage options][snapped])
 
 </Related>
 
@@ -83,9 +83,9 @@ it is not intended as a way to block access to a given option. It merely hides i
 
 By default options are shown to the user when:
 
--   They are not a constant option
--   **and**
--   They are included in an optionGroup
+- They are not a constant option
+- **and**
+- They are included in an optionGroup
 
 You can further control the optional display of options by adding a method
 to the `hide` key under you option, as such:
@@ -110,8 +110,8 @@ So you can make a choice whether to show the option or not.
 
 If it's not obvious from the name, your `hide()` method you should:
 
--   Return `true` or a truthy value to hide the option
--   Return `false` or a falsy value to show the option
+- Return `true` or a truthy value to hide the option
+- Return `false` or a falsy value to show the option
 
 <Tip>
 

--- a/markdown/dev/reference/api/config/options/en.md
+++ b/markdown/dev/reference/api/config/options/en.md
@@ -11,7 +11,7 @@ One of the things that sets FreeSewing apart is that sewing patterns are not
 static. Each pattern is generated on the spot to accommodate the input
 provided by the user. Input that typically includes their measurments.
 
-This *made-to-measure* approach is sort of *our thing* at FreeSewing,
+This _made-to-measure_ approach is sort of _our thing_ at FreeSewing,
 but why stop there?
 There's a lot of things that can be left up to the user and taken into
 consideration when drafting the pattern. Things like how many buttons to use,

--- a/markdown/dev/reference/api/config/options/list/en.md
+++ b/markdown/dev/reference/api/config/options/list/en.md
@@ -8,9 +8,9 @@ Use a list option when you want to offer an array of choices.
 
 Your list option should be a plain object with these properties:
 
--   `dflt` : The default for this option
--   `list` : An array of available values options
--   `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
+- `dflt` : The default for this option
+- `list` : An array of available values options
+- `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
 
 [hide]: /reference/api/config/options#optionally-hide-options-by-configuring-a-hide-method
 

--- a/markdown/dev/reference/api/config/options/mm/en.md
+++ b/markdown/dev/reference/api/config/options/mm/en.md
@@ -34,13 +34,13 @@ options: {
 ##### What's wrong with millimeter options?
 
 Millimeter options do not scale.
-Parametric design is the *raison d'être* of FreeSewing and that core belief
+Parametric design is the _raison d'être_ of FreeSewing and that core belief
 that things should seamlessly adapt goes out the window when you use a `mm`
 option because now you have a value that will not change based on the
 input measurements.
 
-You could argue that it's fine because *you can just lower the option*
-but that breaks the principle of *sensible defaults* (aka no surprises).
+You could argue that it's fine because _you can just lower the option_
+but that breaks the principle of _sensible defaults_ (aka no surprises).
 The fact that you can sidestep the bullet does not mean you're not creating
 a footgun.
 

--- a/markdown/dev/reference/api/config/options/mm/en.md
+++ b/markdown/dev/reference/api/config/options/mm/en.md
@@ -10,10 +10,10 @@ contributions that use millimeter options.
 
 A millimeter option should be a plain object with these properties:
 
--   `mm` : The default value in millimeter
--   `min` : The minimul that's allowed
--   `max` : The maximum that's allowed
--   `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
+- `mm` : The default value in millimeter
+- `min` : The minimul that's allowed
+- `max` : The maximum that's allowed
+- `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
 
 [hide]: /reference/api/config/options#optionally-hide-options-by-configuring-a-hide-method
 

--- a/markdown/dev/reference/api/config/options/pct/en.md
+++ b/markdown/dev/reference/api/config/options/pct/en.md
@@ -10,13 +10,13 @@ they ensure that your pattern will scale regardless of size.
 
 Your percentage option should be a plain object with these properties:
 
--   `pct` : The default percentage
--   `min` : The minimum percentage that's allowed
--   `max` : The maximum percentage that's allowed
--   `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
--   `fromAbs` <small>(optional)</small> : A method to [determine the percentage based on a value in millimeter][fromabs]
--   `toAbs` <small>(optional)</small> : A method to [return the option value in millimeter][toabs]
--   `snap` <small>(optional)</small> : The configuration to control [snapping of percentage options][snap]
+- `pct` : The default percentage
+- `min` : The minimum percentage that's allowed
+- `max` : The maximum percentage that's allowed
+- `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
+- `fromAbs` <small>(optional)</small> : A method to [determine the percentage based on a value in millimeter][fromabs]
+- `toAbs` <small>(optional)</small> : A method to [return the option value in millimeter][toabs]
+- `snap` <small>(optional)</small> : The configuration to control [snapping of percentage options][snap]
 
 [hide]: /reference/api/config/options#optionally-hide-options-by-configuring-a-hide-method
 

--- a/markdown/dev/reference/api/config/options/pct/snap/en.md
+++ b/markdown/dev/reference/api/config/options/pct/snap/en.md
@@ -4,7 +4,7 @@ title: Snapped percentage options
 
 Snapped percentage options are a hybrid between [list options][list] and
 [percentage options][pct]. By combining traits of both, they create a
-sort of *smart list option* that will select the most appropriate value
+sort of _smart list option_ that will select the most appropriate value
 from the list, and also allow a pure parametric value if no close match
 is found.
 
@@ -28,7 +28,7 @@ There are three different scenarios:
 
 ### snap holds a number
 
-When `snap` holds a number, the option will be *snapped* to a
+When `snap` holds a number, the option will be _snapped_ to a
 multiple of this value.
 
 In the example below, the absolute value of this option will be set to a multiple of `7`
@@ -54,7 +54,7 @@ of all possible inputs.
 
 ### snap holds an array of numbers
 
-When snap holds an array of numbers, the option will be *snapped* to one of
+When snap holds an array of numbers, the option will be _snapped_ to one of
 the numbers unless it's further away than half the distance to its closest neighbor.
 
 In the example below, if the absolute value returned by `toAbs()` is in the
@@ -151,9 +151,9 @@ We combine approaches A and B and configure a snapped percentage option
 with:
 
 -   A percentage based on `waistToFloor`
--   Our list of standard elastic widths as *snaps*
+-   Our list of standard elastic widths as _snaps_
 
-For typical humans, our options will *snap* to the closest match in our
+For typical humans, our options will _snap_ to the closest match in our
 list and behave just like Approach A (with a list option).
 
 For dolls and giants, the option will revert to the parametric value and

--- a/markdown/dev/reference/api/config/options/pct/snap/en.md
+++ b/markdown/dev/reference/api/config/options/pct/snap/en.md
@@ -12,12 +12,12 @@ is found.
 
 Your snapped percentage option should be a plain object with these properties:
 
--   `pct` : The default percentage
--   `min` : The minimum percentage that's allowed
--   `max` : The maximum percentage that's allowed
--   `snap`: Holds the snap configuration (see [Snap configuration](#))
--   `toAbs`: a method returning the **millimeter value** of the option ([see `toAbs()`][toabs])
--   `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
+- `pct` : The default percentage
+- `min` : The minimum percentage that's allowed
+- `max` : The maximum percentage that's allowed
+- `snap`: Holds the snap configuration (see [Snap configuration](#))
+- `toAbs`: a method returning the **millimeter value** of the option ([see `toAbs()`][toabs])
+- `hide` <small>(optional)</small> : A method to [control the optional display of the option][hide]
 
 ## Snap configuration
 
@@ -150,8 +150,8 @@ our solution does not scale.
 We combine approaches A and B and configure a snapped percentage option
 with:
 
--   A percentage based on `waistToFloor`
--   Our list of standard elastic widths as _snaps_
+- A percentage based on `waistToFloor`
+- Our list of standard elastic widths as _snaps_
 
 For typical humans, our options will _snap_ to the closest match in our
 list and behave just like Approach A (with a list option).
@@ -165,19 +165,19 @@ Sweet!
 
 Before we wade into the details, let's first agree on terminology:
 
--   The **percentage value** is the page passed by the user for the option.
-    Its value always represents a percentage.
--   The **millimeter value** is the result of feeding the **percentage value** to
-    the `toAbs()` method. Its value always represents millimeters.
--   The **snap values** are the values provided by the snap confguration.
-    Each of the values always represents millimeters.
+- The **percentage value** is the page passed by the user for the option.
+  Its value always represents a percentage.
+- The **millimeter value** is the result of feeding the **percentage value** to
+  the `toAbs()` method. Its value always represents millimeters.
+- The **snap values** are the values provided by the snap confguration.
+  Each of the values always represents millimeters.
 
 Under the hood, and snapped percentage option will:
 
--   Use `toAbs()` to calculate the **millimeter value** from the **percentage value**
--   See whether the **millimeter value** approaches one of the **snap values**
--   If so, use the snap value (in millimeter) as provided by one of the **snap values**
--   If not, use the **millimeter value** as-is
+- Use `toAbs()` to calculate the **millimeter value** from the **percentage value**
+- See whether the **millimeter value** approaches one of the **snap values**
+- If so, use the snap value (in millimeter) as provided by one of the **snap values**
+- If not, use the **millimeter value** as-is
 
 If you're head's spinning, here's an image that will hopefully clarify things a bit:
 
@@ -200,12 +200,12 @@ snapping, just as it would in a normal percentage option.
 
 This system results in the best of both worlds:
 
--   Things like elastic widths and so on can be configured to be fixed values,
-    of common elastic widths for example
--   The absolute value will still scale up and down, but will snap to the closest
-    fixed value when appropriate.
--   When the input measurements go somewhere the designer did not anticipate,
-    the option will just behave as a regular percentage option
+- Things like elastic widths and so on can be configured to be fixed values,
+  of common elastic widths for example
+- The absolute value will still scale up and down, but will snap to the closest
+  fixed value when appropriate.
+- When the input measurements go somewhere the designer did not anticipate,
+  the option will just behave as a regular percentage option
 
 ## Using snapped percentage options in your pattern code
 

--- a/markdown/dev/reference/api/config/ui/department/en.md
+++ b/markdown/dev/reference/api/config/ui/department/en.md
@@ -8,7 +8,7 @@ department: "menswear",
 
 One of the following:
 
--   menswear
--   womenswear
--   unisex
--   accessories
+- menswear
+- womenswear
+- unisex
+- accessories

--- a/markdown/dev/reference/api/config/ui/optiongroups/advanced-option-group/en.md
+++ b/markdown/dev/reference/api/config/ui/optiongroups/advanced-option-group/en.md
@@ -3,7 +3,7 @@ title: The advanced option group
 ---
 
 Naming an option group `advanced` will hide it by default from the user
-unless they enable *expert mode*.
+unless they enable _expert mode_.
 
 ```js
 optionGroups: {

--- a/markdown/dev/reference/api/config/ui/type/en.md
+++ b/markdown/dev/reference/api/config/ui/type/en.md
@@ -8,5 +8,5 @@ type: "pattern",
 
 One of the following:
 
--   pattern
--   block
+- pattern
+- block

--- a/markdown/dev/reference/api/design/en.md
+++ b/markdown/dev/reference/api/design/en.md
@@ -19,10 +19,10 @@ function freesewing.Design(
 This constructor creates a new pattern design.
 It takes the following arguments:
 
--   `config` : The pattern configuration
--   `plugins` : Either a [plugin object](/guides/plugins/), or an array of plugin objects
--   `conditionalPlugins` : Either a [conditional plugin object](/guides/plugins/conditionally-loading-build-time-plugins/), or an array
-    of conditional plugin objects to (conditionally) load in your pattern
+- `config` : The pattern configuration
+- `plugins` : Either a [plugin object](/guides/plugins/), or an array of plugin objects
+- `conditionalPlugins` : Either a [conditional plugin object](/guides/plugins/conditionally-loading-build-time-plugins/), or an array
+  of conditional plugin objects to (conditionally) load in your pattern
 
 ```js
 import freesewing from "@freesewing/core"

--- a/markdown/dev/reference/api/design/en.md
+++ b/markdown/dev/reference/api/design/en.md
@@ -35,7 +35,7 @@ const Sorcha = new freesewing.Design(config, plugins)
 
 <Tip>
 
-This method is a *super-constructor*. It will return a constructor
+This method is a _super-constructor_. It will return a constructor
 method that will become the default export of your design and
 should be called to instantiate your pattern.
 

--- a/markdown/dev/reference/api/en.md
+++ b/markdown/dev/reference/api/en.md
@@ -25,7 +25,7 @@ please refer to our [pattern design tutorial](/tutorials/pattern-design/)
 
 The `@freesewing/core` default export is a single object with the following properties:
 
--   `Design`: The [Design constructor](/reference/api/design/) to create a new design
+- `Design`: The [Design constructor](/reference/api/design/) to create a new design
 
 <Note>
 
@@ -34,9 +34,9 @@ The other constructors and utilities below are exported to facilitate unit testi
 
 </Note>
 
--   `Path`: The [Path constructor](/reference/api/path) to create a new path
--   `Pattern`: The [Pattern constructor](/reference/api/pattern) to create a new pattern
--   `Point`: The [Point constructor](/reference/api/point) to create a new point
--   `Snippet`: The [Snippet constructor](/reference/api/snippet) to create a new snippet
--   `utils`: A collection of [utilities](/reference/api/utils)
--   `version`: A string containing the `@freesewing/core` version number
+- `Path`: The [Path constructor](/reference/api/path) to create a new path
+- `Pattern`: The [Pattern constructor](/reference/api/pattern) to create a new pattern
+- `Point`: The [Point constructor](/reference/api/point) to create a new point
+- `Snippet`: The [Snippet constructor](/reference/api/snippet) to create a new snippet
+- `utils`: A collection of [utilities](/reference/api/utils)
+- `version`: A string containing the `@freesewing/core` version number

--- a/markdown/dev/reference/api/hooks/en.md
+++ b/markdown/dev/reference/api/hooks/en.md
@@ -9,8 +9,8 @@ A **hook** is a lifecycle event.
 You can register a method for a hook. When the hook is triggered, your method will be
 called. It will receive two parameters:
 
--   An object relevant to the hook (see the specific hook for details)
--   Data passed when the hook was registered (optional)
+- An object relevant to the hook (see the specific hook for details)
+- Data passed when the hook was registered (optional)
 
 Below is a list of all available hooks:
 

--- a/markdown/dev/reference/api/hooks/inserttext/en.md
+++ b/markdown/dev/reference/api/hooks/inserttext/en.md
@@ -17,7 +17,7 @@ in [our i18n plugin](/reference/plugins/i18n/).
 
 ## Understanding the insertText hook
 
-When we say that *this hook is called when text is about to be inserted*, that is a simplified view.
+When we say that _this hook is called when text is about to be inserted_, that is a simplified view.
 In reality, this hook is called:
 
 -   For every value set on data-text

--- a/markdown/dev/reference/api/hooks/inserttext/en.md
+++ b/markdown/dev/reference/api/hooks/inserttext/en.md
@@ -6,8 +6,8 @@ The `insertText` hook is called when text is about to be inserted during renderi
 
 Methods attached to the `insertText` hook will receive 2 parameters:
 
--   `locale` : The language code of the language requested by the user (defaults to `en`)
--   `text`: The text to be inserted
+- `locale` : The language code of the language requested by the user (defaults to `en`)
+- `text`: The text to be inserted
 
 Unlike most hooks that receive an object that you can make changes to,
 for this hook you need to return a string.
@@ -20,8 +20,8 @@ in [our i18n plugin](/reference/plugins/i18n/).
 When we say that _this hook is called when text is about to be inserted_, that is a simplified view.
 In reality, this hook is called:
 
--   For every value set on data-text
--   For the combined result of these values, joined together with spaces
+- For every value set on data-text
+- For the combined result of these values, joined together with spaces
 
 Let's use an example to clarify things:
 
@@ -33,9 +33,9 @@ points.example
 
 For the example point above, the `insertText` hook will end up being called 3 times:
 
--   First it will pass `seamAllowance` to the plugin
--   Then it will pass `: 1cm` to the plugin
--   Finally it will pass `seamAllowance : 1cm` to the plugin
+- First it will pass `seamAllowance` to the plugin
+- Then it will pass `: 1cm` to the plugin
+- Finally it will pass `seamAllowance : 1cm` to the plugin
 
 Having the `insertText` hook only run once with `Seam allowance: 1cm` would be problematic because
 the seam allowance may differ, or perhaps we're using imperial units, and so on.

--- a/markdown/dev/reference/api/hooks/postsample/en.md
+++ b/markdown/dev/reference/api/hooks/postsample/en.md
@@ -7,9 +7,9 @@ Your plugin will receive the Pattern object.
 
 It is triggered just before the end of either:
 
--   the [Pattern.sampleOption()](/reference/api/pattern/#sampleoption) method
--   the [Pattern.sampleMeasurement()](/reference/api/pattern/#samplemeasurement) method
--   the [Pattern.sampleModels()](/reference/api/pattern/#samplemodels) method
+- the [Pattern.sampleOption()](/reference/api/pattern/#sampleoption) method
+- the [Pattern.sampleMeasurement()](/reference/api/pattern/#samplemeasurement) method
+- the [Pattern.sampleModels()](/reference/api/pattern/#samplemodels) method
 
 <Note>
 

--- a/markdown/dev/reference/api/hooks/presample/en.md
+++ b/markdown/dev/reference/api/hooks/presample/en.md
@@ -6,9 +6,9 @@ The `preSample` hook runs just before your pattern is sampled.
 
 It is triggered at the very start of either:
 
--   the [Pattern.sampleOption()](/reference/api/pattern/#sampleoption) method
--   the [Pattern.sampleMeasurement()](/reference/api/pattern/#samplemeasurement) method
--   the [Pattern.sampleModels()](/reference/api/pattern/#samplemodels) method
+- the [Pattern.sampleOption()](/reference/api/pattern/#sampleoption) method
+- the [Pattern.sampleMeasurement()](/reference/api/pattern/#samplemeasurement) method
+- the [Pattern.sampleModels()](/reference/api/pattern/#samplemodels) method
 
 Your plugin will receive the Pattern object.
 

--- a/markdown/dev/reference/api/macros/bartack/en.md
+++ b/markdown/dev/reference/api/macros/bartack/en.md
@@ -2,7 +2,7 @@
 title: bartack
 ---
 
-The `bartack` macro allows you to add a *bartack* marker to your sewing pattern.
+The `bartack` macro allows you to add a _bartack_ marker to your sewing pattern.
 It is provided by the [bartack plugin](/reference/plugins/bartack/).
 
 <Example part="plugin_bartack">

--- a/markdown/dev/reference/api/macros/bartackalong/en.md
+++ b/markdown/dev/reference/api/macros/bartackalong/en.md
@@ -2,7 +2,7 @@
 title: bartackAlong
 ---
 
-The `bartackAlong` macro allows you to add a *bartack* marker to your sewing pattern.
+The `bartackAlong` macro allows you to add a _bartack_ marker to your sewing pattern.
 More specifically, a bartack along a path.
 It is provided by the [bartack plugin](/reference/plugins/bartack/).
 

--- a/markdown/dev/reference/api/macros/bartackfractionalong/en.md
+++ b/markdown/dev/reference/api/macros/bartackfractionalong/en.md
@@ -2,7 +2,7 @@
 title: bartackFractionAlong
 ---
 
-The `bartackFractionAlong` macro allows you to add a *bartack* marker to your sewing pattern.
+The `bartackFractionAlong` macro allows you to add a _bartack_ marker to your sewing pattern.
 More specifically, a bartack along a fraction of a path.
 It is provided by the [bartack plugin](/reference/plugins/bartack/).
 

--- a/markdown/dev/reference/api/macros/cutonfold/en.md
+++ b/markdown/dev/reference/api/macros/cutonfold/en.md
@@ -2,7 +2,7 @@
 title: cutonfold
 ---
 
-The `cutonfold` macro adds a *cut on fold* indicator to your pattern.\
+The `cutonfold` macro adds a _cut on fold_ indicator to your pattern.\
 It is provided by the [cutonfold plugin](/reference/plugins/cutonfold).
 
 <Example part="plugin_cutonfold">
@@ -19,8 +19,8 @@ macro('cutonfold', {
 
 | Property    | Default | Type                | Description |
 |------------:|---------|---------------------|-------------|
-| `from`      |         | [Point](/reference/api/point) | The startpoint of the *cut on fold* indicator |
-| `to`        |         | [Point](/reference/api/point) | The endpoint of the *cut on fold* indicator |
+| `from`      |         | [Point](/reference/api/point) | The startpoint of the _cut on fold_ indicator |
+| `to`        |         | [Point](/reference/api/point) | The endpoint of the _cut on fold_ indicator |
 | `margin`    | 5       | [Point](/reference/api/point) | The distance in % to keep from the start/end edge |
 | `offset`    | 15      | Number              | The distance in mm to offset from the line from start to end |
 | `grainline` | `false` | Boolean             | Whether this cutonfold indicator is also the grainline |

--- a/markdown/dev/reference/api/macros/flip/en.md
+++ b/markdown/dev/reference/api/macros/flip/en.md
@@ -19,8 +19,8 @@ macro("flip", {
 
 Under the hood, this macro will:
 
--   Go through all Points in your Part, and multiply their (X or Y)-coordinate by -1
--   Go through all the Paths in your Part, and for each drawing operation will multiply the (X or Y)-coordinare by -1
--   Go through all the Snippets in your Part and multiply the (X or Y)-coordinate of the anchor point by -1
+- Go through all Points in your Part, and multiply their (X or Y)-coordinate by -1
+- Go through all the Paths in your Part, and for each drawing operation will multiply the (X or Y)-coordinare by -1
+- Go through all the Snippets in your Part and multiply the (X or Y)-coordinate of the anchor point by -1
 
 </Note>

--- a/markdown/dev/reference/api/macros/gore/en.md
+++ b/markdown/dev/reference/api/macros/gore/en.md
@@ -22,7 +22,7 @@ macro("gore", {
 |--------------:|---------|------------|----------------------------------------------|
 | `from`        |         | [Point][2] | The point to start drafting the gore from |
 | `radius`      |         | number     | The radius of the sphere the gores should cover |
-| `gores`       |         | number     | The text to put on the *grainline* indicator |
+| `gores`       |         | number     | The text to put on the _grainline_ indicator |
 | `extraLength` |         | number     | The length of the straight section after a complete semisphere |
 | `render`      | `false` | boolean    | Whether or not to render the generated path |
 | `class`       |         | boolean    | Any classes to add to the generated path |

--- a/markdown/dev/reference/api/macros/grainline/en.md
+++ b/markdown/dev/reference/api/macros/grainline/en.md
@@ -2,7 +2,7 @@
 title: grainline
 ---
 
-The `grainline` macro adds a *grainline* indicator to your pattern.\
+The `grainline` macro adds a _grainline_ indicator to your pattern.\
 It is provided by the [grainline plugin](/reference/plugins/grainline/).
 
 <Example part="plugin_grainline">
@@ -18,8 +18,8 @@ macro("grainline", {
 
 | Property    | Default     | Type       | Description                                  |
 |------------:|-------------|------------|----------------------------------------------|
-| `from`      |             | [Point][1] | The startpoint of the *grainline* indicator  |
-| `to`        |             | [Point][1] | The endpoint of the *grainline* indicator    |
-| `text`      | 'grainline' | string     | The text to put on the *grainline* indicator |
+| `from`      |             | [Point][1] | The startpoint of the _grainline_ indicator  |
+| `to`        |             | [Point][1] | The endpoint of the _grainline_ indicator    |
+| `text`      | 'grainline' | string     | The text to put on the _grainline_ indicator |
 
 [1]: /reference/api/point

--- a/markdown/dev/reference/api/macros/hd/en.md
+++ b/markdown/dev/reference/api/macros/hd/en.md
@@ -31,7 +31,7 @@ macro('hd', {
 
 Setting a custom ID will:
 
--   Allow removal of the dimension with [the `rmd` macro](/reference/macros/rmd)
--   Prevent removal of the dimension with [the `rmad` macro](/reference/macros/rmad/)
+- Allow removal of the dimension with [the `rmd` macro](/reference/macros/rmd)
+- Prevent removal of the dimension with [the `rmad` macro](/reference/macros/rmad/)
 
 </Note>

--- a/markdown/dev/reference/api/macros/hd/en.md
+++ b/markdown/dev/reference/api/macros/hd/en.md
@@ -2,7 +2,7 @@
 title: hd
 ---
 
-The `hd` macro adds a *horizontal dimension* to your pattern.\
+The `hd` macro adds a _horizontal dimension_ to your pattern.\
 It is provided by the [dimension plugin](/reference/plugins/dimension/).
 
 <Example part="point_dx">

--- a/markdown/dev/reference/api/macros/ld/en.md
+++ b/markdown/dev/reference/api/macros/ld/en.md
@@ -2,7 +2,7 @@
 title: ld
 ---
 
-The `ld` macro adds a *linear dimension* to your pattern.\
+The `ld` macro adds a _linear dimension_ to your pattern.\
 It is provided by the [dimension plugin](/reference/plugins/dimension/).
 
 <Example part="point_dist">

--- a/markdown/dev/reference/api/macros/ld/en.md
+++ b/markdown/dev/reference/api/macros/ld/en.md
@@ -31,7 +31,7 @@ macro('ld', {
 
 Setting a custom ID will:
 
--   Allow removal of the dimension with [the `rmd` macro](/reference/macros/rmd)
--   Prevent removal of the dimension with [the `rmad` macro](/reference/macros/rmad/)
+- Allow removal of the dimension with [the `rmd` macro](/reference/macros/rmd)
+- Prevent removal of the dimension with [the `rmad` macro](/reference/macros/rmad/)
 
 </Note>

--- a/markdown/dev/reference/api/macros/miniscale/en.md
+++ b/markdown/dev/reference/api/macros/miniscale/en.md
@@ -2,7 +2,7 @@
 title: miniscale
 ---
 
-The `miniscale` macro adds a mini *scale box* to your pattern. This box allows
+The `miniscale` macro adds a mini _scale box_ to your pattern. This box allows
 users to verify their pattern is printed to scale.
 
 The `miniscale` macro is provided by the [scalebox plugin](/reference/plugins/scalebox).
@@ -20,5 +20,5 @@ macro('miniscale', {
 
 | Property    | Default | Type                | Description |
 |-------------|---------|---------------------|-------------|
-| `at`        |         | [Point](/reference/api/point) | The point to anchor the *scale box* on |
+| `at`        |         | [Point](/reference/api/point) | The point to anchor the _scale box_ on |
 | `rotate`    | 0       | Number              | Rotation in degrees |

--- a/markdown/dev/reference/api/macros/mirror/en.md
+++ b/markdown/dev/reference/api/macros/mirror/en.md
@@ -35,7 +35,7 @@ macro('sprinkle', {
 
 | Property     | Default    | Type       | Description |
 |-------------:|------------|------------|-------------|
-| `mirror`     |            | `array`    | Array with 2 [Point](/reference/api/point) objects that define the *mirror line* |
+| `mirror`     |            | `array`    | Array with 2 [Point](/reference/api/point) objects that define the _mirror line_ |
 | `clone`      | `true`     | `bool`     | Whether to clone mirrored points and or paths |
 | `points`     |            | `array`    | An array of [Point](/reference/api/point) objects |
 | `paths`      |            | `array`    | An array of [Path](/reference/api/path) objects |

--- a/markdown/dev/reference/api/macros/pd/en.md
+++ b/markdown/dev/reference/api/macros/pd/en.md
@@ -29,7 +29,7 @@ macro('pd', {
 
 Setting a custom ID will:
 
--   Allow removal of the dimension with [the `rmd` macro](/reference/macros/rmd)
--   Prevent removal of the dimension with [the `rmad` macro](/reference/macros/rmad/)
+- Allow removal of the dimension with [the `rmd` macro](/reference/macros/rmd)
+- Prevent removal of the dimension with [the `rmad` macro](/reference/macros/rmad/)
 
 </Note>

--- a/markdown/dev/reference/api/macros/pd/en.md
+++ b/markdown/dev/reference/api/macros/pd/en.md
@@ -2,7 +2,7 @@
 title: pd
 ---
 
-The `pd` macro adds a *path dimension* to your pattern, indicating the length of a path.\
+The `pd` macro adds a _path dimension_ to your pattern, indicating the length of a path.\
 It is provided by the [dimension plugin](/reference/plugins/dimension/).
 
 <Example part="path_length">

--- a/markdown/dev/reference/api/macros/scalebox/en.md
+++ b/markdown/dev/reference/api/macros/scalebox/en.md
@@ -2,7 +2,7 @@
 title: scalebox
 ---
 
-The `scalebox` macro adds a *scale box* to your pattern. This box allows
+The `scalebox` macro adds a _scale box_ to your pattern. This box allows
 users to verify their pattern is printed to scale.
 
 The `scalebox` macro is provided by the [scalebox plugin](/reference/plugins/scalebox).
@@ -19,9 +19,9 @@ macro('scalebox', {
 
 | Property    | Default | Type                | Description |
 |-------------|---------|---------------------|-------------|
-| `at`        |         | [Point](/reference/api/point) | The point to anchor the *scale box* on |
+| `at`        |         | [Point](/reference/api/point) | The point to anchor the _scale box_ on |
 | `lead`      | FreeSewing | String           | The lead text above the title |
-| `title`     | *pattern name + version* | String | The title text |
+| `title`     | _pattern name + version_ | String | The title text |
 | `text`      | (\*)    | String              | The text below the title |
 | `rotate`    | 0       | Number              | Rotation in degrees |
 

--- a/markdown/dev/reference/api/macros/vd/en.md
+++ b/markdown/dev/reference/api/macros/vd/en.md
@@ -31,7 +31,7 @@ macro('vd', {
 
 Setting a custom ID will:
 
--   Allow removal of the dimension with [the `rmd` macro](/reference/macros/rmd)
--   Prevent removal of the dimension with [the `rmad` macro](/reference/macros/rmad/)
+- Allow removal of the dimension with [the `rmd` macro](/reference/macros/rmd)
+- Prevent removal of the dimension with [the `rmad` macro](/reference/macros/rmad/)
 
 </Note>

--- a/markdown/dev/reference/api/macros/vd/en.md
+++ b/markdown/dev/reference/api/macros/vd/en.md
@@ -2,7 +2,7 @@
 title: vd
 ---
 
-The `vd` macro adds a *vertical dimension* to your pattern.\
+The `vd` macro adds a _vertical dimension_ to your pattern.\
 It is provided by the [dimension plugin](/reference/plugins/dimension/).
 
 <Example part="point_dy">

--- a/markdown/dev/reference/api/path/edge/en.md
+++ b/markdown/dev/reference/api/path/edge/en.md
@@ -8,14 +8,14 @@ Point path.edge(string side)
 
 Returns the Point object at the edge of the path you specify. Edge must be one of:
 
--   `top`
--   `bottom`
--   `left`
--   `right`
--   `topLeft`
--   `topRight`
--   `bottomLeft`
--   `bottomRight`
+- `top`
+- `bottom`
+- `left`
+- `right`
+- `topLeft`
+- `topRight`
+- `bottomLeft`
+- `bottomRight`
 
 <Example part="path_edge">
 Example of the Path.edge() method

--- a/markdown/dev/reference/api/path/en.md
+++ b/markdown/dev/reference/api/path/en.md
@@ -13,8 +13,8 @@ Path new Path();
 
 A Path objects comes with the following properties:
 
--   `render` : Set this to `false` to not render the path (exclude it from the output)
--   `attributes` : An [Attributes](/reference/api/attributes) instance holding the path's attributes
+- `render` : Set this to `false` to not render the path (exclude it from the output)
+- `attributes` : An [Attributes](/reference/api/attributes) instance holding the path's attributes
 
 In addition, a Path object exposes the following methods:
 

--- a/markdown/dev/reference/api/path/shiftalong/en.md
+++ b/markdown/dev/reference/api/path/shiftalong/en.md
@@ -45,7 +45,7 @@ snippets.x2 = new Snippet("notch", points.x2);
 
 ##### The second parameter is optional
 
-The second parameter controls the precision by which the path will be *walked*.
+The second parameter controls the precision by which the path will be _walked_.
 By default, we'll divide it into 25 steps per mm.
 
 If you don't need that precision, you can pass a lower number.

--- a/markdown/dev/reference/api/path/shiftfractionalong/en.md
+++ b/markdown/dev/reference/api/path/shiftfractionalong/en.md
@@ -45,7 +45,7 @@ snippets.x2 = new Snippet("notch", points.x2);
 
 ##### The second parameter is optional
 
-The second parameter controls the precision by which the path will be *walked*.
+The second parameter controls the precision by which the path will be _walked_.
 By default, we'll divide it into 25 steps per mm.
 
 If you don't need that precision, you can pass a lower number.

--- a/markdown/dev/reference/api/path/trim/en.md
+++ b/markdown/dev/reference/api/path/trim/en.md
@@ -19,9 +19,9 @@ it on a long/complex path will be significant.
 
 To limit the impact of path.trim(), follow this approach:
 
--   construct a minimal path that contains the overlap
--   trim it
--   now join it to the rest of your path
+- construct a minimal path that contains the overlap
+- trim it
+- now join it to the rest of your path
 
 You can see an example of this
 [in the front part of the Bruce pattern](https://github.com/freesewing/freesewing/blob/develop/packages/bruce/src/front.js#L195).

--- a/markdown/dev/reference/api/pattern/en.md
+++ b/markdown/dev/reference/api/pattern/en.md
@@ -20,14 +20,14 @@ Refer to the [settings documentation](/reference/api/settings/) for an exhaustiv
 
 ## Pattern properties
 
--   `settings` : The settings as set by the user
--   `options` : the options as set by the user
--   `config` : The pattern configuration
--   `parts` : A plain object to hold your parts
--   `Part` : The [Part](/reference/api/part) constructor
--   `store` : A [Store](/reference/api/store) instance
--   `svg` : An [Svg](/reference/api/svg) instance
--   `is` : A string that will be set to `draft` or `sample` when you respectively draft or sample a pattern. This allows plugins that hook into your pattern to determine what to do in a given scenario.
+- `settings` : The settings as set by the user
+- `options` : the options as set by the user
+- `config` : The pattern configuration
+- `parts` : A plain object to hold your parts
+- `Part` : The [Part](/reference/api/part) constructor
+- `store` : A [Store](/reference/api/store) instance
+- `svg` : An [Svg](/reference/api/svg) instance
+- `is` : A string that will be set to `draft` or `sample` when you respectively draft or sample a pattern. This allows plugins that hook into your pattern to determine what to do in a given scenario.
 
 ## Pattern methods
 

--- a/markdown/dev/reference/api/pattern/sample/en.md
+++ b/markdown/dev/reference/api/pattern/sample/en.md
@@ -2,7 +2,7 @@
 title: Pattern.sample()
 ---
 
-A pattern's `sample()` method will *sample* the pattern which means
+A pattern's `sample()` method will _sample_ the pattern which means
 to draft it in different iterations while adjusting the input settings.
 Under the hood, this method will call one of
 [Pattern.sampleOption()](/reference/apu/pattern/sampleoption),

--- a/markdown/dev/reference/api/pattern/sample/en.md
+++ b/markdown/dev/reference/api/pattern/sample/en.md
@@ -16,16 +16,16 @@ object to determine what to do.
 
 The possiblities are:
 
--   **type**: One of `option`, `measurement`, or `models`
--   **option**: An option name as defined in the pattern config file (only used when `type` is option).
--   **measurement**: A measurement name as defined in the pattern config file (only used when `type` is measurement).
--   **models**: An array of models with the required measurements for this pattern (only used when `type` is models).
+- **type**: One of `option`, `measurement`, or `models`
+- **option**: An option name as defined in the pattern config file (only used when `type` is option).
+- **measurement**: A measurement name as defined in the pattern config file (only used when `type` is measurement).
+- **models**: An array of models with the required measurements for this pattern (only used when `type` is models).
 
 See the specific sample methods below for more details:
 
--   [Pattern.sampleOption()](/reference/apu/pattern/sampleoption)
--   [Pattern.sampleMeasurement()](/reference/apu/pattern/sampleoption)
--   [Pattern.sampleModels()](/reference/apu/pattern/sampleoption)
+- [Pattern.sampleOption()](/reference/apu/pattern/sampleoption)
+- [Pattern.sampleMeasurement()](/reference/apu/pattern/sampleoption)
+- [Pattern.sampleModels()](/reference/apu/pattern/sampleoption)
 
 From a lifecycle point of view, the `Pattern.sample()` method is a substitute for
 `Pattern.draft()`. So you call it after instantiating the pattern, prior to

--- a/markdown/dev/reference/api/pattern/samplemeasurement/en.md
+++ b/markdown/dev/reference/api/pattern/samplemeasurement/en.md
@@ -2,7 +2,7 @@
 title: Pattern.sampleMeasurement()
 ---
 
-A pattern's `sampleMeasurement()` method will *sample* a given measurement,
+A pattern's `sampleMeasurement()` method will _sample_ a given measurement,
 which means to draft it in different iterations while adjusting the input value
 of the given measurement.
 In practice, it will draft 10 iterations of the pattern

--- a/markdown/dev/reference/api/pattern/samplemodels/en.md
+++ b/markdown/dev/reference/api/pattern/samplemodels/en.md
@@ -2,7 +2,7 @@
 title: Pattern.sampleModels()
 ---
 
-A pattern's `sampleModels()` method will *sample* a pattern for a list of
+A pattern's `sampleModels()` method will _sample_ a pattern for a list of
 models you pass to it. It will draft different iterations of the pattern,
 using the measurements for each model you pass to it.
 
@@ -51,7 +51,7 @@ The (optional) string you can pass as the second parameter should hold the
 key of one of the models in the first parameter. In our example above, it
 could hold `modelName2` for example.
 
-By passing this second parameter, you can put the *focus* on one of the models,
+By passing this second parameter, you can put the _focus_ on one of the models,
 which will influence the render style, and make it
 easier to see a comparison between a given set of measrurements, and the rest.
 

--- a/markdown/dev/reference/api/pattern/sampleoption/en.md
+++ b/markdown/dev/reference/api/pattern/sampleoption/en.md
@@ -7,9 +7,9 @@ which means to draft it in different iterations while adjusting the input value
 of the given option.
 The practical implementation varies based on [the type of option](/config/options/):
 
--   For options that are an object with a **min** and **max** property, 10 steps will be sampled, between min and max
--   For options that are a numeric value (**constants**), 10 steps will be sampled between 90% and 110% of the value
--   For options with a **list** of options, each option in the list will be sampled
+- For options that are an object with a **min** and **max** property, 10 steps will be sampled, between min and max
+- For options that are a numeric value (**constants**), 10 steps will be sampled between 90% and 110% of the value
+- For options with a **list** of options, each option in the list will be sampled
 
 <Tip>
 The goal of option sampling is to verify the impact of an option on the pattern, and verify that

--- a/markdown/dev/reference/api/pattern/sampleoption/en.md
+++ b/markdown/dev/reference/api/pattern/sampleoption/en.md
@@ -2,7 +2,7 @@
 title: Pattern.sampleOption()
 ---
 
-A pattern's `sampleOption()` method will *sample* a given option,
+A pattern's `sampleOption()` method will _sample_ a given option,
 which means to draft it in different iterations while adjusting the input value
 of the given option.
 The practical implementation varies based on [the type of option](/config/options/):

--- a/markdown/dev/reference/api/point/copy/en.md
+++ b/markdown/dev/reference/api/point/copy/en.md
@@ -3,7 +3,7 @@ title: Point.copy()
 ---
 
 A point's `copy()` method returns a new point with the same coordinates as the original point.
-This method does *not* copy any attributes the original point may have.
+This method does _not_ copy any attributes the original point may have.
 
 ## Point.copy() signature
 

--- a/markdown/dev/reference/api/point/en.md
+++ b/markdown/dev/reference/api/point/en.md
@@ -7,14 +7,14 @@ A Point object represents a point on a 2D plane with an X and Y axis.
 
 Point objects come with the following properties:
 
--   `x` : The X-coordinate of the point
--   `y` : The Y-coordinate of the point
--   `attributes` : An [Attributes](../attributes) instance holding the point's attributes
+- `x` : The X-coordinate of the point
+- `y` : The Y-coordinate of the point
+- `attributes` : An [Attributes](../attributes) instance holding the point's attributes
 
 The point constructor takes two arguments:
 
--   `x` : The X-coordinate of the point
--   `y` : The Y-coordinate of the point
+- `x` : The X-coordinate of the point
+- `y` : The Y-coordinate of the point
 
 ```js
 Point new Point(x, y);

--- a/markdown/dev/reference/api/point/sitson/en.md
+++ b/markdown/dev/reference/api/point/sitson/en.md
@@ -2,13 +2,13 @@
 title: Point.sitsOn()
 ---
 
-Returns `true` if this point has the *exact* same coordinates as the point you pass to it.
+Returns `true` if this point has the _exact_ same coordinates as the point you pass to it.
 
 <Note>
 
 ###### Too exact?
 
-This method is *very* precise, so points with an X-coordinate of `10` and `10.0001`
+This method is _very_ precise, so points with an X-coordinate of `10` and `10.0001`
 are considered to be different.
 
 To check if two points have the same coordinates rounded to the nearest

--- a/markdown/dev/reference/api/point/translate/en.md
+++ b/markdown/dev/reference/api/point/translate/en.md
@@ -12,8 +12,8 @@ Point point.translate(float deltaX, float deltaY)
 
 In other words, this will:
 
--   Add `deltaX` to the point's X-coordinate
--   Add `deltaY` to the point's Y-coordinate
+- Add `deltaX` to the point's X-coordinate
+- Add `deltaY` to the point's Y-coordinate
 
 Positive values for `deltaX` will move the point to the right. Positive values for `deltaY` will move the point downwards.
 

--- a/markdown/dev/reference/api/settings/layout/en.md
+++ b/markdown/dev/reference/api/settings/layout/en.md
@@ -5,9 +5,9 @@ title: layout
 The `layout` setting allows you to control the way pattern parts are
 layed out on the pattern. There are 3 scenarios:
 
--   layout is truthy: Do layout algorithmically
--   layout is falsy: Do not do any layout apart from stacking all parts together
--   layout is an object: Layout the parts as detailed in the layout object
+- layout is truthy: Do layout algorithmically
+- layout is falsy: Do not do any layout apart from stacking all parts together
+- layout is an object: Layout the parts as detailed in the layout object
 
 Let's look at each in detail:
 
@@ -57,10 +57,10 @@ let pattern = new brian({
 
 For each part in the `parts` attribute of our layout object, there are 4 possible attributes:
 
--   move: Expects an object with an `x` and `y` property, and will move the part by `x` along the X-axis and by `y` along the Y-axis
--   rotate: Expects a number, and will rotate the part by number degrees around its center point
--   flipX: Will flip/mirror the part horizontally
--   flipY: Will flip/mirror the part vertically
+- move: Expects an object with an `x` and `y` property, and will move the part by `x` along the X-axis and by `y` along the Y-axis
+- rotate: Expects a number, and will rotate the part by number degrees around its center point
+- flipX: Will flip/mirror the part horizontally
+- flipY: Will flip/mirror the part vertically
 
 <Related>
 

--- a/markdown/dev/reference/api/settings/margin/en.md
+++ b/markdown/dev/reference/api/settings/margin/en.md
@@ -7,8 +7,8 @@ Each part will have this margin applied. The default is `2mm`.
 
 This means that:
 
--   At the edge of the SVG, the margin will be `margin * 1` (2mm by default)
--   Between parts, the margin will be `margin * 2` (4mm by default)
+- At the edge of the SVG, the margin will be `margin * 1` (2mm by default)
+- Between parts, the margin will be `margin * 2` (4mm by default)
 
 Note that setting the margin to zero (or below) will cause parts to overlap.
 

--- a/markdown/dev/reference/api/snippet/en.md
+++ b/markdown/dev/reference/api/snippet/en.md
@@ -8,8 +8,8 @@ SVG `defs` section, and rendered with the SVG `use` tag.
 
 The snippet constructor takes two arguments:
 
--   `def` : The `xlink:href` id that links to the relevant entry in the SVG `defs` section
--   `anchor` : A [`Point`](#point) on which to anchor the snippet
+- `def` : The `xlink:href` id that links to the relevant entry in the SVG `defs` section
+- `anchor` : A [`Point`](#point) on which to anchor the snippet
 
 ```js
 Snippet new Snippet(def, Point);
@@ -17,9 +17,9 @@ Snippet new Snippet(def, Point);
 
 A Snippet object comes with the following properties:
 
--   `def` : The `xlink:href` id that links to the relevant entry in the SVG `defs` section
--   `anchor` : A [`Point`](../point) on which to anchor the snippet
--   `attributes` : An [`Attributes`](../attributes) instance holding the snippet's attributes
+- `def` : The `xlink:href` id that links to the relevant entry in the SVG `defs` section
+- `anchor` : A [`Point`](../point) on which to anchor the snippet
+- `attributes` : An [`Attributes`](../attributes) instance holding the snippet's attributes
 
 In addition, a Snippet object exposes the following methods:
 

--- a/markdown/dev/reference/api/snippets/buttonhole-end/en.md
+++ b/markdown/dev/reference/api/snippets/buttonhole-end/en.md
@@ -19,8 +19,8 @@ An example of the buttonhole-end snippet
 
 We provide three buttonhole snippets with a different alignment:
 
--   [buttonhole](/reference/snippets/buttonhole/): Anchor point is the middle of the buttonhole
--   [buttonhole-start](/reference/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
--   [buttonhole-end](/reference/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
+- [buttonhole](/reference/snippets/buttonhole/): Anchor point is the middle of the buttonhole
+- [buttonhole-start](/reference/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
+- [buttonhole-end](/reference/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
 
 </Note>

--- a/markdown/dev/reference/api/snippets/buttonhole-start/en.md
+++ b/markdown/dev/reference/api/snippets/buttonhole-start/en.md
@@ -19,8 +19,8 @@ An example of the buttonhole-start snippet
 
 We provide three buttonhole snippets with a different alignment:
 
--   [buttonhole](/reference/snippets/buttonhole/): Anchor point is the middle of the buttonhole
--   [buttonhole-start](/reference/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
--   [buttonhole-end](/reference/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
+- [buttonhole](/reference/snippets/buttonhole/): Anchor point is the middle of the buttonhole
+- [buttonhole-start](/reference/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
+- [buttonhole-end](/reference/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
 
 </Note>

--- a/markdown/dev/reference/api/snippets/buttonhole/en.md
+++ b/markdown/dev/reference/api/snippets/buttonhole/en.md
@@ -19,8 +19,8 @@ An example of the buttonhole snippet
 
 We provide three buttonhole snippets with a different alignment:
 
--   [buttonhole](/reference/snippets/buttonhole/): Anchor point is the middle of the buttonhole
--   [buttonhole-start](/reference/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
--   [buttonhole-end](/reference/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
+- [buttonhole](/reference/snippets/buttonhole/): Anchor point is the middle of the buttonhole
+- [buttonhole-start](/reference/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
+- [buttonhole-end](/reference/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
 
 </Note>

--- a/markdown/dev/reference/api/utils/beamintersectscircle/en.md
+++ b/markdown/dev/reference/api/utils/beamintersectscircle/en.md
@@ -15,7 +15,7 @@ array | false utils.beamIntersectsCircle(
 Finds the intersection between an endless line through points `point1` and `point2`
 and a circle with its center at point `center` and a radius of `radius` mm.
 
-The 5th and last parameter controls the *sorting* of the found intersections.
+The 5th and last parameter controls the _sorting_ of the found intersections.
 This will (almost) always return 2 intersections, and you can choose how
 they are ordered in the returned array:
 

--- a/markdown/dev/reference/api/utils/beamintersectscircle/en.md
+++ b/markdown/dev/reference/api/utils/beamintersectscircle/en.md
@@ -21,8 +21,8 @@ they are ordered in the returned array:
 
 Set sort to:
 
--   `x` : The point with the lowest X-coordinate will go first (left to right)
--   `y` : The point with the lowest Y-coordinate will go first (top to bottom)
+- `x` : The point with the lowest X-coordinate will go first (left to right)
+- `y` : The point with the lowest Y-coordinate will go first (top to bottom)
 
 <Example part="utils_beamintersectscircle">
 A Utils.beamIntersectsCircle() example

--- a/markdown/dev/reference/api/utils/circlesintersect/en.md
+++ b/markdown/dev/reference/api/utils/circlesintersect/en.md
@@ -14,7 +14,7 @@ array | false utils.circlesIntersect(
 
 Finds the intersections between two circles described by their center point and radius.
 
-The 5th and last parameter controls the *sorting* of the found intersections.
+The 5th and last parameter controls the _sorting_ of the found intersections.
 When this returns 2 intersections, you can choose how they are ordered in the returned array:
 
 Set sort to:

--- a/markdown/dev/reference/api/utils/circlesintersect/en.md
+++ b/markdown/dev/reference/api/utils/circlesintersect/en.md
@@ -19,8 +19,8 @@ When this returns 2 intersections, you can choose how they are ordered in the re
 
 Set sort to:
 
--   `x` : The point with the lowest X-coordinate will go first (left to right)
--   `y` : The point with the lowest Y-coordinate will go first (top to bottom)
+- `x` : The point with the lowest X-coordinate will go first (left to right)
+- `y` : The point with the lowest Y-coordinate will go first (top to bottom)
 
 <Example part="utils_circlesintersect">
 A Utils.circlesIntersect() example

--- a/markdown/dev/reference/api/utils/lineintersectscircle/en.md
+++ b/markdown/dev/reference/api/utils/lineintersectscircle/en.md
@@ -15,7 +15,7 @@ array | false utils.lineIntersectsCircle(
 Finds the intersection between a line segment from point `from` to point `to`
 and a circle with its center at point `center` and a radius of `radius` mm.
 
-The 5th and last parameter controls the *sorting* of the found intersections.
+The 5th and last parameter controls the _sorting_ of the found intersections.
 When this returns 2 intersections, you can choose how they are ordered in the returned array:
 
 Set sort to:

--- a/markdown/dev/reference/api/utils/lineintersectscircle/en.md
+++ b/markdown/dev/reference/api/utils/lineintersectscircle/en.md
@@ -20,8 +20,8 @@ When this returns 2 intersections, you can choose how they are ordered in the re
 
 Set sort to:
 
--   `x` : The point with the lowest X-coordinate will go first (left to right)
--   `y` : The point with the lowest Y-coordinate will go first (top to bottom)
+- `x` : The point with the lowest X-coordinate will go first (left to right)
+- `y` : The point with the lowest Y-coordinate will go first (top to bottom)
 
 <Example part="utils_lineintersectscircle">
 A Utils.lineIntersectsCircle() example

--- a/markdown/dev/reference/api/utils/round/en.md
+++ b/markdown/dev/reference/api/utils/round/en.md
@@ -8,5 +8,5 @@ float utils.round(float value)
 
 Rounds a value to two decimals. For example:
 
--   0.1234 becomes 0.12
--   5.6789 becomes 5.68
+- 0.1234 becomes 0.12
+- 5.6789 becomes 5.68

--- a/markdown/dev/reference/api/utils/stretchtoscale/en.md
+++ b/markdown/dev/reference/api/utils/stretchtoscale/en.md
@@ -8,7 +8,7 @@ float utils.stretchToScale(float stretch)
 
 The way people measure stretch intuitively is different from the way we handle stretch in code.
 
-When people say *25% stretch* they mean that 10cm fabric gets stretched to 12.5cm fabric.
+When people say _25% stretch_ they mean that 10cm fabric gets stretched to 12.5cm fabric.
 In code and on our patterns, that means we need to scale things by 80%.
 
 This method does that by returning:

--- a/markdown/dev/reference/measurements/en.md
+++ b/markdown/dev/reference/measurements/en.md
@@ -5,55 +5,55 @@ title: Measurements
 Below is the complete list of measurements currently used by
 the designs we maintain:
 
--   `ankle`
--   `biceps`
--   `bustFront`
--   `bustPointToUnderbust`
--   `bustSpan`
--   `chest`
--   `crossSeam`
--   `crossSeamFront`
--   `crotchDepth`
--   `head`
--   `heel`
--   `highBust`
--   `highBustFront`
--   `hips`
--   `hpsToBust`
--   `hpsToWaistBack`
--   `hpsToWaistFront`
--   `inseam`
--   `knee`
--   `neck`
--   `seat`
--   `seatBack`
--   `shoulderSlope`
--   `shoulderToElbow`
--   `shoulderToShoulder`
--   `shoulderToWrist`
--   `underbust`
--   `upperLeg`
--   `waist`
--   `waistBack`
--   `waistToFloor`
--   `waistToHips`
--   `waistToKnee`
--   `waistToSeat`
--   `waistToUnderbust`
--   `waistToUpperLeg`
--   `wrist`
+- `ankle`
+- `biceps`
+- `bustFront`
+- `bustPointToUnderbust`
+- `bustSpan`
+- `chest`
+- `crossSeam`
+- `crossSeamFront`
+- `crotchDepth`
+- `head`
+- `heel`
+- `highBust`
+- `highBustFront`
+- `hips`
+- `hpsToBust`
+- `hpsToWaistBack`
+- `hpsToWaistFront`
+- `inseam`
+- `knee`
+- `neck`
+- `seat`
+- `seatBack`
+- `shoulderSlope`
+- `shoulderToElbow`
+- `shoulderToShoulder`
+- `shoulderToWrist`
+- `underbust`
+- `upperLeg`
+- `waist`
+- `waistBack`
+- `waistToFloor`
+- `waistToHips`
+- `waistToKnee`
+- `waistToSeat`
+- `waistToUnderbust`
+- `waistToUpperLeg`
+- `wrist`
 
 In addition, the [@freesewing/plugin-measurements](/reference/plugins/measurements) plugin
 will add the following measurements when the measurements they are derived
 from are provided:
 
--   `seatFront` (if both `seat` and `seatBack` are provided)
--   `seatBackArc` (if both `seat` and `seatBack` are provided)
--   `seatFrontArc` (if both `seat` and `seatBack` are provided)
--   `waistFront` (if both `waist` and `waistBack` are provided)
--   `waistBackArc` (if both `waist` and `waistBack` are provided)
--   `waistFrontArc` (if both `waist` and `waistBack` are provided)
--   `crossSeamBack` (if both `crossSeam` and `crossSeamFront` are available)
+- `seatFront` (if both `seat` and `seatBack` are provided)
+- `seatBackArc` (if both `seat` and `seatBack` are provided)
+- `seatFrontArc` (if both `seat` and `seatBack` are provided)
+- `waistFront` (if both `waist` and `waistBack` are provided)
+- `waistBackArc` (if both `waist` and `waistBack` are provided)
+- `waistFrontArc` (if both `waist` and `waistBack` are provided)
+- `crossSeamBack` (if both `crossSeam` and `crossSeamFront` are available)
 
 <Tip>
 

--- a/markdown/dev/reference/plugins/bundle/en.md
+++ b/markdown/dev/reference/plugins/bundle/en.md
@@ -4,14 +4,14 @@ title: "@freesewing/plugin-bundle"
 
 The **@freesewing/plugin-bundle** plugin bundles the most common FreeSewing build-time plugins:
 
--   [plugin-cutonfold](/reference/plugins/cutonfold) : Add cut-on-fold indicators to your patterns
--   [plugin-dimension](/reference/plugins/dimension) : Add dimensions to your (paperless) patterns
--   [plugin-grainline](/reference/plugins/grainline) : Add grainline indicators to your patterns
--   [plugin-logo](/reference/plugins/logo) : Add a scalebox to your patterns
--   [plugin-scalebox](/reference/plugins/scalebox) : Add pretty titles to your pattern parts
--   [plugin-title](/reference/plugins/title) : Add pretty titles to your pattern parts
--   [plugin-round](/reference/plugins/round) : Rounds corners
--   [plugin-sprinkle](/reference/plugins/sprinkle) : Add multiple snippets to your pattern
+- [plugin-cutonfold](/reference/plugins/cutonfold) : Add cut-on-fold indicators to your patterns
+- [plugin-dimension](/reference/plugins/dimension) : Add dimensions to your (paperless) patterns
+- [plugin-grainline](/reference/plugins/grainline) : Add grainline indicators to your patterns
+- [plugin-logo](/reference/plugins/logo) : Add a scalebox to your patterns
+- [plugin-scalebox](/reference/plugins/scalebox) : Add pretty titles to your pattern parts
+- [plugin-title](/reference/plugins/title) : Add pretty titles to your pattern parts
+- [plugin-round](/reference/plugins/round) : Rounds corners
+- [plugin-sprinkle](/reference/plugins/sprinkle) : Add multiple snippets to your pattern
 
 Almost all patterns use these plugins, so it made sense to bundle them.
 

--- a/markdown/dev/reference/plugins/bust/en.md
+++ b/markdown/dev/reference/plugins/bust/en.md
@@ -20,8 +20,8 @@ This is the same technique that's used in a full-bust adjustment to fit a womens
 
 This plugin helps you by:
 
--   Storing the chest circumference in `measurements.bust`
--   Changing `measurments.chestCircumference` to the value of `measurements.highBust`
+- Storing the chest circumference in `measurements.bust`
+- Changing `measurments.chestCircumference` to the value of `measurements.highBust`
 
 </Note>
 
@@ -47,8 +47,8 @@ To learn more about extending a pattern, see [Design inheritance](/howtos/code/i
 To create a truly gender-neutral pattern — one that will adapt to breasts only if they are
 present — you can use this plugin, but you'll also need a few other things:
 
--   You'll need to mark the breast measurements as [optional measurements](/reference/api/config/optionalmeasurements)
--   You'll need to [conditionally load this plugin](/guides/plugins/conditionally-loading-build-time-plugins)
+- You'll need to mark the breast measurements as [optional measurements](/reference/api/config/optionalmeasurements)
+- You'll need to [conditionally load this plugin](/guides/plugins/conditionally-loading-build-time-plugins)
 
 You can see an example of this in [our Teagan design][3].
 

--- a/markdown/dev/reference/plugins/buttons/en.md
+++ b/markdown/dev/reference/plugins/buttons/en.md
@@ -4,12 +4,12 @@ title: "@freesewing/plugin-buttons"
 
 The **@freesewing/plugin-buttons** plugin provides the following [snippets](/reference/api/snippets):
 
--   [button](/reference/api/snippets/button)
--   [buttonhole](/reference/api/snippets/buttonhole)
--   [buttonhole-start](/reference/api/snippets/buttonhole-start)
--   [buttonhole-end](/reference/api/snippets/buttonhole-end)
--   [snap-stud](/reference/api/snippets/snap-stud)
--   [snap-socket](/reference/api/snippets/snap-socket)
+- [button](/reference/api/snippets/button)
+- [buttonhole](/reference/api/snippets/buttonhole)
+- [buttonhole-start](/reference/api/snippets/buttonhole-start)
+- [buttonhole-end](/reference/api/snippets/buttonhole-end)
+- [snap-stud](/reference/api/snippets/snap-stud)
+- [snap-socket](/reference/api/snippets/snap-socket)
 
 <Example part="plugin_buttons">
 An example of the button, buttonhole, buttonhole-start, buttonhole-end, snap-stud, and snap-socket snippets

--- a/markdown/dev/reference/plugins/dimension/en.md
+++ b/markdown/dev/reference/plugins/dimension/en.md
@@ -9,12 +9,12 @@ in [paperless mode](/reference/api/settings/paperless).
 
 The following macors are provided by this plugin:
 
--   [hd](/reference/api/macros/hd) : Adds a horizontal dimension
--   [vd](/reference/api/macros/vd) : Adds a vertical dimension
--   [ld](/reference/api/macros/ld) : Adds a linear dimension
--   [pd](/reference/api/macros/pd) : Adds a dimension along a path
--   [rmd](/reference/api/macros/rmd) : Removes a dimension
--   [rmad](/reference/api/macros/rmad) : Removes all dimensions with a default prefix
+- [hd](/reference/api/macros/hd) : Adds a horizontal dimension
+- [vd](/reference/api/macros/vd) : Adds a vertical dimension
+- [ld](/reference/api/macros/ld) : Adds a linear dimension
+- [pd](/reference/api/macros/pd) : Adds a dimension along a path
+- [rmd](/reference/api/macros/rmd) : Removes a dimension
+- [rmad](/reference/api/macros/rmad) : Removes all dimensions with a default prefix
 
 <Example part="plugin_dimension">
 

--- a/markdown/dev/reference/plugins/dimension/en.md
+++ b/markdown/dev/reference/plugins/dimension/en.md
@@ -3,7 +3,7 @@ title: "@freesewing/plugin-dimension"
 ---
 
 The **@freesewing/plugin-dimension** plugin provides a variety of macros
-to facilitate adding *dimensions* to your design. By *dimensions* we mean
+to facilitate adding _dimensions_ to your design. By _dimensions_ we mean
 the indicators for distance that are added to patterns
 in [paperless mode](/reference/api/settings/paperless).
 

--- a/markdown/dev/reference/plugins/grainline/en.md
+++ b/markdown/dev/reference/plugins/grainline/en.md
@@ -3,7 +3,7 @@ title: "@freesewing/plugin-grainline"
 ---
 
 The **@freesewing/plugin-grainline** plugin provides [the grainline
-macro](/reference/macros/grainline/) which adds a *grainline* indicator
+macro](/reference/macros/grainline/) which adds a _grainline_ indicator
 to your design.
 
 <Example part="plugin_grainline">An example of the grainline macro</Example>

--- a/markdown/dev/reference/plugins/measurements/en.md
+++ b/markdown/dev/reference/plugins/measurements/en.md
@@ -9,13 +9,13 @@ they can be deduced from the measurements that are provided.
 
 It will add the following measurements:
 
--   `seatFront` (if both `seat` and `seatBack` are provided)
--   `seatBackArc` (if both `seat` and `seatBack` are provided)
--   `seatFrontArc` (if both `seat` and `seatBack` are provided)
--   `waistFront` (if both `waist` and `waistBack` are provided)
--   `waistBackArc` (if both `waist` and `waistBack` are provided)
--   `waistFrontArc` (if both `waist` and `waistBack` are provided)
--   `crossSeamBack` (if both `crossSeam` and `crossSeamFront` are available)
+- `seatFront` (if both `seat` and `seatBack` are provided)
+- `seatBackArc` (if both `seat` and `seatBack` are provided)
+- `seatFrontArc` (if both `seat` and `seatBack` are provided)
+- `waistFront` (if both `waist` and `waistBack` are provided)
+- `waistBackArc` (if both `waist` and `waistBack` are provided)
+- `waistFrontArc` (if both `waist` and `waistBack` are provided)
+- `crossSeamBack` (if both `crossSeam` and `crossSeamFront` are available)
 
 ## Installation
 

--- a/markdown/dev/reference/plugins/notches/en.md
+++ b/markdown/dev/reference/plugins/notches/en.md
@@ -4,8 +4,8 @@ title: "@freesewing/plugin-notches"
 
 The **@freesewing/plugin-notces** plugin provides the following [snippets](/reference/api/snippets):
 
--   [notch](/reference/api/snippets/notch)
--   [bnotch](/reference/api/snippets/bnotch)
+- [notch](/reference/api/snippets/notch)
+- [bnotch](/reference/api/snippets/bnotch)
 
 <Example part="plugin_notches">
 An example of the button, buttonhole, buttonhole-start, buttonhole-end, snap-stud, and snap-socket snippets

--- a/markdown/dev/reference/plugins/sprinkle/en.md
+++ b/markdown/dev/reference/plugins/sprinkle/en.md
@@ -5,7 +5,7 @@ title: "@freesewing/plugin-sprinkle"
 The **@freesewing/plugin-sprinkle** plugin provides [the
 sprinkle macro](/reference/api/macros/sprinkle/) which is a faster way
 to add several of the same snippets to your designs (think of it as
-*sprinkling* them onto your parts).
+_sprinkling_ them onto your parts).
 
 <Example part="plugin_sprinkle">An example of the sprinkle macro</Example>
 

--- a/markdown/dev/reference/terms/commit/en.md
+++ b/markdown/dev/reference/terms/commit/en.md
@@ -4,4 +4,4 @@ title: Commit
 
 A [commit](https://github.com/git-guides/git-commit) is made every time somebody publishes an update to our source code.
 
-The word is also used as a verb as in *to commit changes*.
+The word is also used as a verb as in _to commit changes_.

--- a/markdown/dev/reference/terms/discord/en.md
+++ b/markdown/dev/reference/terms/discord/en.md
@@ -4,4 +4,4 @@ title: Discord
 
 The name of our chat provider that powers our chat at https://discord.freesewing.org/
 
-When you hear *discord* just think *chat*.
+When you hear _discord_ just think _chat_.

--- a/markdown/dev/reference/terms/freesewing.org/en.md
+++ b/markdown/dev/reference/terms/freesewing.org/en.md
@@ -19,7 +19,7 @@ built with Gatsby.
 
 ## i18n
 
-Short of *internationalisation*. within the context of FreeSewing, this mostly
+Short of _internationalisation_. within the context of FreeSewing, this mostly
 means translation, but can also relate to other intenationalisation concerns such
 as the type of units to use, or paper sizes, and so on.
 

--- a/markdown/dev/reference/terms/i18n/en.md
+++ b/markdown/dev/reference/terms/i18n/en.md
@@ -2,6 +2,6 @@
 title: i18n
 ---
 
-Short for *internationalisation*. Within the context of FreeSewing, this mostly
+Short for _internationalisation_. Within the context of FreeSewing, this mostly
 means translation, but can also relate to other internationalisation concerns such
 as the type of units to use, or paper sizes, and so on.

--- a/markdown/dev/tutorials/getting-started-linux/create-freesewing-pattern/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/create-freesewing-pattern/en.md
@@ -17,14 +17,14 @@ You can change all of these later. It's just to get you started.
 If you're not sure what to fill in, you can stick with the defaults or leave them blank.
 Only a few of these are mandatory.
 
--   **Language**: Use the arrow keys to chose the language of your choice
--   **Pattern name**: This will be the name of your pattern, but also the name of the folder we'll setup for you. If you're just kicking the tires, something like `test` will do you fine.
--   **description**: A description of your pattern. It's not mandatory.
--   **Pattern type**: Use the arrow keys to chose either `block` or `pattern`. Choose `pattern` if you're not sure what to pick
--   **department**: Use the arrow keys to pick a department like `tops`, `bottoms` or `accessories`. This is is only relevant if you decide to publish your pattern later. But by that time you will have learned how to change this.
--   **Author**: You can enter your name, or leave this blank for now
--   **GitHub repository**: You can leave this blank for now
--   **Package manager**: Choose either `npm` or `yarn` as your package manager. If you're not sure, pick `npm`.
+- **Language**: Use the arrow keys to chose the language of your choice
+- **Pattern name**: This will be the name of your pattern, but also the name of the folder we'll setup for you. If you're just kicking the tires, something like `test` will do you fine.
+- **description**: A description of your pattern. It's not mandatory.
+- **Pattern type**: Use the arrow keys to chose either `block` or `pattern`. Choose `pattern` if you're not sure what to pick
+- **department**: Use the arrow keys to pick a department like `tops`, `bottoms` or `accessories`. This is is only relevant if you decide to publish your pattern later. But by that time you will have learned how to change this.
+- **Author**: You can enter your name, or leave this blank for now
+- **GitHub repository**: You can leave this blank for now
+- **Package manager**: Choose either `npm` or `yarn` as your package manager. If you're not sure, pick `npm`.
 
 When you've answered all questions, the command will download the development enviroment,
 and set it up based on the choices you made.

--- a/markdown/dev/tutorials/getting-started-linux/installing-nvm/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/installing-nvm/en.md
@@ -11,8 +11,8 @@ use [nvm](https://github.com/nvm-sh/nvm), short for _Node version manager_.
 Using nvm has a number of benefits in comparison with installing Node from
 the node.js website, or from a package provided by your linux distribution:
 
--   You can easily switch between different Node versions
--   Everything gets installed in your home folder, avoiding permission problems
+- You can easily switch between different Node versions
+- Everything gets installed in your home folder, avoiding permission problems
 
 To setup nvm, run the following command in a terminal:
 

--- a/markdown/dev/tutorials/getting-started-linux/installing-nvm/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/installing-nvm/en.md
@@ -6,7 +6,7 @@ order: 10
 FreeSewing is built with [Node.js](https://nodejs.org/), a JavaScript runtime.
 
 You'll need to install Node JS on your system, and to do so, we'll
-use [nvm](https://github.com/nvm-sh/nvm), short for *Node version manager*.
+use [nvm](https://github.com/nvm-sh/nvm), short for _Node version manager_.
 
 Using nvm has a number of benefits in comparison with installing Node from
 the node.js website, or from a package provided by your linux distribution:

--- a/markdown/dev/tutorials/getting-started-linux/node-versions/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/node-versions/en.md
@@ -18,7 +18,7 @@ nvm ls
 ```
 
 It will show you a list of local node versions.
-Either the version number, or an *alias* that points to a specific version.
+Either the version number, or an _alias_ that points to a specific version.
 You should see the `lts/*` alias in the list which is what we've just installed.
 
 ### nvm ls-remote

--- a/markdown/dev/tutorials/getting-started-linux/start-development-environment/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/start-development-environment/en.md
@@ -8,9 +8,9 @@ If you chose `test`, you will have a `test` folder. If you chose `banana`, you'l
 
 If you enter that folder, you'll find a couple of subfolders:
 
--   `config` holds your pattern's configuration file
--   `src` holds your pattern's source code
--   `example` holds the development environment
+- `config` holds your pattern's configuration file
+- `src` holds your pattern's source code
+- `example` holds the development environment
 
 To start the development environment, enter the `example` folder and run: `npm run start` (or `yarn start` if you're using Yarn as a package manager.
 
@@ -24,6 +24,6 @@ the pattern's source code. When you do, it will update automatically in your bro
 All you have to do now, is design your pattern.
 Thankfully, we have a tutorial for that too:
 
--   [Pattern design tutorial](/tutorials/pattern-design/): A step-by-step guide to designing your first pattern
+- [Pattern design tutorial](/tutorials/pattern-design/): A step-by-step guide to designing your first pattern
 
 </Note>

--- a/markdown/dev/tutorials/getting-started-mac/create-freesewing-pattern/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/create-freesewing-pattern/en.md
@@ -17,14 +17,14 @@ You can change all of these later. It's just to get you started.
 If you're not sure what to fill in, you can stick with the defaults or leave them blank.
 Only a few of these are mandatory.
 
--   **Language**: Use the arrow keys to chose the language of your choice
--   **Pattern name**: This will be the name of your pattern, but also the name of the folder we'll setup for you. If you're just kicking the tires, something like `test` will do you fine.
--   **description**: A description of your pattern. It's not mandatory.
--   **Pattern type**: Use the arrow keys to chose either `block` or `pattern`. Choose `pattern` if you're not sure what to pick
--   **department**: Use the arrow keys to pick a department like `tops`, `bottoms` or `accessories`. This is is only relevant if you decide to publish your pattern later. But by that time you will have learned how to change this.
--   **Author**: You can enter your name, or leave this blank for now
--   **GitHub repository**: You can leave this blank for now
--   **Package manager**: Choose either `npm` or `yarn` as your package manager. If you're not sure, pick `npm`.
+- **Language**: Use the arrow keys to chose the language of your choice
+- **Pattern name**: This will be the name of your pattern, but also the name of the folder we'll setup for you. If you're just kicking the tires, something like `test` will do you fine.
+- **description**: A description of your pattern. It's not mandatory.
+- **Pattern type**: Use the arrow keys to chose either `block` or `pattern`. Choose `pattern` if you're not sure what to pick
+- **department**: Use the arrow keys to pick a department like `tops`, `bottoms` or `accessories`. This is is only relevant if you decide to publish your pattern later. But by that time you will have learned how to change this.
+- **Author**: You can enter your name, or leave this blank for now
+- **GitHub repository**: You can leave this blank for now
+- **Package manager**: Choose either `npm` or `yarn` as your package manager. If you're not sure, pick `npm`.
 
 When you've answered all questions, the command will download the development enviroment,
 and set it up based on the choices you made.

--- a/markdown/dev/tutorials/getting-started-mac/installing-nvm/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/installing-nvm/en.md
@@ -11,8 +11,8 @@ use [nvm](https://github.com/nvm-sh/nvm), short for _Node version manager_.
 Using nvm has a number of benefits in comparison with installing Node from
 the node.js website, or from a package provided by Homebrew or your OS distribution:
 
--   You can easily switch between different Node versions
--   Everything gets installed in your home folder, avoiding permission problems
+- You can easily switch between different Node versions
+- Everything gets installed in your home folder, avoiding permission problems
 
 The latest instructions for setting up nvm can be found [here](https://github.com/nvm-sh/nvm#installing-and-updating). If you want to just skip to the commands that most likely work, keep reading.
 

--- a/markdown/dev/tutorials/getting-started-mac/installing-nvm/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/installing-nvm/en.md
@@ -6,7 +6,7 @@ order: 20
 FreeSewing is built with [Node.js](https://nodejs.org/), a JavaScript runtime.
 
 You'll need to install Node JS on your system, and to do so, we'll
-use [nvm](https://github.com/nvm-sh/nvm), short for *Node version manager*.
+use [nvm](https://github.com/nvm-sh/nvm), short for _Node version manager_.
 
 Using nvm has a number of benefits in comparison with installing Node from
 the node.js website, or from a package provided by Homebrew or your OS distribution:

--- a/markdown/dev/tutorials/getting-started-mac/installing-xcode/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/installing-xcode/en.md
@@ -4,7 +4,7 @@ order: 10
 ---
 
 Before we can get started, we need some basic tools for development.
-They are bundled in the *Xcode command-line tools* so let's install
+They are bundled in the _Xcode command-line tools_ so let's install
 that first.
 
 Open the Terminal application, and type the following command:

--- a/markdown/dev/tutorials/getting-started-mac/node-versions/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/node-versions/en.md
@@ -18,7 +18,7 @@ nvm ls
 ```
 
 It will show you a list of local node versions.
-Either the version number, or an *alias* that points to a specific version.
+Either the version number, or an _alias_ that points to a specific version.
 You should see the `lts/*` alias in the list which is what we've just installed.
 
 ### nvm ls-remote

--- a/markdown/dev/tutorials/getting-started-mac/start-development-environment/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/start-development-environment/en.md
@@ -8,9 +8,9 @@ If you chose `test`, you will have a `test` folder. If you chose `banana`, you'l
 
 If you enter that folder, you'll find a couple of subfolders:
 
--   `config` holds your pattern's configuration file
--   `src` holds your pattern's source code
--   `example` holds the development environment
+- `config` holds your pattern's configuration file
+- `src` holds your pattern's source code
+- `example` holds the development environment
 
 To start the development environment, enter the `example` folder and run: `npm run start` (or `yarn start` if you're using Yarn as a package manager.
 
@@ -24,6 +24,6 @@ the pattern's source code. When you do, it will update automatically in your bro
 All you have to do now, is design your pattern.
 Thankfully, we have a tutorial for that too:
 
--   [Pattern design tutorial](/tutorials/pattern-design/): A step-by-step guide to designing your first pattern
+- [Pattern design tutorial](/tutorials/pattern-design/): A step-by-step guide to designing your first pattern
 
 </Note>

--- a/markdown/dev/tutorials/getting-started-windows/en.md
+++ b/markdown/dev/tutorials/getting-started-windows/en.md
@@ -83,14 +83,14 @@ If you've chosen to use VSCode as your IDE open VSCode, and inside VSCode open t
 
 This script will prompt you for certain options. Only "Pattern name" is mandatory, the other prompts are optional and/or suggest sensible defaults. You can change all of these later. It's just to get you started. If you're not sure what to fill in you can stick with the defaults or leave them blank.
 
--   **Language**: Use the arrow keys to chose the language of your choice
--   **Pattern name**: This will be the name of your pattern, but also the name of the folder we'll setup for you. If you're just kicking the tires, something like `test` will do you fine.
--   **description**: A description of your pattern. It's not mandatory.
--   **Pattern type**: Use the arrow keys to chose either `block` or `pattern`. Choose `pattern` if you're not sure what to pick.
--   **department**: Use the arrow keys to pick a department like `menswear`, `womenswear` or `accessories`. This is is only relevant if you decide to publish your pattern later. But by that time you will have learned how to change this.
--   **Author**: You can enter your name, or leave this blank for now.
--   **GitHub repository**: You can leave this blank for now.
--   **Package manager**: Choose either `npm` or `yarn` as your package manager. If you're not sure, pick `npm`.
+- **Language**: Use the arrow keys to chose the language of your choice
+- **Pattern name**: This will be the name of your pattern, but also the name of the folder we'll setup for you. If you're just kicking the tires, something like `test` will do you fine.
+- **description**: A description of your pattern. It's not mandatory.
+- **Pattern type**: Use the arrow keys to chose either `block` or `pattern`. Choose `pattern` if you're not sure what to pick.
+- **department**: Use the arrow keys to pick a department like `menswear`, `womenswear` or `accessories`. This is is only relevant if you decide to publish your pattern later. But by that time you will have learned how to change this.
+- **Author**: You can enter your name, or leave this blank for now.
+- **GitHub repository**: You can leave this blank for now.
+- **Package manager**: Choose either `npm` or `yarn` as your package manager. If you're not sure, pick `npm`.
 
 ### Start the development environment (WSL)
 
@@ -124,14 +124,14 @@ Open a terminal, then navigate to the folder you wish to contain the pattern (e.
 
 This script will prompt you for certain options. Only "Pattern name" is mandatory, the other prompts are optional and/or suggest sensible defaults. You can change all of these later. It's just to get you started. If you're not sure what to fill in you can stick with the defaults or leave them blank.
 
--   **Language**: Use the arrow keys to chose the language of your choice
--   **Pattern name**: This will be the name of your pattern, but also the name of the folder we'll setup for you. If you're just kicking the tires, something like `test` will do you fine.
--   **description**: A description of your pattern. It's not mandatory.
--   **Pattern type**: Use the arrow keys to chose either `block` or `pattern`. Choose `pattern` if you're not sure what to pick.
--   **department**: Use the arrow keys to pick a department like `tops`, `bottoms` or `accessories`. This is is only relevant if you decide to publish your pattern later. But by that time you will have learned how to change this.
--   **Author**: You can enter your name, or leave this blank for now.
--   **GitHub repository**: You can leave this blank for now.
--   **Package manager**: Choose either `npm` or `yarn` as your package manager. If you're not sure, pick `npm`.
+- **Language**: Use the arrow keys to chose the language of your choice
+- **Pattern name**: This will be the name of your pattern, but also the name of the folder we'll setup for you. If you're just kicking the tires, something like `test` will do you fine.
+- **description**: A description of your pattern. It's not mandatory.
+- **Pattern type**: Use the arrow keys to chose either `block` or `pattern`. Choose `pattern` if you're not sure what to pick.
+- **department**: Use the arrow keys to pick a department like `tops`, `bottoms` or `accessories`. This is is only relevant if you decide to publish your pattern later. But by that time you will have learned how to change this.
+- **Author**: You can enter your name, or leave this blank for now.
+- **GitHub repository**: You can leave this blank for now.
+- **Package manager**: Choose either `npm` or `yarn` as your package manager. If you're not sure, pick `npm`.
 
 ### Start the development environment
 

--- a/markdown/dev/tutorials/pattern-design/adding-measurements/en.md
+++ b/markdown/dev/tutorials/pattern-design/adding-measurements/en.md
@@ -3,13 +3,13 @@ title: Adding measurements
 order: 130
 ---
 
-FreeSewing is all about *made-to-measure* sewing patterns;
+FreeSewing is all about _made-to-measure_ sewing patterns;
 we are going to draft our pattern according to the measurements provided to us.
 
 Which begs the question, which measurements?
 
 It is you, as the pattern designer, who decides which measurements are required to draft your pattern.
-For our bib, the only measurement we need is the baby's *head circumference*.
+For our bib, the only measurement we need is the baby's _head circumference_.
 
 So let's add it as a required measurement.
 

--- a/markdown/dev/tutorials/pattern-design/adding-options/en.md
+++ b/markdown/dev/tutorials/pattern-design/adding-options/en.md
@@ -3,7 +3,7 @@ title: Adding options
 order: 140
 ---
 
-You know what your bib should look like, and you have the *head* measurement
+You know what your bib should look like, and you have the _head_ measurement
 to work with. But there's still a number of choices you have to make:
 
 -   How large should the neck opening be?

--- a/markdown/dev/tutorials/pattern-design/adding-options/en.md
+++ b/markdown/dev/tutorials/pattern-design/adding-options/en.md
@@ -6,9 +6,9 @@ order: 140
 You know what your bib should look like, and you have the _head_ measurement
 to work with. But there's still a number of choices you have to make:
 
--   How large should the neck opening be?
--   How wide should the bib be?
--   How long should the bib be?
+- How large should the neck opening be?
+- How wide should the bib be?
+- How long should the bib be?
 
 You can make all of these choices for the user and set them in stone, so to speak.
 
@@ -33,10 +33,10 @@ Open the config file at `config/index.js` and add this to the options:
 
 Can you guess what it means?
 
--   We've added a option of type percentage
--   Its minimum value is 70%
--   Its maximum value is 90%
--   Its default value is 80%
+- We've added a option of type percentage
+- Its minimum value is 70%
+- Its maximum value is 90%
+- Its default value is 80%
 
 <Note>
 
@@ -55,9 +55,9 @@ options: {
 }
 ```
 
--   You've added `widthRatio` and `lengthRatio` options
--   You've given all options sensible defaults
--   You've given all options sensible maximum and minimum boundaries
+- You've added `widthRatio` and `lengthRatio` options
+- You've given all options sensible defaults
+- You've given all options sensible maximum and minimum boundaries
 
 <Note>
 

--- a/markdown/dev/tutorials/pattern-design/completing-your-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/completing-your-pattern/en.md
@@ -22,8 +22,8 @@ export default function(part) {
 }
 ```
 
-So far, we've kept to the *// Design pattern here* area, but now we're going to work on
-the area under *// Complete?*
+So far, we've kept to the _// Design pattern here_ area, but now we're going to work on
+the area under _// Complete?_
 
 <Note>
 
@@ -122,7 +122,7 @@ However, for future refefence, `sa` is a variable that you can get from `part.sh
 just like `complete`. But instead of `true` or `false` it will hold the amount of seam allowance
 in mm.
 
-Note that you can still do `if (sa)` because zero is *falsy*.
+Note that you can still do `if (sa)` because zero is _falsy_.
 
 We won't be adding seam allowance, but we will be doing something that is essentially the same.
 Rather than draw an outline outside our bib to indicate the seam allowance, we'll draw one within
@@ -170,10 +170,10 @@ points.scalebox = points.title.shift(-90, 55)
 macro("scalebox", { at: points.scalebox })
 ```
 
-And with that, our pattern is now *complete*:
+And with that, our pattern is now _complete_:
 
 <Example pattern="tutorial" part="step11">
 We used attributes to add color, dashes, text on a path and even opacity
 </Example>
 
-We're not done yet though. There's one more thing the user can ask for: a *paperless* pattern.
+We're not done yet though. There's one more thing the user can ask for: a _paperless_ pattern.

--- a/markdown/dev/tutorials/pattern-design/conclusion/en.md
+++ b/markdown/dev/tutorials/pattern-design/conclusion/en.md
@@ -6,26 +6,26 @@ order: 280
 Congratulations, you have created your first pattern. And while it's arguably rather simple,
 you have learned a bunch of things along the way. Let's list some of the things you've learned:
 
--   You learned how to [setup your development environment](/tutorials/pattern-design/create-freesewing-pattern) with `npx create-freesewing-pattern`
--   You learned how to [add parts](/tutorials/pattern-design/your-first-part), [measurements](/tutorials/pattern-design/adding-measurements), and [options](/tutorials/pattern-design/adding-options) to your pattern's configuration file
--   You learned what [a good boilerplate is to start with a new part](/tutorials/pattern-design/part-structure)
--   You learned [how to add points and draw paths](/tutorials/pattern-design/constructing-the-neck-opening)
--   You learned how you can make changes in a loop to [adapt the neck opening](/tutorials/pattern-design/fitting-the-neck-opening) or [rotate the straps](/tutorials/pattern-design/avoiding-overlap) until they were just right
--   You learned about [macros and how to use them](/tutorials/pattern-design/creating-the-closure)
--   You learned different methods to manipulate [points](/reference/api/point/) and [paths](/reference/api/path/)
--   You learned about using [attributes](/reference/api/attributes/) to influence the appearance of points and paths
--   You learned about what it means to draft [a complete pattern](/tutorials/pattern-design/completing-your-pattern)
--   You learned about [snippets and how to add them](/tutorials/pattern-design/completing-your-pattern#adding-snippets)
--   You learned [how to offset a path](/tutorials/pattern-design/completing-your-pattern#seam-allowance) to create seam allowance, or in our case, mark the bias tape line
--   You learned how to create a [paperless pattern](/tutorials/pattern-design/paperless-bib) by adding dimensions
+- You learned how to [setup your development environment](/tutorials/pattern-design/create-freesewing-pattern) with `npx create-freesewing-pattern`
+- You learned how to [add parts](/tutorials/pattern-design/your-first-part), [measurements](/tutorials/pattern-design/adding-measurements), and [options](/tutorials/pattern-design/adding-options) to your pattern's configuration file
+- You learned what [a good boilerplate is to start with a new part](/tutorials/pattern-design/part-structure)
+- You learned [how to add points and draw paths](/tutorials/pattern-design/constructing-the-neck-opening)
+- You learned how you can make changes in a loop to [adapt the neck opening](/tutorials/pattern-design/fitting-the-neck-opening) or [rotate the straps](/tutorials/pattern-design/avoiding-overlap) until they were just right
+- You learned about [macros and how to use them](/tutorials/pattern-design/creating-the-closure)
+- You learned different methods to manipulate [points](/reference/api/point/) and [paths](/reference/api/path/)
+- You learned about using [attributes](/reference/api/attributes/) to influence the appearance of points and paths
+- You learned about what it means to draft [a complete pattern](/tutorials/pattern-design/completing-your-pattern)
+- You learned about [snippets and how to add them](/tutorials/pattern-design/completing-your-pattern#adding-snippets)
+- You learned [how to offset a path](/tutorials/pattern-design/completing-your-pattern#seam-allowance) to create seam allowance, or in our case, mark the bias tape line
+- You learned how to create a [paperless pattern](/tutorials/pattern-design/paperless-bib) by adding dimensions
 
 You can find the complete code of the tutorial pattern [here on GitHub](https://github.com/freesewing/freesewing/blob/develop/packages/tutorial/src/bib.js).
 
 ## More reading material
 
--   If you haven't done so already, read through [the pattern guide](/guides/patterns/) which provides a good overview of how patterns work under the hood
--   Bookmark [the FreeSewing API docs](/reference/api/), they are your reference every time you're not entirely certain how something works
--   Have a look at [the design guide](/guides/best-practices/) for best practices that will help you make the best possible patterns
+- If you haven't done so already, read through [the pattern guide](/guides/patterns/) which provides a good overview of how patterns work under the hood
+- Bookmark [the FreeSewing API docs](/reference/api/), they are your reference every time you're not entirely certain how something works
+- Have a look at [the design guide](/guides/best-practices/) for best practices that will help you make the best possible patterns
 
 ## What to do next
 

--- a/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
@@ -50,10 +50,10 @@ You've added some points to your part, and drawn your first path. Let's look at 
 points.right = new Point(measurements.head / 10, 0)
 ```
 
--   We're adding a point named `right` to `points` which holds our part's points
--   We're using the Point constructor, which takes two arguments: The point's X and Y values
--   The X value is `measurements.head / 10`
--   The Y value is `0`
+- We're adding a point named `right` to `points` which holds our part's points
+- We're using the Point constructor, which takes two arguments: The point's X and Y values
+- The X value is `measurements.head / 10`
+- The Y value is `0`
 
 The `bottom` part is very similar, so let's skip to the next line:
 
@@ -62,12 +62,12 @@ points.rightCp1 = points.right
   .shift(90, points.bottom.dy(points.right)/2)
 ```
 
--   We're adding a point named `rightCp1`, which will become the _control point_ of the right part
--   Instead of using the Point constructor, we're calling the `Point.shift()` method on an existing point
--   It takes two arguments: The angle to shift towards, and the distance
--   You can see that we're shifting 90 degrees (that means up) but the distance uses another method
--   The `Point.dy()` method returns the delta along the Y axis between the point you call it on and the point you pass it
--   We shift half of the Y-delta
+- We're adding a point named `rightCp1`, which will become the _control point_ of the right part
+- Instead of using the Point constructor, we're calling the `Point.shift()` method on an existing point
+- It takes two arguments: The angle to shift towards, and the distance
+- You can see that we're shifting 90 degrees (that means up) but the distance uses another method
+- The `Point.dy()` method returns the delta along the Y axis between the point you call it on and the point you pass it
+- We shift half of the Y-delta
 
 The next point is very similar again, except that this time we're shifting to the right (0 degrees) for half of
 the X-delta between points `bottom` and `right`.
@@ -87,10 +87,10 @@ paths.quarterNeck = new Path()
   .curve(points.rightCp1, points.bottomCp2, points.bottom)
 ```
 
--   We're adding a path named `quarterNeck` to `paths` which holds our part's paths
--   We're using the Path constructor, which takes no arguments
--   We're following up with a `Path.move()` call that takes one Point as argument
--   Then, there's a `Path.curve()` call that takes 3 points as arguments
+- We're adding a path named `quarterNeck` to `paths` which holds our part's paths
+- We're using the Path constructor, which takes no arguments
+- We're following up with a `Path.move()` call that takes one Point as argument
+- Then, there's a `Path.curve()` call that takes 3 points as arguments
 
 If you've read through the high-level [Pattern guide](/guides/patterns/) you will have learned that paths
 always start with a `move()` operation. In this case, we moved to our `right` points.

--- a/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
@@ -62,7 +62,7 @@ points.rightCp1 = points.right
   .shift(90, points.bottom.dy(points.right)/2)
 ```
 
--   We're adding a point named `rightCp1`, which will become the *control point* of the right part
+-   We're adding a point named `rightCp1`, which will become the _control point_ of the right part
 -   Instead of using the Point constructor, we're calling the `Point.shift()` method on an existing point
 -   It takes two arguments: The angle to shift towards, and the distance
 -   You can see that we're shifting 90 degrees (that means up) but the distance uses another method

--- a/markdown/dev/tutorials/pattern-design/create-freesewing-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/create-freesewing-pattern/en.md
@@ -19,14 +19,14 @@ npx create-freesewing-pattern
 
 This will load a few dependencies, and then ask you the following questions:
 
--   **Language**: Use the arrow keys to select the language of your choice
--   **Pattern name**: Enter `tutorial`
--   **description**: Enter `The FreeSewing tutorial`
--   **Pattern type**: Use the arrow key to select `Pattern`
--   **Department**: Use the arrow keys to select `Accessories`
--   **Author**: Enter your GitHub username
--   **GitHub repository**: This will be prefilled for you, so just hit Enter
--   **Package manager**: Use the arrow to choose. Pick `npm` if you're not sure.
+- **Language**: Use the arrow keys to select the language of your choice
+- **Pattern name**: Enter `tutorial`
+- **description**: Enter `The FreeSewing tutorial`
+- **Pattern type**: Use the arrow key to select `Pattern`
+- **Department**: Use the arrow keys to select `Accessories`
+- **Author**: Enter your GitHub username
+- **GitHub repository**: This will be prefilled for you, so just hit Enter
+- **Package manager**: Use the arrow to choose. Pick `npm` if you're not sure.
 
 After you've answered these questions, the default template will be copied, after which all dependencies will be installed.
 

--- a/markdown/dev/tutorials/pattern-design/drawing-the-straps/en.md
+++ b/markdown/dev/tutorials/pattern-design/drawing-the-straps/en.md
@@ -124,5 +124,5 @@ it doesn't look much different. We'll use some other classes later that will mak
 
 </Note> 
 
-It's looking pretty good. But those sharp corners at the bottom don't exactly say *baby* do they?
+It's looking pretty good. But those sharp corners at the bottom don't exactly say _baby_ do they?
 Let's fix that.

--- a/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
@@ -28,9 +28,9 @@ do {
 
 We've added a few new variables:
 
--   `tweak`: A _tweak factor_ that we'll use to increase or decrease the neck opening by making it more or less than 1
--   `target`: How long our (quarter) neck opening should be
--   `delta`: How far we're off. Positive numbers mean it's too long, negative means too short
+- `tweak`: A _tweak factor_ that we'll use to increase or decrease the neck opening by making it more or less than 1
+- `target`: How long our (quarter) neck opening should be
+- `delta`: How far we're off. Positive numbers mean it's too long, negative means too short
 
 Now that we know what `target` is, we construct our path as we did before.
 But this time around, we multiply our point coordinates with our `tweak` variable (1 at the start).

--- a/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
@@ -3,7 +3,7 @@ title: Fitting the neck opening
 order: 170
 ---
 
-Here's how we'll make sure the neck opening is *just right*:
+Here's how we'll make sure the neck opening is _just right_:
 
 ```js
 let tweak = 1
@@ -28,7 +28,7 @@ do {
 
 We've added a few new variables:
 
--   `tweak`: A *tweak factor* that we'll use to increase or decrease the neck opening by making it more or less than 1
+-   `tweak`: A _tweak factor_ that we'll use to increase or decrease the neck opening by making it more or less than 1
 -   `target`: How long our (quarter) neck opening should be
 -   `delta`: How far we're off. Positive numbers mean it's too long, negative means too short
 

--- a/markdown/dev/tutorials/pattern-design/paperless-bib/en.md
+++ b/markdown/dev/tutorials/pattern-design/paperless-bib/en.md
@@ -25,7 +25,7 @@ let {
 } = part.shorthand()
 ```
 
-The idea behind *paperless patterns* is that users don't need to print your
+The idea behind _paperless patterns_ is that users don't need to print your
 pattern in order to use it.
 Instead, we include dimensions on the pattern that allows them to transfer
 the pattern directly onto fabric, or onto an intermediate medium such as tracing paper.
@@ -81,7 +81,7 @@ if (paperless) {
 }
 ```
 
-There's a lot going on, but it's mostly repetition. To see what that did to your pattern, you have to enable *paperless mode* in your developing environment; you can find the option under *Pattern options* on the right. Let's look at the end result, and discuss:
+There's a lot going on, but it's mostly repetition. To see what that did to your pattern, you have to enable _paperless mode_ in your developing environment; you can find the option under _Pattern options_ on the right. Let's look at the end result, and discuss:
 
 <Example pattern="tutorial" part="bib" settings_paperless="true">
 Your paperless bib

--- a/markdown/dev/tutorials/pattern-design/paperless-bib/en.md
+++ b/markdown/dev/tutorials/pattern-design/paperless-bib/en.md
@@ -36,10 +36,10 @@ markings, depending on the units requested by the user.
 While the grid gets added automatically, the dimensions you have to add yourself.
 Thankfully, there's macros that can help you with that, specifically:
 
--   The `hd` macro adds a horizontal dimension
--   The `vd` macro adds a vertical dimension
--   The `ld` macro adds a linear dimension
--   The `pd` macro adds a path dimension that follows a given path
+- The `hd` macro adds a horizontal dimension
+- The `vd` macro adds a vertical dimension
+- The `ld` macro adds a linear dimension
+- The `pd` macro adds a path dimension that follows a given path
 
 <Note> The documentation, as always, holds [all the information about the macros](/reference/macros/). </Note>
 
@@ -89,8 +89,8 @@ Your paperless bib
 
 We used the `hd` macro to add two horizontal dimensions:
 
--   One at the bottom for the width of our bib
--   One for the width of the neck opening
+- One at the bottom for the width of our bib
+- One for the width of the neck opening
 
 The `hd` macro takes a `from` and `to` point as well as a `y` value that says at what Y-value to draw the dimension.
 

--- a/markdown/dev/tutorials/pattern-design/part-structure/en.md
+++ b/markdown/dev/tutorials/pattern-design/part-structure/en.md
@@ -45,7 +45,7 @@ This is the boilerplate of our `draftBib` method. It takes the part as an argume
 
 <Note>
 
-If you're new to JavaScript, and don't intuitively *get this*, stick with it. It will become second nature soon enough.
+If you're new to JavaScript, and don't intuitively _get this_, stick with it. It will become second nature soon enough.
 
 </Note>
 
@@ -61,7 +61,7 @@ let {
 ```
 
 This is FreeSewing's **shorthand** method. It returns an object with a bunch of handy helpers
-and you use JavaScript's *object destructuring* to only get what you need.
+and you use JavaScript's _object destructuring_ to only get what you need.
 
 The example above makes the following variables available:
 
@@ -75,9 +75,9 @@ These will make it possible for you to draw points and paths easily.
 The following three variables are also needed to create a full-fledged FreeSewing pattern; their function and usage will
 be covered in detail [later on in this tutorial](/tutorials/pattern-design/completing-your-pattern/):
 
--   `complete`: create a *complete* pattern (or not)
--   `sa`: include *seam allowance* (or not)
--   `paperless`: allow the pattern to be *paperless*
+-   `complete`: create a _complete_ pattern (or not)
+-   `sa`: include _seam allowance_ (or not)
+-   `paperless`: allow the pattern to be _paperless_
 
 For now, we only need these so that the pattern skeleton compiles properly.
 

--- a/markdown/dev/tutorials/pattern-design/part-structure/en.md
+++ b/markdown/dev/tutorials/pattern-design/part-structure/en.md
@@ -65,19 +65,19 @@ and you use JavaScript's _object destructuring_ to only get what you need.
 
 The example above makes the following variables available:
 
--   `Point`: The Point constructor
--   `points`: A reference to the part's points
--   `Path`: The Path constructor
--   `paths`: A reference to the part's paths
+- `Point`: The Point constructor
+- `points`: A reference to the part's points
+- `Path`: The Path constructor
+- `paths`: A reference to the part's paths
 
 These will make it possible for you to draw points and paths easily.
 
 The following three variables are also needed to create a full-fledged FreeSewing pattern; their function and usage will
 be covered in detail [later on in this tutorial](/tutorials/pattern-design/completing-your-pattern/):
 
--   `complete`: create a _complete_ pattern (or not)
--   `sa`: include _seam allowance_ (or not)
--   `paperless`: allow the pattern to be _paperless_
+- `complete`: create a _complete_ pattern (or not)
+- `sa`: include _seam allowance_ (or not)
+- `paperless`: allow the pattern to be _paperless_
 
 For now, we only need these so that the pattern skeleton compiles properly.
 

--- a/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
@@ -11,7 +11,7 @@ and the range of options we provided.
 
 ###### No more grading
 
-FreeSewing patterns are *made-to-measure*, which means that you don't need to
+FreeSewing patterns are _made-to-measure_, which means that you don't need to
 grade your pattern to provide a range of sizes. You should sample your pattern
 for different measurements and options to see how well it adapts.
 
@@ -87,13 +87,13 @@ If we test it, we can see that it works as intended. But there's one thing that 
 Making the bib wider shortens the length from the bottom of the neck opening to the bottom of the bib.
 Thereby making the bib shorter when it's worn.
 
-Even if the *total length* of the bib stays the same, the *useable length* shortens when the bib is made wider.
+Even if the _total length_ of the bib stays the same, the _useable length_ shortens when the bib is made wider.
 Users will not expect this, so it's something that we should fix in our pattern.
 
 <Note>
 
-Adjusting the pattern to make the `widthRatio` not influence the *useable length* of the bib is not
-covered in this tutorial. It is left *as an exercise to the reader*.
+Adjusting the pattern to make the `widthRatio` not influence the _useable length_ of the bib is not
+covered in this tutorial. It is left _as an exercise to the reader_.
 
 </Note>
 
@@ -137,7 +137,7 @@ Your bib with the head circumference measurement sampled </Example>
 ## Testing models
 
 Whereas testing a measurement will only vary one individual measurement, testing models will
-draft your pattern for different sets of measurments, which we refer to as *models*.
+draft your pattern for different sets of measurments, which we refer to as _models_.
 
 On the surface, the result below is the same as our measurement test. But that is because our bib
 only uses one measurement. So testing that one measurement ends up being the same as testing a complete
@@ -173,16 +173,16 @@ Your bib sampled for a range of baby sizes </Example>
 
 ## The antperson test
 
-A special case of model testing is the so-called *antperson test*.
-It drafts your pattern with a set of *typical* measurements , and then drafts it again
-with measurements that are 1/10th of those *typical* measurements.
+A special case of model testing is the so-called _antperson test_.
+It drafts your pattern with a set of _typical_ measurements , and then drafts it again
+with measurements that are 1/10th of those _typical_ measurements.
 
 It is named after [the cartoon character](https://en.wikipedia.org/wiki/Ant-Man_\(film\)) who can shrink,
 yet somehow his suit still fits.
 
 The purpose of the antperson test is to bring out areas in your pattern where you made assumptions
 that will not properly scale.
-Many drafting books will tell you to *add 3cm there* or *measure 2 inch to the right*. Those instructions
+Many drafting books will tell you to _add 3cm there_ or _measure 2 inch to the right_. Those instructions
 don't scale, and you should avoid them.
 
 The best patterns will pass the antperson test with 2 patterns exactly the same, where one will simply be 1/10th the scale of the other.

--- a/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
@@ -21,9 +21,9 @@ If testing your pattern sounds like a lot of work, you're in luck. FreeSewing ca
 for you. Click the **Test your pattern** button in the top navigation bar of your
 development environment, and you'll see a number of choices on the right:
 
--   Test pattern options
--   Test measurements
--   Test models
+- Test pattern options
+- Test measurements
+- Test models
 
 The [API docs on sampling](/reference/api/pattern/#sample) have all the details on how this works, but
 for now we'll just look at the end result of each of these.

--- a/markdown/dev/tutorials/pattern-design/your-first-part/en.md
+++ b/markdown/dev/tutorials/pattern-design/your-first-part/en.md
@@ -3,7 +3,7 @@ title: Your first part
 order: 120
 ---
 
-Much like garments themselves, patterns are made up of *parts*.
+Much like garments themselves, patterns are made up of _parts_.
 
 Most patterns will have multiple parts. A sleeve, a back part, the collar, and so on.
 Our pattern is very simple, and only has one part: the bib.
@@ -14,7 +14,7 @@ button in your browser, you'll get to see it:
 
 ![The default pattern with its box part](./step1.png)
 
-Since we only need one part, we'll rename this *box* part, and call it *bib*.
+Since we only need one part, we'll rename this _box_ part, and call it _bib_.
 
 ## Rename the box part to bib
 
@@ -59,7 +59,7 @@ Pattern.prototype.draftBib = draftBib
 
 ###### Always use draftPartname
 
-FreeSewing will expect for each part to find a method named Draft*Partname*.
+FreeSewing will expect for each part to find a method named Draft\_Partname\_.
 
 If you have a part named `sleeve` you should have a method called `draftSleeve()` that drafts that part.
 

--- a/markdown/org/docs/faq/breasts/en.md
+++ b/markdown/org/docs/faq/breasts/en.md
@@ -2,7 +2,7 @@
 title: "What's all this talk about with or without breasts?"
 ---
 
-Some people get confused by the terms *with breasts* and *without breasts*.
+Some people get confused by the terms _with breasts_ and _without breasts_.
 
 We use these terms as a gender-inclusive way to ask whether or not a person has breasts.
 
@@ -13,11 +13,11 @@ These garment designs are usually based off of the ideal or average body.
 Meaning, for womenswear, the designer will likely make a garment for a body with breasts,
 narrow shoulders, a smaller waist and wide hips.
 
-These characteristics are generally thought of as *the typical characteristics of a woman's body*.
+These characteristics are generally thought of as _the typical characteristics of a woman's body_.
 However, we believe it is best to stay away from this;
 no body is average and we want to build a gender-inclusive environment.
 
-We do not want to exclude anyone and we think that *body shape ≠ gender*.
+We do not want to exclude anyone and we think that _body shape ≠ gender_.
 That's why we use the terminology **with breasts** and **without breasts**,
 simply asking whether a person has breast tissue or not.
 

--- a/markdown/org/docs/faq/email-trouble/en.md
+++ b/markdown/org/docs/faq/email-trouble/en.md
@@ -14,10 +14,10 @@ we can help you activate your account.
 
 In France, several E-mail providers share the same filtering:
 
--   free.fr
--   laposte.net
--   organge.fr
--   sfr.fr
+- free.fr
+- laposte.net
+- organge.fr
+- sfr.fr
 
 They are all known to cause issues with deliveries.
 

--- a/markdown/org/docs/faq/measurement-estimates/en.md
+++ b/markdown/org/docs/faq/measurement-estimates/en.md
@@ -19,8 +19,8 @@ The value they represent shows how far the measurement deviates from the proport
 
 These indicators serve a dual purpose:
 
--   Help you spot mistakes in your measurements (you know best where your outliers are)
--   Help you anticipate where our software might struggle to come up with good results
+- Help you spot mistakes in your measurements (you know best where your outliers are)
+- Help you anticipate where our software might struggle to come up with good results
 
 <Note>
 

--- a/markdown/org/docs/faq/sizes/en.md
+++ b/markdown/org/docs/faq/sizes/en.md
@@ -5,7 +5,7 @@ title: I know my size, but your pattern doesn't fit me
 The standard sizes we offer are there to allow you to discover our platform without
 the need to create an account. We advise against using them as-is.
 
-Drafting made-to-measure sewing patterns really is *our thing*.\
+Drafting made-to-measure sewing patterns really is _our thing_.\
 If you insist on getting a pattern in a standard size, FreeSewing is not for you.
 
 Thankfully, Fiona curates

--- a/markdown/org/docs/faq/why-signup/en.md
+++ b/markdown/org/docs/faq/why-signup/en.md
@@ -18,8 +18,8 @@ would be hopelessly inpractical.
 This question often hints at an underlying distrust towards
 creating an account. As such, the following links may also be relevant:
 
--   Read [our privacy notice][1]
--   Learn more about [your rights][2]
+- Read [our privacy notice][1]
+- Learn more about [your rights][2]
 
 </Note>
 

--- a/markdown/org/docs/faq/womenswear-blocks/en.md
+++ b/markdown/org/docs/faq/womenswear-blocks/en.md
@@ -4,7 +4,7 @@ title: Why do you even publish womenswear blocks? They are [insert strong opinio
 
 This question comes up every now and then.
 The wording varies, but the sentiment can be summarized as
-*why even publish this garbage, it doesn't work at all*.
+_why even publish this garbage, it doesn't work at all_.
 
 Let me start by saying that you are not wrong. Both [Breanna](/designs/breanna/)
 and [Bella](/designs/bella/) have serious shortcomings.

--- a/markdown/org/docs/guide/account/en.md
+++ b/markdown/org/docs/guide/account/en.md
@@ -6,7 +6,7 @@ order: 300
 To generate made-to-measure sewing patterns, we need measurements.
 Asking for them every time would be rather tedious, so we store them for you.
 
-We need a place to store them, and that *place* is your account.
+We need a place to store them, and that _place_ is your account.
 Your account data is stored on our backend, subject to [our privacy notice][1],
 and with respect for [your rights][2].
 

--- a/markdown/org/docs/guide/en.md
+++ b/markdown/org/docs/guide/en.md
@@ -9,13 +9,13 @@ to save you a bunch of questions later, and make sure you get the most out of ou
 
 ##### What we'll explain
 
--   We'll tell you [what FreeSewing is][1] and [what freesewing.org is][2]
--   We'll tell you about our [made-to-measure sewing patterns][3]
-    and what we mean by [_with breasts_ vs _without breasts_][4]
--   We'll cover [why you need an account][5]
-    what we mean by [your people][6] or [your patterns][7], and we talk about [measurements][8]
--   We'll go over [how you can configure your patterns][9] with design and pattern options
--   Finally, we'll tell you [where you can get help][10] if you get stuck.
+- We'll tell you [what FreeSewing is][1] and [what freesewing.org is][2]
+- We'll tell you about our [made-to-measure sewing patterns][3]
+  and what we mean by [_with breasts_ vs _without breasts_][4]
+- We'll cover [why you need an account][5]
+  what we mean by [your people][6] or [your patterns][7], and we talk about [measurements][8]
+- We'll go over [how you can configure your patterns][9] with design and pattern options
+- Finally, we'll tell you [where you can get help][10] if you get stuck.
 
 Sounds good? Then let's dive right in:
 

--- a/markdown/org/docs/guide/en.md
+++ b/markdown/org/docs/guide/en.md
@@ -11,7 +11,7 @@ to save you a bunch of questions later, and make sure you get the most out of ou
 
 -   We'll tell you [what FreeSewing is][1] and [what freesewing.org is][2]
 -   We'll tell you about our [made-to-measure sewing patterns][3]
-    and what we mean by [*with breasts* vs *without breasts*][4]
+    and what we mean by [_with breasts_ vs _without breasts_][4]
 -   We'll cover [why you need an account][5]
     what we mean by [your people][6] or [your patterns][7], and we talk about [measurements][8]
 -   We'll go over [how you can configure your patterns][9] with design and pattern options

--- a/markdown/org/docs/guide/measurements/en.md
+++ b/markdown/org/docs/guide/measurements/en.md
@@ -7,8 +7,8 @@ Taking accurate measurements is crucial for good results with our designs, yet n
 
 We've added a few indicators to help you spot mistakes or problems in your measurements.
 
--   We include [estimates for your different measurements][1], and highlight those measurements where a person differs significantly from the estimate
--   Your models show [a graph of their body measurements][2] in comparison to our standard sizes
+- We include [estimates for your different measurements][1], and highlight those measurements where a person differs significantly from the estimate
+- Your models show [a graph of their body measurements][2] in comparison to our standard sizes
 
 [1]: /docs/guide/measurements/estimates/
 

--- a/markdown/org/docs/guide/measurements/estimates/en.md
+++ b/markdown/org/docs/guide/measurements/estimates/en.md
@@ -16,10 +16,10 @@ This estimate is based on your neck circumference, so this won't show up until y
 ##### This is a difficult area for us to work in
 
 We want to help you get the best results, and that includes helping you spot issues with your measurements.
-On the other hand, we in no way want to imply that someone's measurements are *wrong* somehow.
+On the other hand, we in no way want to imply that someone's measurements are _wrong_ somehow.
 
 We are an extremely size-inclusive pattern outlet, and a disproportionate amount of our users are people who struggle to find clothes or patterns from other outlets.
-So on one hand, it might seem like we're setting ourselves up for failure by comparing measurements to a set of more or less *standard* measurements.
+So on one hand, it might seem like we're setting ourselves up for failure by comparing measurements to a set of more or less _standard_ measurements.
 But you know your body. You know which of your measurements deviate from the average.
 And us pointing out that they do is in a way only confirmation that you've been measuring correctly.
 On the other hand, if something jumps out where you are fairly average sized, you know to double-check those measurements.

--- a/markdown/org/docs/guide/options/en.md
+++ b/markdown/org/docs/guide/options/en.md
@@ -5,7 +5,7 @@ order: 998
 
 When you [create a pattern](/create/) there are two important groups of things you can tweak:
 
--   The **design options** are options the designer added to the pattern. Typically style and fit choices.
--   The **pattern options** are a set of options that come with the platform, and are available for all patterns. Below is a complete list:
+- The **design options** are options the designer added to the pattern. Typically style and fit choices.
+- The **pattern options** are a set of options that come with the platform, and are available for all patterns. Below is a complete list:
 
 <ReadMore list />

--- a/markdown/org/docs/guide/options/sa/en.md
+++ b/markdown/org/docs/guide/options/sa/en.md
@@ -2,7 +2,7 @@
 title: Seam allowance
 ---
 
-This controls whether you want *seam allowance* or not.
+This controls whether you want _seam allowance_ or not.
 And, if you want it, how much you want.
 
 This will probably be self-explanatory if you know what seam allowance is.

--- a/markdown/org/docs/guide/options/scale/en.md
+++ b/markdown/org/docs/guide/options/scale/en.md
@@ -9,5 +9,5 @@ line width and so on.
 It was specifically created to accommodate patterns for doll clothes and other
 situations where the text and snippets would become too large in comparison to the pattern.
 
-You need to enable *Expert mode* after which you can find the scale setting
-under *Advanced*.
+You need to enable _Expert mode_ after which you can find the scale setting
+under _Advanced_.

--- a/markdown/org/docs/guide/options/units/en.md
+++ b/markdown/org/docs/guide/options/units/en.md
@@ -6,8 +6,8 @@ This controls the units used (by the text) on the pattern.
 
 Freesewing supports two types of units:
 
--   Metric units (cm)
--   Imperial units (inch)
+- Metric units (cm)
+- Imperial units (inch)
 
 You can configure your default units in your account settings.\
 In addition, you can set the units individually for each model.\

--- a/markdown/org/docs/guide/patterns/en.md
+++ b/markdown/org/docs/guide/patterns/en.md
@@ -17,7 +17,7 @@ You can save as many patterns as you like.
 
 ##### Patterns vs Designs
 
-If you came to this site looking for *patterns* you might have found them under *designs*.
+If you came to this site looking for _patterns_ you might have found them under _designs_.
 It's not a super important distinction, but it helps to understand that:
 
 -   **Design**: One of the styles that we offer. We've got dozens of designs, and you can try them all

--- a/markdown/org/docs/guide/patterns/en.md
+++ b/markdown/org/docs/guide/patterns/en.md
@@ -20,7 +20,7 @@ You can save as many patterns as you like.
 If you came to this site looking for _patterns_ you might have found them under _designs_.
 It's not a super important distinction, but it helps to understand that:
 
--   **Design**: One of the styles that we offer. We've got dozens of designs, and you can try them all
--   **Pattern**: The result of generating one of those styles into a pattern. We've got thousands of patterns stored for our users, and some might be yours
+- **Design**: One of the styles that we offer. We've got dozens of designs, and you can try them all
+- **Pattern**: The result of generating one of those styles into a pattern. We've got thousands of patterns stored for our users, and some might be yours
 
 </Tip>

--- a/markdown/org/docs/guide/people/en.md
+++ b/markdown/org/docs/guide/people/en.md
@@ -7,7 +7,7 @@ Once you have an account, you can start adding measurements.
 But that quickly brings up the next question: what if you want
 a pattern for you, but also for your partner?
 
-That's why we have *people*.
+That's why we have _people_.
 
 You create a person, and add measurements to that person.
 Now you can generate patterns for this person, based on their measurements.

--- a/markdown/org/docs/measurements/crossseamfront/en.md
+++ b/markdown/org/docs/measurements/crossseamfront/en.md
@@ -7,6 +7,6 @@ The **cross seam front** is the front part of the [cross seam](/docs/measurement
 To measure your **cross seam front** tie a string around your waist. Then, measure down from the
 center front of your waist until the spot that is:
 
--   Where the fork of a tight-fitting pair of trousers would sit
--   At the base of your scrotum
--   Somewhere towards the front of your perineum
+- Where the fork of a tight-fitting pair of trousers would sit
+- At the base of your scrotum
+- Somewhere towards the front of your perineum

--- a/markdown/org/docs/measurements/hps/en.md
+++ b/markdown/org/docs/measurements/hps/en.md
@@ -2,7 +2,7 @@
 title: High Point Shoulder (HPS)
 ---
 
-The *high point shoulder* or *HPS* point is used as the base for several vertical measurements.
+The _high point shoulder_ or _HPS_ point is used as the base for several vertical measurements.
 
 The HPS is where your shoulder seam would meet your neck.
 The point is situated where your neck meets your shoulder.

--- a/markdown/org/docs/measurements/hpstobust/en.md
+++ b/markdown/org/docs/measurements/hpstobust/en.md
@@ -6,7 +6,7 @@ title: HPS to bust
 
 ###### HPS: high point shoulder
 
-The *high point shoulder* or *HPS* point is used as the base for several vertical measurements.
+The _high point shoulder_ or _HPS_ point is used as the base for several vertical measurements.
 Refer to [the hps documentation](/docs/measurements/hps/) for information on how to locate this point.
 
 </Note>

--- a/markdown/org/docs/measurements/hpstowaistback/en.md
+++ b/markdown/org/docs/measurements/hpstowaistback/en.md
@@ -6,7 +6,7 @@ title: HPS to waist back
 
 ###### HPS: high point shoulder
 
-The *high point shoulder* or *HPS* point is used as the base for several vertical measurements.
+The _high point shoulder_ or _HPS_ point is used as the base for several vertical measurements.
 Refer to [the hps documentation](/docs/measurements/hps/) for information on how to locate this point.
 
 </Note>

--- a/markdown/org/docs/measurements/hpstowaistfront/en.md
+++ b/markdown/org/docs/measurements/hpstowaistfront/en.md
@@ -6,7 +6,7 @@ title: HPS to waist front
 
 ###### HPS: high point shoulder
 
-The *high point shoulder* or *HPS* point is used as the base for several vertical measurements.
+The _high point shoulder_ or _HPS_ point is used as the base for several vertical measurements.
 Refer to [the hps documentation](/docs/measurements/hps/) for information on how to locate this point.
 
 </Note>

--- a/markdown/org/docs/patterns/aaron/cutting/en.md
+++ b/markdown/org/docs/patterns/aaron/cutting/en.md
@@ -1,13 +1,13 @@
--   Cut **1 back** on the fold
--   Cut **1 front** on the fold
--   Cut **3 strips** for neck opening and armhole binding
+- Cut **1 back** on the fold
+- Cut **1 front** on the fold
+- Cut **3 strips** for neck opening and armhole binding
 
 <Warning>
 
 #### Caveats
 
--   There is no seam allowance on the armholes
--   There is no seam allowance on the neck opening
--   There is extra hem allowance at the hem
+- There is no seam allowance on the armholes
+- There is no seam allowance on the neck opening
+- There is extra hem allowance at the hem
 
 </Warning>

--- a/markdown/org/docs/patterns/aaron/instructions/en.md
+++ b/markdown/org/docs/patterns/aaron/instructions/en.md
@@ -54,8 +54,8 @@ This is the only part of making this A-shirt that requires a bit of practice. Do
 
 The first thing we need to do is decide where we are going to start/stop our binding. Here's what I suggest:
 
--   For the armholes: at the side seam. This will hide our seam under the arm
--   For the neck opening: the center back of the neck. You might want to mark this with a pin
+- For the armholes: at the side seam. This will hide our seam under the arm
+- For the neck opening: the center back of the neck. You might want to mark this with a pin
 
 ### Place (the start of) your binding
 

--- a/markdown/org/docs/patterns/aaron/instructions/en.md
+++ b/markdown/org/docs/patterns/aaron/instructions/en.md
@@ -2,14 +2,14 @@
 
 ![Close the side and shoulder seams](step01.png)
 
-Put front and back on top of each other with *good sides together*.
+Put front and back on top of each other with _good sides together_.
 Sew the side seams and the short seams at the shoulder straps. If you have a serger, this is a good moment to use it. If not, finish your seams otherwise.
 
 ## Step 2: Finish hem
 
 ![Finish the hem](step02.png)
 
-Fold the hem upwards, and sew it down. If you have a coverlock, use it. If not, use a *twin needle* or *zig-zag stitch* to keep the seam stretchable.
+Fold the hem upwards, and sew it down. If you have a coverlock, use it. If not, use a _twin needle_ or _zig-zag stitch_ to keep the seam stretchable.
 
 <Note>
 

--- a/markdown/org/docs/patterns/aaron/needs/en.md
+++ b/markdown/org/docs/patterns/aaron/needs/en.md
@@ -1,7 +1,7 @@
 To make Aaron, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 0.75 meters (0.8 yards) of a suitable fabric ([see Fabric options](/docs/patterns/aaron/fabric))
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 0.75 meters (0.8 yards) of a suitable fabric ([see Fabric options](/docs/patterns/aaron/fabric))
 
 <Note>
 

--- a/markdown/org/docs/patterns/albert/cutting/en.md
+++ b/markdown/org/docs/patterns/albert/cutting/en.md
@@ -1,3 +1,3 @@
--   Cut **1 front** on the fold
--   Cut **1 pocket** on the fold
--   Cut **2 straps**
+- Cut **1 front** on the fold
+- Cut **1 pocket** on the fold
+- Cut **2 straps**

--- a/markdown/org/docs/patterns/albert/instructions/en.md
+++ b/markdown/org/docs/patterns/albert/instructions/en.md
@@ -9,11 +9,11 @@ title: Albert Construction
 -   Press the seam allowance of the sides and bottom to the wrong side.
 -   On the right side topstich close to where the hem edge lies underneath, making sure to catch the hem and seam allowances as you sew.
 -   Pin the pocket to the front using the guides.
--   *Edgestitch* the sides and bottom of the pocket leaving the top open. Make sure to backstitch at the start and end to secure the pocket properly.
+-   _Edgestitch_ the sides and bottom of the pocket leaving the top open. Make sure to backstitch at the start and end to secure the pocket properly.
 
 <Tip>
 
-If you have trouble catching the top hem we suggest to either *Baste* close to the hem edge first, and use that as a guide when stitching on the right side or pin the hem edge down from the right side making sure the pins are parallel to the top edge and use them as a guide.
+If you have trouble catching the top hem we suggest to either _Baste_ close to the hem edge first, and use that as a guide when stitching on the right side or pin the hem edge down from the right side making sure the pins are parallel to the top edge and use them as a guide.
 
 </Tip>
 

--- a/markdown/org/docs/patterns/albert/instructions/en.md
+++ b/markdown/org/docs/patterns/albert/instructions/en.md
@@ -4,12 +4,12 @@ title: Albert Construction
 
 ### Step 1: The Pocket
 
--   Along the top of the pocket fold the seam allowance to wrong side, press.
--   Then fold the top hem allowance to wrong side and press, making sure the seam allowance is tucked underneath. Pin in place if you need to.
--   Press the seam allowance of the sides and bottom to the wrong side.
--   On the right side topstich close to where the hem edge lies underneath, making sure to catch the hem and seam allowances as you sew.
--   Pin the pocket to the front using the guides.
--   _Edgestitch_ the sides and bottom of the pocket leaving the top open. Make sure to backstitch at the start and end to secure the pocket properly.
+- Along the top of the pocket fold the seam allowance to wrong side, press.
+- Then fold the top hem allowance to wrong side and press, making sure the seam allowance is tucked underneath. Pin in place if you need to.
+- Press the seam allowance of the sides and bottom to the wrong side.
+- On the right side topstich close to where the hem edge lies underneath, making sure to catch the hem and seam allowances as you sew.
+- Pin the pocket to the front using the guides.
+- _Edgestitch_ the sides and bottom of the pocket leaving the top open. Make sure to backstitch at the start and end to secure the pocket properly.
 
 <Tip>
 
@@ -26,10 +26,10 @@ A fun thing you can do is embroider/stitch the pocket with the name of the perso
 
 ### Step 2: The Front
 
--   Press under the side seam allowances to the wrong side.
--   Press under the side seams to the wrong side along the hem lines making sure the seam allowances are tucked underneath.
--   On the right side topstich close to where the folded edges lie underneath, making sure to catch the hems as you sew.
--   Repeat Step 2 for the top and bottom hems.
+- Press under the side seam allowances to the wrong side.
+- Press under the side seams to the wrong side along the hem lines making sure the seam allowances are tucked underneath.
+- On the right side topstich close to where the folded edges lie underneath, making sure to catch the hems as you sew.
+- Repeat Step 2 for the top and bottom hems.
 
 <Note>
 
@@ -40,11 +40,11 @@ The side seams are narrow hems simply being the seam allowance folded over twice
 
 ### Step 3: The Straps
 
--   Fold one strap in half, right sides together and sew the top and side together.
--   Turn inside out through the bottom. Press.
--   Using the cross and rectangle as a guide, stitch the top of the strap to the wrong side of the front on the top left.
--   Using the cross and rectangle as a guide, stitch the bottom of the strap to the wrong side of the front at the side right.
--   Repeat Step 3 for the remaining strap attaching it at the top right and then the side left.
+- Fold one strap in half, right sides together and sew the top and side together.
+- Turn inside out through the bottom. Press.
+- Using the cross and rectangle as a guide, stitch the top of the strap to the wrong side of the front on the top left.
+- Using the cross and rectangle as a guide, stitch the bottom of the strap to the wrong side of the front at the side right.
+- Repeat Step 3 for the remaining strap attaching it at the top right and then the side left.
 
 <Note>
 

--- a/markdown/org/docs/patterns/albert/needs/en.md
+++ b/markdown/org/docs/patterns/albert/needs/en.md
@@ -1,4 +1,4 @@
 To make Albert, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 1.25 meters (1.4 yards) (depending on the length of your apron) of a suitable fabric ([see Fabric options](/docs/patterns/albert/fabric))
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 1.25 meters (1.4 yards) (depending on the length of your apron) of a suitable fabric ([see Fabric options](/docs/patterns/albert/fabric))

--- a/markdown/org/docs/patterns/albert/options/biblength/en.md
+++ b/markdown/org/docs/patterns/albert/options/biblength/en.md
@@ -1,4 +1,4 @@
-Controls the length of the *bib* part of your apron.
+Controls the length of the _bib_ part of your apron.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/albert/options/bibwidth/en.md
+++ b/markdown/org/docs/patterns/albert/options/bibwidth/en.md
@@ -1,4 +1,4 @@
-Controls the width of the *bib* part of your apron.
+Controls the width of the _bib_ part of your apron.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/bee/cutting/en.md
+++ b/markdown/org/docs/patterns/bee/cutting/en.md
@@ -10,31 +10,31 @@ There are three variations of this pattern. **One Colour**, which is where the b
 
 **Main fabric**
 
--   Cut **4 cup** parts.
--   Cut **2 neck tie** parts.
--   Cut **1 band tie** part.
+- Cut **4 cup** parts.
+- Cut **2 neck tie** parts.
+- Cut **1 band tie** part.
 
 ### Two Colours (Reversible)
 
 **Main fabric**
 
--   Cut **2 cup** parts from main.
--   Cut **2 neck tie** parts.
--   Cut **1 band tie** part.
+- Cut **2 cup** parts from main.
+- Cut **2 neck tie** parts.
+- Cut **1 band tie** part.
 
 **Lining fabric**
 
--   Cut **2 cup** parts.
--   Cut **2 neck tie** parts.
--   Cut **1 band tie** part.
+- Cut **2 cup** parts.
+- Cut **2 neck tie** parts.
+- Cut **1 band tie** part.
 
 ### Cross Back Tie Variant.
 
 **Main fabric**
 
--   Cut **4 cup** parts or Cut **2 cups** from main and lining if making reversible ties.
--   Cut **2 neck tie** parts or Cut **2 neck ties** from main and lining if making reversible ties.
--   Cut **1 band** part if making cross back tie variant instead of band tie variant.
+- Cut **4 cup** parts or Cut **2 cups** from main and lining if making reversible ties.
+- Cut **2 neck tie** parts or Cut **2 neck ties** from main and lining if making reversible ties.
+- Cut **1 band** part if making cross back tie variant instead of band tie variant.
 
 <Note>
 

--- a/markdown/org/docs/patterns/bee/instructions/en.md
+++ b/markdown/org/docs/patterns/bee/instructions/en.md
@@ -36,14 +36,14 @@ The notches in this pattern act more like dots so **do not** clip them to mark t
 
 #### Band Tie Variant
 
--   With raw edges and main fabric together, *baste* one of the neck ties to the top of one of the cup pieces making sure that the tie goes towards the bottom of the cup.
+-   With raw edges and main fabric together, _baste_ one of the neck ties to the top of one of the cup pieces making sure that the tie goes towards the bottom of the cup.
 -   With the neck tie sandwiched inside, pin a lining cup piece right sides together to the main cup piece.
 -   Sew the lining to the main cup between notches along the front, top and side seams, making sure not to catch the neck tie and to reinforce the stitch at the notches.
--   (Optional) Fold to the wrong side and *edgestitch* the seam allowance down between notches on the front and side seams. Do not sew the allowances together.
+-   (Optional) Fold to the wrong side and _edgestitch_ the seam allowance down between notches on the front and side seams. Do not sew the allowances together.
 -   With good sides together, sew the lining to the main fabric along the bottom, leaving a gap between the side notches making sure to reinforce the stitch at the either end.
 -   Trim the seam allowances of the sewn edges whilst leaving the seam allowance between the notches. Clip the corners. You may also need to clip the curved seams.
 -   Turn inside out by pulling the neck tie through one of the gaps. Press.
--   (Optional) *edgestitch* the top, sides and bottom of the cup leaving the gaps between the notches open.
+-   (Optional) _edgestitch_ the top, sides and bottom of the cup leaving the gaps between the notches open.
 -   Stitch along casing line to create band channel.
 
 <Note>Repeat this for the other cup</Note>
@@ -53,23 +53,23 @@ The notches in this pattern act more like dots so **do not** clip them to mark t
 If your seam allowance is wide you may find that you need to trim the gaps' seam allowances a little to reduce bulk.\
 If you are having trouble turning the cups you can try one of these methods:
 
--   Create a 2.5cm (1") gap in the front or side seam and turn throught that, either *slipstitch*-ing the gap closed or *edgestitch*-ing it closed during Step 7.
--   Widen one of the existing gaps and turn through that. Then when turned *edgestitch* or *slipstitch* the widened part closed.
+-   Create a 2.5cm (1") gap in the front or side seam and turn throught that, either _slipstitch_-ing the gap closed or _edgestitch_-ing it closed during Step 7.
+-   Widen one of the existing gaps and turn through that. Then when turned _edgestitch_ or _slipstitch_ the widened part closed.
 
 </Tip>
 <Note>
 
-Whilst certainly optional it is recommended to *edgestitch* the top and sides of the cups but the bottom is entirely optional.
+Whilst certainly optional it is recommended to _edgestitch_ the top and sides of the cups but the bottom is entirely optional.
 
 </Note>
 
 #### Cross Back Ties Variant
 
--   With raw edges and main fabric together, *baste* one of the neck ties to the top of one of the cup pieces making sure that the tie goes towards the bottom of the cup.
+-   With raw edges and main fabric together, _baste_ one of the neck ties to the top of one of the cup pieces making sure that the tie goes towards the bottom of the cup.
 -   With the neck tie sandwiched inside, pin a lining cup piece right sides together to the main cup piece.
 -   Sew the lining to the main cup along the front, top and side seams, making sure not to catch the neck tie.
 -   Turn the cups right side out and press.
--   (Optional) *edgestitch* the top and sides of the cups.
+-   (Optional) _edgestitch_ the top and sides of the cups.
 -   Sew a line of basting stitches along the bottom of the cups, just inside the seamline.
 -   Gather cups along the basting stitches.
 

--- a/markdown/org/docs/patterns/bee/instructions/en.md
+++ b/markdown/org/docs/patterns/bee/instructions/en.md
@@ -17,18 +17,18 @@ The notches in this pattern act more like dots so **do not** clip them to mark t
 
 #### Neck Ties One Colour Method
 
--   Fold one of the neck tie pieces in half lengthwise, right sides and raw edges together.
--   Sew along the raw edges, leaving one of the short ends open.
--   Trim the seam allowances and clip the corners.
--   Turn inside out and press.
+- Fold one of the neck tie pieces in half lengthwise, right sides and raw edges together.
+- Sew along the raw edges, leaving one of the short ends open.
+- Trim the seam allowances and clip the corners.
+- Turn inside out and press.
 
 <Note>Repeat this for the other neck tie</Note>
 
 #### Neck Ties Two Colours Method
 
--   With right sides together, sew one main neck tie to one lining neck tie leaving one of the short edges open.
--   Trim the seam allowances and clip the corners.
--   Turn inside out. Press.
+- With right sides together, sew one main neck tie to one lining neck tie leaving one of the short edges open.
+- Trim the seam allowances and clip the corners.
+- Turn inside out. Press.
 
 <Note>Repeat this for the the remaining neck tie pieces</Note>
 
@@ -36,15 +36,15 @@ The notches in this pattern act more like dots so **do not** clip them to mark t
 
 #### Band Tie Variant
 
--   With raw edges and main fabric together, _baste_ one of the neck ties to the top of one of the cup pieces making sure that the tie goes towards the bottom of the cup.
--   With the neck tie sandwiched inside, pin a lining cup piece right sides together to the main cup piece.
--   Sew the lining to the main cup between notches along the front, top and side seams, making sure not to catch the neck tie and to reinforce the stitch at the notches.
--   (Optional) Fold to the wrong side and _edgestitch_ the seam allowance down between notches on the front and side seams. Do not sew the allowances together.
--   With good sides together, sew the lining to the main fabric along the bottom, leaving a gap between the side notches making sure to reinforce the stitch at the either end.
--   Trim the seam allowances of the sewn edges whilst leaving the seam allowance between the notches. Clip the corners. You may also need to clip the curved seams.
--   Turn inside out by pulling the neck tie through one of the gaps. Press.
--   (Optional) _edgestitch_ the top, sides and bottom of the cup leaving the gaps between the notches open.
--   Stitch along casing line to create band channel.
+- With raw edges and main fabric together, _baste_ one of the neck ties to the top of one of the cup pieces making sure that the tie goes towards the bottom of the cup.
+- With the neck tie sandwiched inside, pin a lining cup piece right sides together to the main cup piece.
+- Sew the lining to the main cup between notches along the front, top and side seams, making sure not to catch the neck tie and to reinforce the stitch at the notches.
+- (Optional) Fold to the wrong side and _edgestitch_ the seam allowance down between notches on the front and side seams. Do not sew the allowances together.
+- With good sides together, sew the lining to the main fabric along the bottom, leaving a gap between the side notches making sure to reinforce the stitch at the either end.
+- Trim the seam allowances of the sewn edges whilst leaving the seam allowance between the notches. Clip the corners. You may also need to clip the curved seams.
+- Turn inside out by pulling the neck tie through one of the gaps. Press.
+- (Optional) _edgestitch_ the top, sides and bottom of the cup leaving the gaps between the notches open.
+- Stitch along casing line to create band channel.
 
 <Note>Repeat this for the other cup</Note>
 
@@ -53,8 +53,8 @@ The notches in this pattern act more like dots so **do not** clip them to mark t
 If your seam allowance is wide you may find that you need to trim the gaps' seam allowances a little to reduce bulk.\
 If you are having trouble turning the cups you can try one of these methods:
 
--   Create a 2.5cm (1") gap in the front or side seam and turn throught that, either _slipstitch_-ing the gap closed or _edgestitch_-ing it closed during Step 7.
--   Widen one of the existing gaps and turn through that. Then when turned _edgestitch_ or _slipstitch_ the widened part closed.
+- Create a 2.5cm (1") gap in the front or side seam and turn throught that, either _slipstitch_-ing the gap closed or _edgestitch_-ing it closed during Step 7.
+- Widen one of the existing gaps and turn through that. Then when turned _edgestitch_ or _slipstitch_ the widened part closed.
 
 </Tip>
 <Note>
@@ -65,13 +65,13 @@ Whilst certainly optional it is recommended to _edgestitch_ the top and sides of
 
 #### Cross Back Ties Variant
 
--   With raw edges and main fabric together, _baste_ one of the neck ties to the top of one of the cup pieces making sure that the tie goes towards the bottom of the cup.
--   With the neck tie sandwiched inside, pin a lining cup piece right sides together to the main cup piece.
--   Sew the lining to the main cup along the front, top and side seams, making sure not to catch the neck tie.
--   Turn the cups right side out and press.
--   (Optional) _edgestitch_ the top and sides of the cups.
--   Sew a line of basting stitches along the bottom of the cups, just inside the seamline.
--   Gather cups along the basting stitches.
+- With raw edges and main fabric together, _baste_ one of the neck ties to the top of one of the cup pieces making sure that the tie goes towards the bottom of the cup.
+- With the neck tie sandwiched inside, pin a lining cup piece right sides together to the main cup piece.
+- Sew the lining to the main cup along the front, top and side seams, making sure not to catch the neck tie.
+- Turn the cups right side out and press.
+- (Optional) _edgestitch_ the top and sides of the cups.
+- Sew a line of basting stitches along the bottom of the cups, just inside the seamline.
+- Gather cups along the basting stitches.
 
 <Tip>
 
@@ -80,8 +80,8 @@ There are also notches on either side of the band piece's midpoint to help give 
 
 </Tip>
 
--   Find the midpoint of the band piece, this is marked by a notch, then pin the gathered bottoms of cups to band piece, right sides together. You'll want the cups to meet at the band's midpoint.
--   Stitch the cups to the band. Once they're stitched in place, check the fit of the cups once more before continuing. Unpicking swim fabric is a pain, so it's better to make sure the cups fit just right before moving on.
+- Find the midpoint of the band piece, this is marked by a notch, then pin the gathered bottoms of cups to band piece, right sides together. You'll want the cups to meet at the band's midpoint.
+- Stitch the cups to the band. Once they're stitched in place, check the fit of the cups once more before continuing. Unpicking swim fabric is a pain, so it's better to make sure the cups fit just right before moving on.
 
 <Note>
 
@@ -89,8 +89,8 @@ You may prefer to wrap the one cup over the other at the midpoint. To do this pl
 
 </Note>
 
--   Now it's time to finish the band. To do this, fold in the seam allowance on both sides of the band. The raw edges of your swim cups should be turned to the inside of the band. Then, fold the band in half lengthwise, aligning the long edges and enclosing the seam allowances. Swim fabric can be slippery, so you may need extra pins or clips to hold the fabric in place.
--   Stitch along the top of the band, securing the seam allowances within the band.
+- Now it's time to finish the band. To do this, fold in the seam allowance on both sides of the band. The raw edges of your swim cups should be turned to the inside of the band. Then, fold the band in half lengthwise, aligning the long edges and enclosing the seam allowances. Swim fabric can be slippery, so you may need extra pins or clips to hold the fabric in place.
+- Stitch along the top of the band, securing the seam allowances within the band.
 
 <Tip>
 
@@ -98,9 +98,9 @@ For extra support, you can also add swim elastic into the band, either by stitch
 
 </Tip>
 
--   At this point, the band is a long tube with open ends. Next, we'll be sewing those closed while providing a loop to thread your neck ties through. To do this fold over one end of the band towards the inside of the swim top. The amount you fold over should be, at minimum, the width of your neck ties plus a seam allowance. Stitch the end down to create a loop at least as wide as your neck ties. There will be a lot of pressure on this point, so make sure your stitching is secure, and consider running a second line of stitching next to the first, for additional support. Repeat for the other end of the band.
--   To thread your neck-ties for cross back ties, take the tie from the left cup and thread it through the loop on the right side of the band, from top to bottom. Thread the tie from the right cup top-to-bottom through the loop on the left side of the band. Then tie the neck ties at center back to secure the swim top.
--   Skip to "Step 5: Enjoy!"
+- At this point, the band is a long tube with open ends. Next, we'll be sewing those closed while providing a loop to thread your neck ties through. To do this fold over one end of the band towards the inside of the swim top. The amount you fold over should be, at minimum, the width of your neck ties plus a seam allowance. Stitch the end down to create a loop at least as wide as your neck ties. There will be a lot of pressure on this point, so make sure your stitching is secure, and consider running a second line of stitching next to the first, for additional support. Repeat for the other end of the band.
+- To thread your neck-ties for cross back ties, take the tie from the left cup and thread it through the loop on the right side of the band, from top to bottom. Thread the tie from the right cup top-to-bottom through the loop on the left side of the band. Then tie the neck ties at center back to secure the swim top.
+- Skip to "Step 5: Enjoy!"
 
 ### Step 3: Band tie
 
@@ -108,20 +108,20 @@ You only need to do this step if making the band tie variant.
 
 #### Band Tie One Colour Method
 
--   Fold the band tie piece in half lengthwise, right sides and raw edges together.
--   Sew along the raw edges, leaving one of the short ends open.
--   Trim the seam allowances and clip the corners.
--   Turn inside out. Press.
+- Fold the band tie piece in half lengthwise, right sides and raw edges together.
+- Sew along the raw edges, leaving one of the short ends open.
+- Trim the seam allowances and clip the corners.
+- Turn inside out. Press.
 
 #### Band Tie Two Colours Method
 
--   With right sides together, sew the main band tie to the lining neck tie leaving one of the short edges open.
--   Trim the seam allowances and clip the corners.
--   Turn inside out. Press.
+- With right sides together, sew the main band tie to the lining neck tie leaving one of the short edges open.
+- Trim the seam allowances and clip the corners.
+- Turn inside out. Press.
 
 ### Step 4: Putting it all together.
 
--   Thread the band tie through the gaps along the bottom edge of the cups, making sure the front sides of the cups are in the centre and that the main and lining sides are on the respective side.
+- Thread the band tie through the gaps along the bottom edge of the cups, making sure the front sides of the cups are in the centre and that the main and lining sides are on the respective side.
 
 ### Step 5: Enjoy!
 

--- a/markdown/org/docs/patterns/bee/needs/en.md
+++ b/markdown/org/docs/patterns/bee/needs/en.md
@@ -4,10 +4,10 @@ title: Bee What you need
 
 To make Bee, you will need the following:
 
--   Basic sewing supplies
--   About 0.5 - 1 metre (0.6 - 1.1 yards) of a suitable fabric ([see Bee Fabric options](/docs/patterns/bee/fabric/))
--   (Optional) About 0.5 - 1 metre (0.6 - 1.1 yards) of lining fabric ([see Bee Fabric options](/docs/patterns/bee/fabric/))
--   (Optional) Ribbons/Tapes/Cords for neck ties and bands, with the same length and width as neck tie and/or band.
+- Basic sewing supplies
+- About 0.5 - 1 metre (0.6 - 1.1 yards) of a suitable fabric ([see Bee Fabric options](/docs/patterns/bee/fabric/))
+- (Optional) About 0.5 - 1 metre (0.6 - 1.1 yards) of lining fabric ([see Bee Fabric options](/docs/patterns/bee/fabric/))
+- (Optional) Ribbons/Tapes/Cords for neck ties and bands, with the same length and width as neck tie and/or band.
 
 <Note>
 

--- a/markdown/org/docs/patterns/bee/options/crossbackties/en.md
+++ b/markdown/org/docs/patterns/bee/options/crossbackties/en.md
@@ -6,16 +6,16 @@ A variation of Bee, where the neck ties cross and tie in the back by looping int
 
 #### Default
 
--   2 neck ties
--   1 band tie
+- 2 neck ties
+- 1 band tie
 
 The neck ties are sewn into the cups and tie at the neck like a halter.\
 The band tie is thread through casings in the cups and ties with itself at the back
 
 #### Cross Back Ties
 
--   2 neck ties
--   No band tie
+- 2 neck ties
+- No band tie
 
 The band tie and casing on the cups are replaced by a band which is sewn with loops in the back.\
 The neck ties are longer and cross over each other in the back, then go through the loops in the band and then tie with one another.

--- a/markdown/org/docs/patterns/bella/cutting/en.md
+++ b/markdown/org/docs/patterns/bella/cutting/en.md
@@ -4,8 +4,8 @@ title: Bella Cutting
 
 **Main fabric**
 
--   Cut **1 Front** part on the fold.
--   Cut **2 Back** parts.
+- Cut **1 Front** part on the fold.
+- Cut **2 Back** parts.
 
 These cutting instructions are just for the default Bella block. Adjust your cutting accordingly if you have/are making changes to the block.
 

--- a/markdown/org/docs/patterns/bella/instructions/en.md
+++ b/markdown/org/docs/patterns/bella/instructions/en.md
@@ -15,10 +15,10 @@ Blocks are typically not made as-is but rather serve as a basis for other patter
 
 ### Step 1: Mock-up Construction
 
--   Close the front bust and waist darts.
--   Close the back darts.
--   Sew the front to the backs at the shoulders good sides together.
--   Sew the front to the backs at the side seams good sides together.
+- Close the front bust and waist darts.
+- Close the back darts.
+- Sew the front to the backs at the shoulders good sides together.
+- Sew the front to the backs at the side seams good sides together.
 
 <Tip>
 
@@ -28,9 +28,9 @@ If you are making adjustments you may wish to sew the seams wrong sides together
 
 ### Step 2: Try it on
 
--   Try it on and check the fit by pinning the back closed whilst wearing it.
--   Make any alterations and try it on again.
--   Repeat until you are happy.
+- Try it on and check the fit by pinning the back closed whilst wearing it.
+- Make any alterations and try it on again.
+- Repeat until you are happy.
 
 <Tip>
 
@@ -47,10 +47,10 @@ Sometimes you may need to wear the mock-up for an extended amount of time to get
 Remember to treat Bella as a basis rather than a final product, so adjust what you need to get the desired look.\
 For instance:
 
--   Change the neck line
--   Add/change the closure allowances
--   Alter the dart placements
--   Add a collar
+- Change the neck line
+- Add/change the closure allowances
+- Alter the dart placements
+- Add a collar
 
 It is all up to you! Experiment and go forth!
 
@@ -58,8 +58,8 @@ It is all up to you! Experiment and go forth!
 
 ### Step 3: Make a paper pattern
 
--   Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
--   Now you have a pattern you can use to produce a garment.
+- Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
+- Now you have a pattern you can use to produce a garment.
 
 <Note>
 

--- a/markdown/org/docs/patterns/bella/needs/en.md
+++ b/markdown/org/docs/patterns/bella/needs/en.md
@@ -4,8 +4,8 @@ title: Bella What you need
 
 To make Bella, you will need the following:
 
--   Basic sewing supplies
--   About 0.5 metres (0.6 yards) of a suitable fabric ([see Bella Fabric options](/docs/patterns/bella/fabric/))
+- Basic sewing supplies
+- About 0.5 metres (0.6 yards) of a suitable fabric ([see Bella Fabric options](/docs/patterns/bella/fabric/))
 
 This list is for a default Bella Block. If you have/are making changes to the block you may need to get additional items such as closures, binding etc.
 

--- a/markdown/org/docs/patterns/benjamin/cutting/en.md
+++ b/markdown/org/docs/patterns/benjamin/cutting/en.md
@@ -3,20 +3,20 @@ needs to be cut out. Below are two typical layouts.
 
 ## Without adjustment ribbon
 
--   **Main fabric**
-    -   Cut **4 Knot**
-    -   Cut **2 Collar band**
--   **Interfacing**
-    -   Cut **4 interfacing knot**
-    -   Cut **2 interfacing collar band**
+- **Main fabric**
+  - Cut **4 Knot**
+  - Cut **2 Collar band**
+- **Interfacing**
+  - Cut **4 interfacing knot**
+  - Cut **2 interfacing collar band**
 
 ## With adjustment ribbon
 
--   **Main fabric**
-    -   Cut **1 Knot 1**
-    -   Cut **1 Knot 2**
-    -   Cut **2 Knot 3**
--   **Interfacing**
-    -   Cut **1 interfacing knot 1**
-    -   Cut **1 interfacing knot 2**
-    -   Cut **2 interfacing knot 3**
+- **Main fabric**
+  - Cut **1 Knot 1**
+  - Cut **1 Knot 2**
+  - Cut **2 Knot 3**
+- **Interfacing**
+  - Cut **1 interfacing knot 1**
+  - Cut **1 interfacing knot 2**
+  - Cut **2 interfacing knot 3**

--- a/markdown/org/docs/patterns/benjamin/needs/en.md
+++ b/markdown/org/docs/patterns/benjamin/needs/en.md
@@ -1,7 +1,7 @@
 To make Benjamin, you will need the following:
 
--   Basic sewing supplies
--   About 0.5 meters (0.6 yards) of a suitable fabric ([see Fabric options](/docs/patterns/benjamin/fabric/)). Left over
-    pieces of a recent project could work too.
--   About the same amount of interfacing
--   Optionally: Bow tie adjustment ribbon and hardware
+- Basic sewing supplies
+- About 0.5 meters (0.6 yards) of a suitable fabric ([see Fabric options](/docs/patterns/benjamin/fabric/)). Left over
+  pieces of a recent project could work too.
+- About the same amount of interfacing
+- Optionally: Bow tie adjustment ribbon and hardware

--- a/markdown/org/docs/patterns/benjamin/options/bowstyle/en.md
+++ b/markdown/org/docs/patterns/benjamin/options/bowstyle/en.md
@@ -2,10 +2,10 @@ Four different bow tie styles!
 
 Benjamin allows you to make four different bow ties.
 
--   Contemporary Diamond
--   Traditional Butterfly
--   Classic Square
--   Whimsical Wide Square
+- Contemporary Diamond
+- Traditional Butterfly
+- Classic Square
+- Whimsical Wide Square
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/benjamin/options/endstyle/en.md
+++ b/markdown/org/docs/patterns/benjamin/options/endstyle/en.md
@@ -3,9 +3,9 @@
 In addition to having four different bow tie styles, each style can be individualized
 with three different tip options:
 
--   Straight
--   Pointed
--   Round
+- Straight
+- Pointed
+- Round
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/bent/cutting/en.md
+++ b/markdown/org/docs/patterns/bent/cutting/en.md
@@ -4,10 +4,10 @@ title: Bent Cutting
 
 **Main fabric**
 
--   Cut **1 Front** part on the fold.
--   Cut **1 Back** part on the fold.
--   Cut **2 Top sleeve** parts.
--   Cut **2 Under sleeve** parts.
+- Cut **1 Front** part on the fold.
+- Cut **1 Back** part on the fold.
+- Cut **2 Top sleeve** parts.
+- Cut **2 Under sleeve** parts.
 
 These cutting instructions are just for the default Bent block. Adjust your cutting accordingly if you have/are making changes to the block.
 

--- a/markdown/org/docs/patterns/bent/instructions/en.md
+++ b/markdown/org/docs/patterns/bent/instructions/en.md
@@ -21,10 +21,10 @@ As Bent is a block it does not have any closures. So the instructions below will
 
 ### Step 1: Mock-up Construction
 
--   Sew the fronts to the back at the shoulder seams good sides together.
--   Sew the fronts to the back at the side seams good sides together.
--   Sew the under sleeves to the top sleeves good sides together along the side seams.
--   Attach the sleeves to the body, good sides together and sew them in the round.
+- Sew the fronts to the back at the shoulder seams good sides together.
+- Sew the fronts to the back at the side seams good sides together.
+- Sew the under sleeves to the top sleeves good sides together along the side seams.
+- Attach the sleeves to the body, good sides together and sew them in the round.
 
 <Note>
 
@@ -40,9 +40,9 @@ If you are making adjustments you may wish to sew the seams wrong sides together
 
 ### Step 2: Try it on
 
--   Try it on and check the fit by pinning the front closed whilst wearing it.
--   Make any alterations and try it on again.
--   Repeat until you are happy.
+- Try it on and check the fit by pinning the front closed whilst wearing it.
+- Make any alterations and try it on again.
+- Repeat until you are happy.
 
 <Tip>
 
@@ -58,10 +58,10 @@ Sometimes you may need to wear the mock-up for an extended amount of time to get
 Remember to treat Bent as a basis rather than a final product, so adjust what you need to get the desired look.\
 For instance:
 
--   Change the neck line
--   Add/change the closure allowances
--   Alter the hem style
--   Add a collar
+- Change the neck line
+- Add/change the closure allowances
+- Alter the hem style
+- Add a collar
 
 It is all up to you! Experiment and go forth!
 
@@ -69,8 +69,8 @@ It is all up to you! Experiment and go forth!
 
 ### Step 3: Make a paper pattern
 
--   Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
--   Now you have a pattern you can use to produce a garment.
+- Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
+- Now you have a pattern you can use to produce a garment.
 
 <Note>
 

--- a/markdown/org/docs/patterns/bent/needs/en.md
+++ b/markdown/org/docs/patterns/bent/needs/en.md
@@ -4,8 +4,8 @@ title: Bent What you need
 
 To make Bent, you will need the following:
 
--   Basic sewing supplies
--   About 1.5 - 2 metres (1.7 - 2.2 yards) of a suitable fabric ([see Bent Fabric options](/docs/patterns/bent/fabric/))
+- Basic sewing supplies
+- About 1.5 - 2 metres (1.7 - 2.2 yards) of a suitable fabric ([see Bent Fabric options](/docs/patterns/bent/fabric/))
 
 This list is for a default Bent Block. If you have/are making changes to the block you may need to get additional items such as closures, binding etc.
 

--- a/markdown/org/docs/patterns/bent/options/s3armhole/en.md
+++ b/markdown/org/docs/patterns/bent/options/s3armhole/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the armhole side.
 
--   Increase this option to shift the shoulder seam forward on the armhole side
--   Decrease this option to shift the shoulder seam backward on the armhole side
+- Increase this option to shift the shoulder seam forward on the armhole side
+- Decrease this option to shift the shoulder seam backward on the armhole side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/bent/options/s3collar/en.md
+++ b/markdown/org/docs/patterns/bent/options/s3collar/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the collar side.
 
--   Increase this option to shift the shoulder seam forward on the collar side
--   Decrease this option to shift the shoulder seam backward on the collar side
+- Increase this option to shift the shoulder seam forward on the collar side
+- Decrease this option to shift the shoulder seam backward on the collar side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/breanna/cutting/en.md
+++ b/markdown/org/docs/patterns/breanna/cutting/en.md
@@ -1,8 +1,8 @@
 **Main fabric**
 
--   Cut **1 Front** part on the fold.
--   Cut **2 Back** parts.
--   Cut **2 Sleeve** parts, _good sides together_.
+- Cut **1 Front** part on the fold.
+- Cut **2 Back** parts.
+- Cut **2 Sleeve** parts, _good sides together_.
 
 These cutting instructions are just for the default Breanna block. Adjust your cutting accordingly if you have/are making changes to the block.
 

--- a/markdown/org/docs/patterns/breanna/cutting/en.md
+++ b/markdown/org/docs/patterns/breanna/cutting/en.md
@@ -2,7 +2,7 @@
 
 -   Cut **1 Front** part on the fold.
 -   Cut **2 Back** parts.
--   Cut **2 Sleeve** parts, *good sides together*.
+-   Cut **2 Sleeve** parts, _good sides together_.
 
 These cutting instructions are just for the default Breanna block. Adjust your cutting accordingly if you have/are making changes to the block.
 

--- a/markdown/org/docs/patterns/breanna/instructions/en.md
+++ b/markdown/org/docs/patterns/breanna/instructions/en.md
@@ -11,11 +11,11 @@ Blocks are typically not made as-is but rather serve as a basis for other patter
 
 ### Step 1: Mock-up Construction
 
--   Close the front darts.
--   Close the back darts.
--   Sew the front to the backs at the shoulders good sides together.
--   Matching notches, sew the sleeves to the shoulder good sides together.
--   Sew the side seams good sides together.
+- Close the front darts.
+- Close the back darts.
+- Sew the front to the backs at the shoulders good sides together.
+- Matching notches, sew the sleeves to the shoulder good sides together.
+- Sew the side seams good sides together.
 
 <Note>
 
@@ -31,9 +31,9 @@ If you are making adjustments you may wish to sew the seams wrong sides together
 
 ### Step 2: Try it on
 
--   Try it on and check the fit by pinning the back closed whilst wearing it.
--   Make any alterations and try it on again.
--   Repeat until you are happy.
+- Try it on and check the fit by pinning the back closed whilst wearing it.
+- Make any alterations and try it on again.
+- Repeat until you are happy.
 
 <Tip>
 
@@ -50,10 +50,10 @@ Sometimes you may need to wear the mock-up for an extended amount of time to get
 Remember to treat Breanna as a basis rather than a final product, so adjust what you need to get the desired look.\
 For instance:
 
--   Change the neck line
--   Add/change the closure allowances
--   Alter the dart placements
--   Add a collar
+- Change the neck line
+- Add/change the closure allowances
+- Alter the dart placements
+- Add a collar
 
 It is all up to you! Experiment and go forth!
 
@@ -61,8 +61,8 @@ It is all up to you! Experiment and go forth!
 
 ### Step 3: Make a paper pattern
 
--   Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
--   Now you have a pattern you can use to produce a garment.
+- Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
+- Now you have a pattern you can use to produce a garment.
 
 <Note>
 

--- a/markdown/org/docs/patterns/breanna/needs/en.md
+++ b/markdown/org/docs/patterns/breanna/needs/en.md
@@ -1,7 +1,7 @@
 To make Breanna, you will need the following:
 
--   Basic sewing supplies
--   About 1.25 - 1.5 metres (1.4 - 1.7 yards) of a suitable fabric ([see Breanna Fabric options](/docs/patterns/Breanna/fabric/))
+- Basic sewing supplies
+- About 1.25 - 1.5 metres (1.4 - 1.7 yards) of a suitable fabric ([see Breanna Fabric options](/docs/patterns/Breanna/fabric/))
 
 This list is for a default Breanna Block. If you have/are making changes to the block you may need to get additional items such as closures, binding etc.
 

--- a/markdown/org/docs/patterns/breanna/options/en.md
+++ b/markdown/org/docs/patterns/breanna/options/en.md
@@ -12,7 +12,7 @@ sleevecap is drafted makes it easy to understand what all the individual options
 
 ### The bounding box
 
-The *bounding box* of the sleevecap is a rectangle that is as wide as the sleeve, and
+The _bounding box_ of the sleevecap is a rectangle that is as wide as the sleeve, and
 as high as the sleevecap. Inside this box, we will construct our sleevecap later.
 
 ![The Breanna sleevecap](sleevecap.svg)
@@ -59,7 +59,7 @@ be changed to lie more to the right or the left, rather than smack in the middle
 ![Controlling the inflection points](sleevecapinflection.svg)
 
 With points 1, 2, 3, and 4 in place, we have a box to draw our sleevecap in. Now it's time to
-map out our *inflection points*. These are points 5 and 6 on our drawing, and their placement
+map out our _inflection points_. These are points 5 and 6 on our drawing, and their placement
 is determined by the following 4 options:
 
 -   [Sleevecap back X](/docs/patterns/breanna/options/sleevecapbackfactorx) : Controls the horizontal placement of point 5
@@ -79,10 +79,10 @@ are instrumental in creating the points that always lie on the sleevecap: the an
 ![Controlling the anchor points](sleevecapanchor.svg)
 
 Ultimately, our sleevecap will be the combination of 5 curves. In addition to points 1 and 2,
-the four *anchor points* that are marked in orange in our example will be the start/finish of
+the four _anchor points_ that are marked in orange in our example will be the start/finish of
 those curves.
 
-The points are *offset* perpendicular from the middle of a line between the two anchor points
+The points are _offset_ perpendicular from the middle of a line between the two anchor points
 surrounding them. The offset for each point is controlled by these 4 options:
 
 -   [Sleevecap Q1 offset](/docs/patterns/breanna/options/sleevecapq1offset) : Controls the offset perpendicular to the line from points 2 to 6
@@ -107,7 +107,7 @@ control each quarter individually.
 We now have all the start and end points to draw the 5 curves that will make up our sleevecaps.
 What we're missing are the control points
 (see [our info on Bézier curves](https://freesewing.dev/concepts/beziercurves) to learn more
-about how curves are constructed). These are determined by the so-called *spread*.
+about how curves are constructed). These are determined by the so-called _spread_.
 
 For each of the anchor points (the ones marked in orange, not points 1 and 2) there is an option
 to control the spread upwards, and downwards:

--- a/markdown/org/docs/patterns/breanna/options/en.md
+++ b/markdown/org/docs/patterns/breanna/options/en.md
@@ -48,8 +48,8 @@ is a trade-off between the measurments of the model, options, ease, sleevecap ea
 that the sleeve ultimately has to fit the armhole. So the height may vary, and we don't control
 the exact value. But there are two options that control the shape of our sleevecap:
 
--   [Sleevecap top X](/docs/patterns/breanna/options/sleevecaptopfactorx/) : Controls the horizontal placement of point 3 and 4
--   [Sleevecap top Y](/docs/patterns/breanna/options/sleevecaptopfactory/) : Controls the vertical placement of point 4
+- [Sleevecap top X](/docs/patterns/breanna/options/sleevecaptopfactorx/) : Controls the horizontal placement of point 3 and 4
+- [Sleevecap top Y](/docs/patterns/breanna/options/sleevecaptopfactory/) : Controls the vertical placement of point 4
 
 In other words, point 4 can be made higher and lower and, perhaps less intutitively, it can also
 be changed to lie more to the right or the left, rather than smack in the middle as in our example.
@@ -62,10 +62,10 @@ With points 1, 2, 3, and 4 in place, we have a box to draw our sleevecap in. Now
 map out our _inflection points_. These are points 5 and 6 on our drawing, and their placement
 is determined by the following 4 options:
 
--   [Sleevecap back X](/docs/patterns/breanna/options/sleevecapbackfactorx) : Controls the horizontal placement of point 5
--   [Sleevecap back Y](/docs/patterns/breanna/options/sleevecapbackfactory) : Controls the vertical placement of point 5
--   [Sleevecap front X](/docs/patterns/breanna/options/sleevecapbackfactorx) : Controls the horizontal placement of point 6
--   [Sleevecap front Y](/docs/patterns/breanna/options/sleevecapbackfactory) : Controls the vertical placement of point 6
+- [Sleevecap back X](/docs/patterns/breanna/options/sleevecapbackfactorx) : Controls the horizontal placement of point 5
+- [Sleevecap back Y](/docs/patterns/breanna/options/sleevecapbackfactory) : Controls the vertical placement of point 5
+- [Sleevecap front X](/docs/patterns/breanna/options/sleevecapbackfactorx) : Controls the horizontal placement of point 6
+- [Sleevecap front Y](/docs/patterns/breanna/options/sleevecapbackfactory) : Controls the vertical placement of point 6
 
 <Note>
 
@@ -85,10 +85,10 @@ those curves.
 The points are _offset_ perpendicular from the middle of a line between the two anchor points
 surrounding them. The offset for each point is controlled by these 4 options:
 
--   [Sleevecap Q1 offset](/docs/patterns/breanna/options/sleevecapq1offset) : Controls the offset perpendicular to the line from points 2 to 6
--   [Sleevecap Q2 offset](/docs/patterns/breanna/options/sleevecapq2offset) : Controls the offset perpendicular to the line from points 6 to 4
--   [Sleevecap Q3 offset](/docs/patterns/breanna/options/sleevecapq3offset) : Controls the offset perpendicular to the line from points 4 to 5
--   [Sleevecap Q4 offset](/docs/patterns/breanna/options/sleevecapq3offset) : Controls the offset perpendicular to the line from points 5 to 1
+- [Sleevecap Q1 offset](/docs/patterns/breanna/options/sleevecapq1offset) : Controls the offset perpendicular to the line from points 2 to 6
+- [Sleevecap Q2 offset](/docs/patterns/breanna/options/sleevecapq2offset) : Controls the offset perpendicular to the line from points 6 to 4
+- [Sleevecap Q3 offset](/docs/patterns/breanna/options/sleevecapq3offset) : Controls the offset perpendicular to the line from points 4 to 5
+- [Sleevecap Q4 offset](/docs/patterns/breanna/options/sleevecapq3offset) : Controls the offset perpendicular to the line from points 5 to 1
 
 <Note>
 
@@ -112,14 +112,14 @@ about how curves are constructed). These are determined by the so-called _spread
 For each of the anchor points (the ones marked in orange, not points 1 and 2) there is an option
 to control the spread upwards, and downwards:
 
--   [Sleevecap Q1 downward spread](/docs/patterns/breanna/options/sleevecapq1spread1) : Controls the downward spread in the first quarter
--   [Sleevecap Q1 upward spread](/docs/patterns/breanna/options/sleevecapq1spread2) : Controls the upward spread in the first quarter
--   [Sleevecap Q2 downward spread](/docs/patterns/breanna/options/sleevecapq2spread1) : Controls the downward spread in the second quarter
--   [Sleevecap Q2 upward spread](/docs/patterns/breanna/options/sleevecapq2spread2) : Controls the upward spread in the second quarter
--   [Sleevecap Q3 upward spread](/docs/patterns/breanna/options/sleevecapq3spread1) : Controls the upward spread in the third quarter
--   [Sleevecap Q3 downward spread](/docs/patterns/breanna/options/sleevecapq3spread2) : Controls the downward spread in the third quarter
--   [Sleevecap Q4 upward spread](/docs/patterns/breanna/options/sleevecapq4spread1) : Controls the upward spread in the fourth quarter
--   [Sleevecap Q4 downward spread](/docs/patterns/breanna/options/sleevecapq4spread2) : Controls the downward spread in the fourth quarter
+- [Sleevecap Q1 downward spread](/docs/patterns/breanna/options/sleevecapq1spread1) : Controls the downward spread in the first quarter
+- [Sleevecap Q1 upward spread](/docs/patterns/breanna/options/sleevecapq1spread2) : Controls the upward spread in the first quarter
+- [Sleevecap Q2 downward spread](/docs/patterns/breanna/options/sleevecapq2spread1) : Controls the downward spread in the second quarter
+- [Sleevecap Q2 upward spread](/docs/patterns/breanna/options/sleevecapq2spread2) : Controls the upward spread in the second quarter
+- [Sleevecap Q3 upward spread](/docs/patterns/breanna/options/sleevecapq3spread1) : Controls the upward spread in the third quarter
+- [Sleevecap Q3 downward spread](/docs/patterns/breanna/options/sleevecapq3spread2) : Controls the downward spread in the third quarter
+- [Sleevecap Q4 upward spread](/docs/patterns/breanna/options/sleevecapq4spread1) : Controls the upward spread in the fourth quarter
+- [Sleevecap Q4 downward spread](/docs/patterns/breanna/options/sleevecapq4spread2) : Controls the downward spread in the fourth quarter
 
 <Note>
 
@@ -135,10 +135,10 @@ the curve will rise above it.
 While the sleevecap in Breanna (and all patterns that extend Breanna) have a lot of options, understanding how the
 sleevecap is constructed can help you design the exact sleevecap shape you want. To do so:
 
--   Start with placing the top of your sleevecap
--   Then determine the inflection points
--   Next, use the offset to control the steepness of the curve
--   Finally, use the spread to smooth things out
+- Start with placing the top of your sleevecap
+- Then determine the inflection points
+- Next, use the offset to control the steepness of the curve
+- Finally, use the spread to smooth things out
 
 What's important to remember is that you're only ever controlling the shape of the sleevecap.
 Whatever shape you design, it will be fitted to the armhole, meaning that its size can and will be adapted

--- a/markdown/org/docs/patterns/brian/cutting/en.md
+++ b/markdown/org/docs/patterns/brian/cutting/en.md
@@ -1,8 +1,8 @@
 **Main fabric**
 
--   Cut **1 Front** part on the fold.
--   Cut **1 Back** part on the fold.
--   Cut **2 Sleeve** parts.
+- Cut **1 Front** part on the fold.
+- Cut **1 Back** part on the fold.
+- Cut **2 Sleeve** parts.
 
 These cutting instructions are just for the default Brian block. Adjust your cutting accordingly if you have/are making changes to the block.
 

--- a/markdown/org/docs/patterns/brian/instructions/en.md
+++ b/markdown/org/docs/patterns/brian/instructions/en.md
@@ -11,9 +11,9 @@ Blocks are typically not made as-is but rather serve as a basis for other patter
 
 ### Step 1: Mock-up Construction
 
--   Sew the front to the backs at the shoulders good sides together.
--   Matching notches, sew the sleeves to the shoulder good sides together.
--   Sew the side seams good sides together.
+- Sew the front to the backs at the shoulders good sides together.
+- Matching notches, sew the sleeves to the shoulder good sides together.
+- Sew the side seams good sides together.
 
 <Note>
 
@@ -29,9 +29,9 @@ If you are making adjustments you may wish to sew the seams wrong sides together
 
 ### Step 2: Try it on
 
--   Try it on and check the fit by pinning the back closed whilst wearing it.
--   Make any alterations and try it on again.
--   Repeat until you are happy.
+- Try it on and check the fit by pinning the back closed whilst wearing it.
+- Make any alterations and try it on again.
+- Repeat until you are happy.
 
 <Tip>
 
@@ -48,9 +48,9 @@ Sometimes you may need to wear the mock-up for an extended amount of time to get
 Remember to treat Brian as a basis rather than a final product, so adjust what you need to get the desired look.\
 For instance:
 
--   Change the neck line
--   Add/change the closure allowances
--   Add a collar
+- Change the neck line
+- Add/change the closure allowances
+- Add a collar
 
 It is all up to you! Experiment and go forth!
 
@@ -58,8 +58,8 @@ It is all up to you! Experiment and go forth!
 
 ### Step 3: Make a paper pattern
 
--   Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
--   Now you have a pattern you can use to produce a garment.
+- Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
+- Now you have a pattern you can use to produce a garment.
 
 <Note>
 

--- a/markdown/org/docs/patterns/brian/needs/en.md
+++ b/markdown/org/docs/patterns/brian/needs/en.md
@@ -1,7 +1,7 @@
 To make Brian, you will need the following:
 
--   Basic sewing supplies
--   About 1.25 - 1.5 metres (1.4 - 1.7 yards) of a suitable fabric ([see Brian Fabric options](/docs/patterns/brian/fabric/))
+- Basic sewing supplies
+- About 1.25 - 1.5 metres (1.4 - 1.7 yards) of a suitable fabric ([see Brian Fabric options](/docs/patterns/brian/fabric/))
 
 This list is for a default Brian Block. If you have/are making changes to the block you may need to get additional items such as closures, binding etc.
 

--- a/markdown/org/docs/patterns/brian/options/en.md
+++ b/markdown/org/docs/patterns/brian/options/en.md
@@ -12,7 +12,7 @@ sleevecap is drafted makes it easy to understand what all the individual options
 
 ### The bounding box
 
-The *bounding box* of the sleevecap is a rectangle that is as wide as the sleeve, and
+The _bounding box_ of the sleevecap is a rectangle that is as wide as the sleeve, and
 as high as the sleevecap. Inside this box, we will construct our sleevecap later.
 
 ![The Brian sleevecap](sleevecap.svg)
@@ -59,7 +59,7 @@ be changed to lie more to the right or the left, rather than smack in the middle
 ![Controlling the inflection points](sleevecapinflection.svg)
 
 With points 1, 2, 3, and 4 in place, we have a box to draw our sleevecap in. Now it's time to
-map out our *inflection points*. These are points 5 and 6 on our drawing, and their placement
+map out our _inflection points_. These are points 5 and 6 on our drawing, and their placement
 is determined by the following 4 options:
 
 -   [Sleevecap back X](/docs/patterns/brian/options/sleevecapbackfactorx) : Controls the horizontal placement of point 5
@@ -79,10 +79,10 @@ are instrumental in creating the points that always lie on the sleevecap: the an
 ![Controlling the anchor points](sleevecapanchor.svg)
 
 Ultimately, our sleevecap will be the combination of 5 curves. In addition to points 1 and 2,
-the four *anchor points* that are marked in orange in our example will be the start/finish of
+the four _anchor points_ that are marked in orange in our example will be the start/finish of
 those curves.
 
-The points are *offset* perpendicular from the middle of a line between the two anchor points
+The points are _offset_ perpendicular from the middle of a line between the two anchor points
 surrounding them. The offset for each point is controlled by these 4 options:
 
 -   [Sleevecap Q1 offset](/docs/patterns/brian/options/sleevecapq1offset) : Controls the offset perpendicular to the line from points 2 to 6
@@ -107,7 +107,7 @@ control each quarter individually.
 We now have all the start and end points to draw the 5 curves that will make up our sleevecaps.
 What we're missing are the control points
 (see [our info on Bézier curves](https://freesewing.dev/concepts/beziercurves) to learn more
-about how curves are constructed). These are determined by the so-called *spread*.
+about how curves are constructed). These are determined by the so-called _spread_.
 
 For each of the anchor points (the ones marked in orange, not points 1 and 2) there is an option
 to control the spread upwards, and downwards:

--- a/markdown/org/docs/patterns/brian/options/en.md
+++ b/markdown/org/docs/patterns/brian/options/en.md
@@ -48,8 +48,8 @@ is a trade-off between the measurments of the model, options, ease, sleevecap ea
 that the sleeve ultimately has to fit the armhole. So the height may vary, and we don't control
 the exact value. But there are two options that control the shape of our sleevecap:
 
--   [Sleevecap top X](/docs/patterns/brian/options/sleevecaptopfactorx/) : Controls the horizontal placement of point 3 and 4
--   [Sleevecap top Y](/docs/patterns/brian/options/sleevecaptopfactory/) : Controls the vertical placement of point 4
+- [Sleevecap top X](/docs/patterns/brian/options/sleevecaptopfactorx/) : Controls the horizontal placement of point 3 and 4
+- [Sleevecap top Y](/docs/patterns/brian/options/sleevecaptopfactory/) : Controls the vertical placement of point 4
 
 In other words, point 4 can be made higher and lower and, perhaps less intutitively, it can also
 be changed to lie more to the right or the left, rather than smack in the middle as in our example.
@@ -62,10 +62,10 @@ With points 1, 2, 3, and 4 in place, we have a box to draw our sleevecap in. Now
 map out our _inflection points_. These are points 5 and 6 on our drawing, and their placement
 is determined by the following 4 options:
 
--   [Sleevecap back X](/docs/patterns/brian/options/sleevecapbackfactorx) : Controls the horizontal placement of point 5
--   [Sleevecap back Y](/docs/patterns/brian/options/sleevecapbackfactory) : Controls the vertical placement of point 5
--   [Sleevecap front X](/docs/patterns/brian/options/sleevecapbackfactorx) : Controls the horizontal placement of point 6
--   [Sleevecap front Y](/docs/patterns/brian/options/sleevecapbackfactory) : Controls the vertical placement of point 6
+- [Sleevecap back X](/docs/patterns/brian/options/sleevecapbackfactorx) : Controls the horizontal placement of point 5
+- [Sleevecap back Y](/docs/patterns/brian/options/sleevecapbackfactory) : Controls the vertical placement of point 5
+- [Sleevecap front X](/docs/patterns/brian/options/sleevecapbackfactorx) : Controls the horizontal placement of point 6
+- [Sleevecap front Y](/docs/patterns/brian/options/sleevecapbackfactory) : Controls the vertical placement of point 6
 
 <Note>
 
@@ -85,10 +85,10 @@ those curves.
 The points are _offset_ perpendicular from the middle of a line between the two anchor points
 surrounding them. The offset for each point is controlled by these 4 options:
 
--   [Sleevecap Q1 offset](/docs/patterns/brian/options/sleevecapq1offset) : Controls the offset perpendicular to the line from points 2 to 6
--   [Sleevecap Q2 offset](/docs/patterns/brian/options/sleevecapq2offset) : Controls the offset perpendicular to the line from points 6 to 4
--   [Sleevecap Q3 offset](/docs/patterns/brian/options/sleevecapq3offset) : Controls the offset perpendicular to the line from points 4 to 5
--   [Sleevecap Q4 offset](/docs/patterns/brian/options/sleevecapq3offset) : Controls the offset perpendicular to the line from points 5 to 1
+- [Sleevecap Q1 offset](/docs/patterns/brian/options/sleevecapq1offset) : Controls the offset perpendicular to the line from points 2 to 6
+- [Sleevecap Q2 offset](/docs/patterns/brian/options/sleevecapq2offset) : Controls the offset perpendicular to the line from points 6 to 4
+- [Sleevecap Q3 offset](/docs/patterns/brian/options/sleevecapq3offset) : Controls the offset perpendicular to the line from points 4 to 5
+- [Sleevecap Q4 offset](/docs/patterns/brian/options/sleevecapq3offset) : Controls the offset perpendicular to the line from points 5 to 1
 
 <Note>
 
@@ -112,14 +112,14 @@ about how curves are constructed). These are determined by the so-called _spread
 For each of the anchor points (the ones marked in orange, not points 1 and 2) there is an option
 to control the spread upwards, and downwards:
 
--   [Sleevecap Q1 downward spread](/docs/patterns/brian/options/sleevecapq1spread1) : Controls the downward spread in the first quarter
--   [Sleevecap Q1 upward spread](/docs/patterns/brian/options/sleevecapq1spread2) : Controls the upward spread in the first quarter
--   [Sleevecap Q2 downward spread](/docs/patterns/brian/options/sleevecapq2spread1) : Controls the downward spread in the second quarter
--   [Sleevecap Q2 upward spread](/docs/patterns/brian/options/sleevecapq2spread2) : Controls the upward spread in the second quarter
--   [Sleevecap Q3 upward spread](/docs/patterns/brian/options/sleevecapq3spread1) : Controls the upward spread in the third quarter
--   [Sleevecap Q3 downward spread](/docs/patterns/brian/options/sleevecapq3spread2) : Controls the downward spread in the third quarter
--   [Sleevecap Q4 upward spread](/docs/patterns/brian/options/sleevecapq4spread1) : Controls the upward spread in the fourth quarter
--   [Sleevecap Q4 downward spread](/docs/patterns/brian/options/sleevecapq4spread2) : Controls the downward spread in the fourth quarter
+- [Sleevecap Q1 downward spread](/docs/patterns/brian/options/sleevecapq1spread1) : Controls the downward spread in the first quarter
+- [Sleevecap Q1 upward spread](/docs/patterns/brian/options/sleevecapq1spread2) : Controls the upward spread in the first quarter
+- [Sleevecap Q2 downward spread](/docs/patterns/brian/options/sleevecapq2spread1) : Controls the downward spread in the second quarter
+- [Sleevecap Q2 upward spread](/docs/patterns/brian/options/sleevecapq2spread2) : Controls the upward spread in the second quarter
+- [Sleevecap Q3 upward spread](/docs/patterns/brian/options/sleevecapq3spread1) : Controls the upward spread in the third quarter
+- [Sleevecap Q3 downward spread](/docs/patterns/brian/options/sleevecapq3spread2) : Controls the downward spread in the third quarter
+- [Sleevecap Q4 upward spread](/docs/patterns/brian/options/sleevecapq4spread1) : Controls the upward spread in the fourth quarter
+- [Sleevecap Q4 downward spread](/docs/patterns/brian/options/sleevecapq4spread2) : Controls the downward spread in the fourth quarter
 
 <Note>
 
@@ -135,10 +135,10 @@ the curve will rise above it.
 While the sleevecap in Brian (and all patterns that extend Brian) have a lot of options, understanding how the
 sleevecap is constructed can help you design the exact sleevecap shape you want. To do so:
 
--   Start with placing the top of your sleevecap
--   Then determine the inflection points
--   Next, use the offset to control the steepness of the curve
--   Finally, use the spread to smooth things out
+- Start with placing the top of your sleevecap
+- Then determine the inflection points
+- Next, use the offset to control the steepness of the curve
+- Finally, use the spread to smooth things out
 
 What's important to remember is that you're only ever controlling the shape of the sleevecap.
 Whatever shape you design, it will be fitted to the armhole, meaning that its size can and will be adapted

--- a/markdown/org/docs/patterns/brian/options/s3armhole/en.md
+++ b/markdown/org/docs/patterns/brian/options/s3armhole/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the armhole side.
 
--   Increase this option to shift the shoulder seam forward on the armhole side
--   Decrease this option to shift the shoulder seam backward on the armhole side
+- Increase this option to shift the shoulder seam forward on the armhole side
+- Decrease this option to shift the shoulder seam backward on the armhole side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/brian/options/s3collar/en.md
+++ b/markdown/org/docs/patterns/brian/options/s3collar/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the collar side.
 
--   Increase this option to shift the shoulder seam forward on the collar side
--   Decrease this option to shift the shoulder seam backward on the collar side
+- Increase this option to shift the shoulder seam forward on the collar side
+- Decrease this option to shift the shoulder seam backward on the collar side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/bruce/cutting/en.md
+++ b/markdown/org/docs/patterns/bruce/cutting/en.md
@@ -1,16 +1,16 @@
 Bruce consists of a back, and two sides, insets and fronts.
 
--   **Main fabric**
-    -   Cut **1 back** on the fold
-    -   Cut **2 fronts**
-    -   Cut **2 insets**
-    -   Cut **2 sides**
+- **Main fabric**
+  - Cut **1 back** on the fold
+  - Cut **2 fronts**
+  - Cut **2 insets**
+  - Cut **2 sides**
 
 <Warning>
 
 ###### Caveats
 
--   **back**: Extra hem allowance at the leg
--   **front**: Cut this **twice**
+- **back**: Extra hem allowance at the leg
+- **front**: Cut this **twice**
 
 </Warning>

--- a/markdown/org/docs/patterns/bruce/instructions/en.md
+++ b/markdown/org/docs/patterns/bruce/instructions/en.md
@@ -73,9 +73,9 @@ After you have joined the first inset and the fronts, continue with the second o
 
 With the fronts and insets joined together, you are left with 3 parts:
 
--   The joined insets and fronts
--   The joined sides and back
--   The elastic
+- The joined insets and fronts
+- The joined sides and back
+- The elastic
 
 ### Step 5: Close the fronts dart
 

--- a/markdown/org/docs/patterns/bruce/needs/en.md
+++ b/markdown/org/docs/patterns/bruce/needs/en.md
@@ -1,6 +1,6 @@
 To make Bruce, you will need the following:
 
--   Basic sewing supplies
--   About 1 meter (1.1 yards) of a suitable fabric ([see Fabric options](/docs/patterns/bruce/fabric/))
--   Enough wide (3cm (1.2 inch) or wider) elastic to fit around your waist
--   A serger, although you can survive without one
+- Basic sewing supplies
+- About 1 meter (1.1 yards) of a suitable fabric ([see Fabric options](/docs/patterns/bruce/fabric/))
+- Enough wide (3cm (1.2 inch) or wider) elastic to fit around your waist
+- A serger, although you can survive without one

--- a/markdown/org/docs/patterns/carlita/cutting/en.md
+++ b/markdown/org/docs/patterns/carlita/cutting/en.md
@@ -6,22 +6,22 @@ Certain parts have to be drafted off of the existing parts. How to draft these a
 
 ### Materials
 
--   **Main fabric**
-    -   Cut **2 Front** parts
-    -   Cut **2 Side** parts
-    -   Cut **2 Front facing** parts
-    -   Cut **2 Back** parts
-    -   Cut **2 topsleeve** parts
-    -   Cut **2 undersleeve** parts
-    -   Cut **2 tail** parts
-    -   Cut **4 belt** parts
-    -   Cut **2 Collar stand** parts
-    -   Cut **2 collar** parts on the fold or Cut the upper collar on the fold and the under collar on the bias
-    -   Cut **2 cuffFacing** parts
-    -   Cut **2 Pocket** parts
-    -   Cut **4 pocketFlap** parts
-    -   Cut **2 chestPocketWelt** parts
-    -   Cut **2 innerPocketWelt** parts
+- **Main fabric**
+  - Cut **2 Front** parts
+  - Cut **2 Side** parts
+  - Cut **2 Front facing** parts
+  - Cut **2 Back** parts
+  - Cut **2 topsleeve** parts
+  - Cut **2 undersleeve** parts
+  - Cut **2 tail** parts
+  - Cut **4 belt** parts
+  - Cut **2 Collar stand** parts
+  - Cut **2 collar** parts on the fold or Cut the upper collar on the fold and the under collar on the bias
+  - Cut **2 cuffFacing** parts
+  - Cut **2 Pocket** parts
+  - Cut **4 pocketFlap** parts
+  - Cut **2 chestPocketWelt** parts
+  - Cut **2 innerPocketWelt** parts
 
 <Note>
 
@@ -29,30 +29,30 @@ If your main fabric is quite lightweight and flimsy you may need to interface al
 
 </Note>
 
--   **Lining fabric**
-    -   Cut **2 Front lining** parts
-    -   Cut **2 Side** parts
-    -   Cut **2 Back** parts
-    -   Cut **2 topsleeve** parts
-    -   Cut **2 undersleeve** parts
-    -   Cut **2 tail** parts
-    -   Cut **2 innerPocketBag** parts
-    -   Cut **1 innerPocketTab** parts
-    -   Cut **2 pocketLining** parts
-    -   Cut **2 chestPocketBag** parts
--   **Light to Mediumweight Hair Canvas**
-    -   Cut **2 Front** parts
-    -   Cut **2 Side** parts
-    -   Cut **1 Collar stand** parts
-    -   Cut **2 collar** parts on the bias and seam together
-    -   Cut **2 cuffFacing** parts
-    -   Cut **2 pocketFlap** parts
-    -   Cut **2 chestPocketWelt** parts
-    -   Cut **2 innerPocketWelt** parts
--   **Heavyweight Hair Canvas**
-    -   Cut **2 Front shoulder** parts
-    -   Cut **2 Side shoulder** parts
-    -   Cut **2 Back shoulder** parts
+- **Lining fabric**
+  - Cut **2 Front lining** parts
+  - Cut **2 Side** parts
+  - Cut **2 Back** parts
+  - Cut **2 topsleeve** parts
+  - Cut **2 undersleeve** parts
+  - Cut **2 tail** parts
+  - Cut **2 innerPocketBag** parts
+  - Cut **1 innerPocketTab** parts
+  - Cut **2 pocketLining** parts
+  - Cut **2 chestPocketBag** parts
+- **Light to Mediumweight Hair Canvas**
+  - Cut **2 Front** parts
+  - Cut **2 Side** parts
+  - Cut **1 Collar stand** parts
+  - Cut **2 collar** parts on the bias and seam together
+  - Cut **2 cuffFacing** parts
+  - Cut **2 pocketFlap** parts
+  - Cut **2 chestPocketWelt** parts
+  - Cut **2 innerPocketWelt** parts
+- **Heavyweight Hair Canvas**
+  - Cut **2 Front shoulder** parts
+  - Cut **2 Side shoulder** parts
+  - Cut **2 Back shoulder** parts
 
 <Note>
 

--- a/markdown/org/docs/patterns/carlita/instructions/en.md
+++ b/markdown/org/docs/patterns/carlita/instructions/en.md
@@ -6,12 +6,12 @@ Some parts for Carlton require you to draft parts from the existing parts. The f
 
 ##### Front facing and Front lining
 
--   Trace off of **Front** part.
--   Cut along the green line.
--   Add seam allowance (if including) along green line to both pieces
--   The piece with the lapel is now the **Front facing** part.
--   Trim the hem allowance (if included) of the remaining piece to seam allowance length
--   The remaining piece is now the **Front lining** part.
+- Trace off of **Front** part.
+- Cut along the green line.
+- Add seam allowance (if including) along green line to both pieces
+- The piece with the lapel is now the **Front facing** part.
+- Trim the hem allowance (if included) of the remaining piece to seam allowance length
+- The remaining piece is now the **Front lining** part.
 
 <Note>
 
@@ -27,24 +27,24 @@ Don't forget the seam allowance for these pieces when cutting if you are making 
 
 ##### Front and Side Shoulder
 
--   Trace off of **Front and Side** parts.
--   Tape together so the notches match and armhole is complete. Do not worry about connecting everything else, you just need the armhole.
--   Draw a curve from shoulder to bottom of armhole.
--   Cut along this curve and discard the lower parts.
--   Separate out the pieces back into their front and side pieces.
--   These are now you \*_Front and Side shoulder_ parts.
+- Trace off of **Front and Side** parts.
+- Tape together so the notches match and armhole is complete. Do not worry about connecting everything else, you just need the armhole.
+- Draw a curve from shoulder to bottom of armhole.
+- Cut along this curve and discard the lower parts.
+- Separate out the pieces back into their front and side pieces.
+- These are now you \*_Front and Side shoulder_ parts.
 
 ##### Back shoulder
 
--   Trace off of **Back** part.
--   Cut along the orange line.
--   Discard lower piece.
--   Remove the seam allowamces (if included) of the upper piece.
--   The upper piece is now the **Back shoulder** part.
+- Trace off of **Back** part.
+- Cut along the orange line.
+- Discard lower piece.
+- Remove the seam allowamces (if included) of the upper piece.
+- The upper piece is now the **Back shoulder** part.
 
 #### Cutting
 
--   Cut all the parts above from their respective fabrics/facings. ([see Carlita Cutting](/docs/patterns/carlita/cutting/))
+- Cut all the parts above from their respective fabrics/facings. ([see Carlita Cutting](/docs/patterns/carlita/cutting/))
 
 ### Step 2 : Preliminary Instructions
 
@@ -58,34 +58,34 @@ Below are some notes from [@AnnekeCaramin](/users/AnnekeCaramin) who
 
 </Warning>
 
--   Find and mark roll line on lapel,
--   Draft back stay & cut from heavy muslin or hair canvas if you want to be absolutely bulletproof
--   Iron interfacing onto back armholes, entire side front (except for seam & hem allowances), bias strips onto back hem
--   Stitch front shoulder hair canvas pieces to larger hair canvas piece (quilt together with parallel rows of stitching)
--   Attach front hair canvas thing to center front with permanent basting stitch
--   Get that thimble out and pad stitch the lapels
--   Tape the roll line
--   Tape the front and lapel edge
--   Take a picture and post it on social media because this looks so cool
--   Close back darts
--   Sew back seam in two parts. Baste the part that will form the pleat closed, fold down and press.
--   Baste the back stay to the shoulders, armholes and neckline
--   Stabilize waist seam with selvedge strip of muslin (optional)
--   Stabilize top of coat tail with strip of hair canvas (optional)
--   Fold, pin and baste pleats on coat tail piece
--   Sew waist seam and press up. Catch stitch waist seam to strip of muslin (optional)
--   Sew belt and pocket flap pieces with right sides together, turn and press.
--   Sew patch pocket top edge to lining, leaving a hole for turning later. Sew side and bottom edge of patch pocket to lining (make lining 1 mm smaller all around to make sure it doesn’t show on the outside). Turn and press.
--   Fold front welt pieces with right sides together, turn and press.
--   Place front welt on center front piece between notches. Put pocket bag on top. Match location of front welt and pocket bag on side front piece, pin second part of pocket bag in place. Stitch and press. Pin and sew princess seam up until pocket stitching, stop and continue after the pocket. Stitch the edges of the front welt down.
--   Place patch pocket and pocket flap on marked locations and attach.
--   Sew front sleeve seam. Attach cuff facing up until the cuff fold line. Stitch back sleeve seam, careful not to catch the facing. Sew the rest of the facing seam. Turn, press, fold cuff back and baste to keep in place.
--   Stitch upper lining piece to front facing. Stitch side front lining to front facing. (When using an extra back facing piece, leave top five cm of lining/facing seam unsewn)
--   Make inner pocket flap, fold and press welts. Mark welt location, pin welts, flap and pocket bag in place. Stitch. Slash between welts. Turn and press. Stitch those little triangle thingies to the welts and close pocket bag. Omg.
--   Optional: cut under collar on the bias to make it sit nicer. Interface collar stand. Sew collar stands to upper and under collar. Cut piece of hair canvas for under collar. Pad stitch under collar. Sew collar pieces around edge with right sides together, leaving bottom edge open. Turn and press. Fold collar into right shape around tailor’s ham or rolled up towel and steam the shit out of it.
--   Lining: optional: cut back neck facing from shell fabric to have something nice to sew a label on. Draft separate upper back lining piece. Stitch back seams, stitch darts as tucks. Stitch tail lining to upper back. Stitch shoulder and side seams on lining. Stitch shoulder seams on front and back facing. Stitch lining to facing, connecting the earlier stitching lines. Insert lining sleeves to mentally prepare for the real deal.
--   Get some shoulder pads or craft them yourself from hair canvas and cotton batting. Set in sleeves, cry, unpick, set in sleeves again. Add a strip of cotton batting to the sleeve head for maximum oomph. Attach shoulder pads.
--   Pin collar to neckline, matching center back to center collar. Mind the varying seam allowances! Baste in place. Pin facing/lining combo to neckline and front edge, sandwiching collar in between. Stitch carefully around the entire coat, including the bottom edge of the facing (leave the rest of the hem alone). Check for puckers or pleats, trim seams, turn the whole thing right side out and press.
--   Turn hem up, press and baste into place. Sew hem with an invisible stitch, then hand sew lining hem to coat.
--   Mark buttonholes on coat front and belt pieces. Make buttonholes and attach buttons.
--   Remove all basting still present, put on your coat, give yourself a pat on the back and then sleep for three weeks.
+- Find and mark roll line on lapel,
+- Draft back stay & cut from heavy muslin or hair canvas if you want to be absolutely bulletproof
+- Iron interfacing onto back armholes, entire side front (except for seam & hem allowances), bias strips onto back hem
+- Stitch front shoulder hair canvas pieces to larger hair canvas piece (quilt together with parallel rows of stitching)
+- Attach front hair canvas thing to center front with permanent basting stitch
+- Get that thimble out and pad stitch the lapels
+- Tape the roll line
+- Tape the front and lapel edge
+- Take a picture and post it on social media because this looks so cool
+- Close back darts
+- Sew back seam in two parts. Baste the part that will form the pleat closed, fold down and press.
+- Baste the back stay to the shoulders, armholes and neckline
+- Stabilize waist seam with selvedge strip of muslin (optional)
+- Stabilize top of coat tail with strip of hair canvas (optional)
+- Fold, pin and baste pleats on coat tail piece
+- Sew waist seam and press up. Catch stitch waist seam to strip of muslin (optional)
+- Sew belt and pocket flap pieces with right sides together, turn and press.
+- Sew patch pocket top edge to lining, leaving a hole for turning later. Sew side and bottom edge of patch pocket to lining (make lining 1 mm smaller all around to make sure it doesn’t show on the outside). Turn and press.
+- Fold front welt pieces with right sides together, turn and press.
+- Place front welt on center front piece between notches. Put pocket bag on top. Match location of front welt and pocket bag on side front piece, pin second part of pocket bag in place. Stitch and press. Pin and sew princess seam up until pocket stitching, stop and continue after the pocket. Stitch the edges of the front welt down.
+- Place patch pocket and pocket flap on marked locations and attach.
+- Sew front sleeve seam. Attach cuff facing up until the cuff fold line. Stitch back sleeve seam, careful not to catch the facing. Sew the rest of the facing seam. Turn, press, fold cuff back and baste to keep in place.
+- Stitch upper lining piece to front facing. Stitch side front lining to front facing. (When using an extra back facing piece, leave top five cm of lining/facing seam unsewn)
+- Make inner pocket flap, fold and press welts. Mark welt location, pin welts, flap and pocket bag in place. Stitch. Slash between welts. Turn and press. Stitch those little triangle thingies to the welts and close pocket bag. Omg.
+- Optional: cut under collar on the bias to make it sit nicer. Interface collar stand. Sew collar stands to upper and under collar. Cut piece of hair canvas for under collar. Pad stitch under collar. Sew collar pieces around edge with right sides together, leaving bottom edge open. Turn and press. Fold collar into right shape around tailor’s ham or rolled up towel and steam the shit out of it.
+- Lining: optional: cut back neck facing from shell fabric to have something nice to sew a label on. Draft separate upper back lining piece. Stitch back seams, stitch darts as tucks. Stitch tail lining to upper back. Stitch shoulder and side seams on lining. Stitch shoulder seams on front and back facing. Stitch lining to facing, connecting the earlier stitching lines. Insert lining sleeves to mentally prepare for the real deal.
+- Get some shoulder pads or craft them yourself from hair canvas and cotton batting. Set in sleeves, cry, unpick, set in sleeves again. Add a strip of cotton batting to the sleeve head for maximum oomph. Attach shoulder pads.
+- Pin collar to neckline, matching center back to center collar. Mind the varying seam allowances! Baste in place. Pin facing/lining combo to neckline and front edge, sandwiching collar in between. Stitch carefully around the entire coat, including the bottom edge of the facing (leave the rest of the hem alone). Check for puckers or pleats, trim seams, turn the whole thing right side out and press.
+- Turn hem up, press and baste into place. Sew hem with an invisible stitch, then hand sew lining hem to coat.
+- Mark buttonholes on coat front and belt pieces. Make buttonholes and attach buttons.
+- Remove all basting still present, put on your coat, give yourself a pat on the back and then sleep for three weeks.

--- a/markdown/org/docs/patterns/carlita/instructions/en.md
+++ b/markdown/org/docs/patterns/carlita/instructions/en.md
@@ -32,7 +32,7 @@ Don't forget the seam allowance for these pieces when cutting if you are making 
 -   Draw a curve from shoulder to bottom of armhole.
 -   Cut along this curve and discard the lower parts.
 -   Separate out the pieces back into their front and side pieces.
--   These are now you \**Front and Side shoulder* parts.
+-   These are now you \*_Front and Side shoulder_ parts.
 
 ##### Back shoulder
 

--- a/markdown/org/docs/patterns/carlita/needs/en.md
+++ b/markdown/org/docs/patterns/carlita/needs/en.md
@@ -1,15 +1,15 @@
 To make Carlita, you will need the following:
 
--   Basic sewing supplies
--   About 5 - 6 metres (5.5 - 6.6 yards) of a suitable main fabric ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
--   About 3.5 - 4 metres (3.8 - 4.4 yards) of lining fabric ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
--   About 0.75 - 1 metre (0.8 - 1.1 yards) of sleeve lining fabric ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
--   Light to Mediumweight hair canvas ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
--   Heavyweight hair canvas ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
--   Tailors tape
--   6 Buttons for front closure
--   Strong thread for attaching facings
--   (Optional) Silk buttonhole twist if hand-sewing the buttonholes and buttons.
+- Basic sewing supplies
+- About 5 - 6 metres (5.5 - 6.6 yards) of a suitable main fabric ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
+- About 3.5 - 4 metres (3.8 - 4.4 yards) of lining fabric ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
+- About 0.75 - 1 metre (0.8 - 1.1 yards) of sleeve lining fabric ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
+- Light to Mediumweight hair canvas ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
+- Heavyweight hair canvas ([see Carlita Fabric options](/docs/patterns/carlita/fabric/))
+- Tailors tape
+- 6 Buttons for front closure
+- Strong thread for attaching facings
+- (Optional) Silk buttonhole twist if hand-sewing the buttonholes and buttons.
 
 <Warning>
 

--- a/markdown/org/docs/patterns/carlita/options/collarflare/en.md
+++ b/markdown/org/docs/patterns/carlita/options/collarflare/en.md
@@ -1,7 +1,7 @@
 Controls the flare of the collar by altering the fall length (between the neck and the points) of the collar.
 
--   Increase this option to increase the fall length.
--   Decrease this option to decrease the fall length.
+- Increase this option to increase the fall length.
+- Decrease this option to decrease the fall length.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/carlita/options/collarspread/en.md
+++ b/markdown/org/docs/patterns/carlita/options/collarspread/en.md
@@ -1,7 +1,7 @@
 Controls the distance between the points of the collar.
 
--   Increase this option to spread the collar out and towards the shoulder.
--   Decrease this option to bring the collar in towards the body.
+- Increase this option to spread the collar out and towards the shoulder.
+- Decrease this option to bring the collar in towards the body.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/carlita/options/s3armhole/en.md
+++ b/markdown/org/docs/patterns/carlita/options/s3armhole/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the armhole side.
 
--   Increase this option to shift the shoulder seam forward on the armhole side
--   Decrease this option to shift the shoulder seam backward on the armhole side
+- Increase this option to shift the shoulder seam forward on the armhole side
+- Decrease this option to shift the shoulder seam backward on the armhole side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/carlita/options/s3collar/en.md
+++ b/markdown/org/docs/patterns/carlita/options/s3collar/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the collar side.
 
--   Increase this option to shift the shoulder seam forward on the collar side
--   Decrease this option to shift the shoulder seam backward on the collar side
+- Increase this option to shift the shoulder seam forward on the collar side
+- Decrease this option to shift the shoulder seam backward on the collar side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/carlton/cutting/en.md
+++ b/markdown/org/docs/patterns/carlton/cutting/en.md
@@ -6,21 +6,21 @@ Certain parts have to be drafted off of the existing parts. How to draft these a
 
 ### Materials
 
--   **Main fabric**
-    -   Cut **2 Front** parts
-    -   Cut **2 Front facing** parts
-    -   Cut **2 Back** parts
-    -   Cut **2 topsleeve** parts
-    -   Cut **2 undersleeve** parts
-    -   Cut **2 tail** parts
-    -   Cut **4 belt** parts
-    -   Cut **2 Collar stand** parts
-    -   Cut **2 collar** parts on the fold or Cut the upper collar on the fold and the under collar on the bias
-    -   Cut **2 cuffFacing** parts
-    -   Cut **2 Pocket** parts
-    -   Cut **4 pocketFlap** parts
-    -   Cut **2 chestPocketWelt** parts
-    -   Cut **2 innerPocketWelt** parts
+- **Main fabric**
+  - Cut **2 Front** parts
+  - Cut **2 Front facing** parts
+  - Cut **2 Back** parts
+  - Cut **2 topsleeve** parts
+  - Cut **2 undersleeve** parts
+  - Cut **2 tail** parts
+  - Cut **4 belt** parts
+  - Cut **2 Collar stand** parts
+  - Cut **2 collar** parts on the fold or Cut the upper collar on the fold and the under collar on the bias
+  - Cut **2 cuffFacing** parts
+  - Cut **2 Pocket** parts
+  - Cut **4 pocketFlap** parts
+  - Cut **2 chestPocketWelt** parts
+  - Cut **2 innerPocketWelt** parts
 
 <Note>
 
@@ -28,28 +28,28 @@ If your main fabric is quite lightweight and flimsy you may need to interface al
 
 </Note>
 
--   **Lining fabric**
-    -   Cut **2 Front lining** parts
-    -   Cut **2 Back** parts
-    -   Cut **2 topsleeve** parts
-    -   Cut **2 undersleeve** parts
-    -   Cut **2 tail** parts
-    -   Cut **2 innerPocketBag** parts
-    -   Cut **1 innerPocketTab** parts
-    -   Cut **2 pocketLining** parts
-    -   Cut **2 chestPocketBag** parts
--   **Light to Mediumweight Hair Canvas**
-    -   Cut **2 Front Facing** parts
-    -   Cut **1 Collar stand** parts
-    -   Cut **2 collar** parts on the bias and seam together
-    -   Cut **2 cuffFacing** parts
-    -   Cut **2 pocketFlap** parts
-    -   Cut **2 chestPocketWelt** parts
-    -   Cut **2 innerPocketWelt** parts
--   **Heavyweight Hair Canvas**
-    -   Cut **2 Front Shoulder** parts
-    -   Cut **2 Chest canvas** parts
-    -   Cut **2 Back shoulder** parts
+- **Lining fabric**
+  - Cut **2 Front lining** parts
+  - Cut **2 Back** parts
+  - Cut **2 topsleeve** parts
+  - Cut **2 undersleeve** parts
+  - Cut **2 tail** parts
+  - Cut **2 innerPocketBag** parts
+  - Cut **1 innerPocketTab** parts
+  - Cut **2 pocketLining** parts
+  - Cut **2 chestPocketBag** parts
+- **Light to Mediumweight Hair Canvas**
+  - Cut **2 Front Facing** parts
+  - Cut **1 Collar stand** parts
+  - Cut **2 collar** parts on the bias and seam together
+  - Cut **2 cuffFacing** parts
+  - Cut **2 pocketFlap** parts
+  - Cut **2 chestPocketWelt** parts
+  - Cut **2 innerPocketWelt** parts
+- **Heavyweight Hair Canvas**
+  - Cut **2 Front Shoulder** parts
+  - Cut **2 Chest canvas** parts
+  - Cut **2 Back shoulder** parts
 
 <Note>
 

--- a/markdown/org/docs/patterns/carlton/instructions/en.md
+++ b/markdown/org/docs/patterns/carlton/instructions/en.md
@@ -6,12 +6,12 @@ Some parts for Carlton require you to draft parts from the existing parts. The f
 
 ##### Front facing and Front lining
 
--   Trace off of **Front** part.
--   Cut along the green line.
--   Add seam allowance (if including) along green line to both pieces
--   The piece with the lapel is now the **Front facing** part.
--   Trim the hem allowance (if included) of the remaining piece to seam allowance length
--   The remaining piece is now the **Front lining** part.
+- Trace off of **Front** part.
+- Cut along the green line.
+- Add seam allowance (if including) along green line to both pieces
+- The piece with the lapel is now the **Front facing** part.
+- Trim the hem allowance (if included) of the remaining piece to seam allowance length
+- The remaining piece is now the **Front lining** part.
 
 <Note>
 
@@ -27,32 +27,32 @@ Don't forget the seam allowance for these pieces when cutting if you are making 
 
 ##### Chest canvas
 
--   Trace off of **Front** part.
--   Cut along the orange line.
--   Discard lower piece.
--   Cut along lapel line.
--   Discard lapel piece.
--   Remove the seam allowances (if included) of the upper piece.
--   The upper piece is now the **Chest canvas** part.
+- Trace off of **Front** part.
+- Cut along the orange line.
+- Discard lower piece.
+- Cut along lapel line.
+- Discard lapel piece.
+- Remove the seam allowances (if included) of the upper piece.
+- The upper piece is now the **Chest canvas** part.
 
 ##### Front Shoulder
 
--   Trace off of **Front** part.
--   Draw a curve from shoulder to bottom of armhole.
--   Cut along this curve and discard the lower part.
--   The upper piece is now the **Front Shoulder** part.
+- Trace off of **Front** part.
+- Draw a curve from shoulder to bottom of armhole.
+- Cut along this curve and discard the lower part.
+- The upper piece is now the **Front Shoulder** part.
 
 ##### Back shoulder
 
--   Trace off of **Back** part.
--   Cut along the orange line.
--   Discard lower piece.
--   Remove the seam allowamces (if included) of the upper piece.
--   The upper piece is now the **Back shoulder** part.
+- Trace off of **Back** part.
+- Cut along the orange line.
+- Discard lower piece.
+- Remove the seam allowamces (if included) of the upper piece.
+- The upper piece is now the **Back shoulder** part.
 
 #### Cutting
 
--   Cut all the parts above from their respective fabrics/facings. ([see Carlton Cutting](/docs/patterns/carlton/cutting/))
+- Cut all the parts above from their respective fabrics/facings. ([see Carlton Cutting](/docs/patterns/carlton/cutting/))
 
 ### Step 2: Fix Me
 

--- a/markdown/org/docs/patterns/carlton/needs/en.md
+++ b/markdown/org/docs/patterns/carlton/needs/en.md
@@ -1,15 +1,15 @@
 To make Carlton, you will need the following:
 
--   Basic sewing supplies
--   About 5 - 6 metres (5.5 - 6.6 yards) of a suitable main fabric ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
--   About 3.5 - 4 metres (3.8 - 4.4 yards) of lining fabric ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
--   About 0.75 - 1 metre (0.8 - 1.1 yards) of sleeve lining fabric ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
--   Light to Mediumweight hair canvas ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
--   Heavyweight hair canvas ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
--   Tailors tape
--   6 Buttons for front closure
--   Strong thread for attaching facings
--   (Optional) Silk buttonhole twist if hand-sewing the buttonholes and buttons.
+- Basic sewing supplies
+- About 5 - 6 metres (5.5 - 6.6 yards) of a suitable main fabric ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
+- About 3.5 - 4 metres (3.8 - 4.4 yards) of lining fabric ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
+- About 0.75 - 1 metre (0.8 - 1.1 yards) of sleeve lining fabric ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
+- Light to Mediumweight hair canvas ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
+- Heavyweight hair canvas ([see Carlton Fabric options](/docs/patterns/carlton/fabric/))
+- Tailors tape
+- 6 Buttons for front closure
+- Strong thread for attaching facings
+- (Optional) Silk buttonhole twist if hand-sewing the buttonholes and buttons.
 
 <Warning>
 

--- a/markdown/org/docs/patterns/carlton/options/collarflare/en.md
+++ b/markdown/org/docs/patterns/carlton/options/collarflare/en.md
@@ -1,7 +1,7 @@
 Controls the flare of the collar by altering the fall length (between the neck and the points) of the collar.
 
--   Increase this option to increase the fall length.
--   Decrease this option to decrease the fall length.
+- Increase this option to increase the fall length.
+- Decrease this option to decrease the fall length.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/carlton/options/collarspread/en.md
+++ b/markdown/org/docs/patterns/carlton/options/collarspread/en.md
@@ -1,7 +1,7 @@
 Controls the distance between the points of the collar.
 
--   Increase this option to spread the collar out and towards the shoulder.
--   Decrease this option to bring the collar in towards the body.
+- Increase this option to spread the collar out and towards the shoulder.
+- Decrease this option to bring the collar in towards the body.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/carlton/options/s3armhole/en.md
+++ b/markdown/org/docs/patterns/carlton/options/s3armhole/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the armhole side.
 
--   Increase this option to shift the shoulder seam forward on the armhole side
--   Decrease this option to shift the shoulder seam backward on the armhole side
+- Increase this option to shift the shoulder seam forward on the armhole side
+- Decrease this option to shift the shoulder seam backward on the armhole side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/carlton/options/s3collar/en.md
+++ b/markdown/org/docs/patterns/carlton/options/s3collar/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the collar side.
 
--   Increase this option to shift the shoulder seam forward on the collar side
--   Decrease this option to shift the shoulder seam backward on the collar side
+- Increase this option to shift the shoulder seam forward on the collar side
+- Decrease this option to shift the shoulder seam backward on the collar side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/cathrin/cutting/en.md
+++ b/markdown/org/docs/patterns/cathrin/cutting/en.md
@@ -4,11 +4,11 @@ Cut 2 core and 2 outer of each side panel with _good sides together_.
 
 For example, for the 11-panel version of Cathrin:
 
--   Panel 1 - Cut 1 core and 1 outer
--   Panel 2 - Cut 2 core and 2 outer
--   Panel 3 - Cut 2 core and 2 outer
--   Panel 4 - Cut 2 core and 2 outer
--   Panel 5 - Cut 2 core and 2 outer
--   Panel 6 - Cut 2 core and 2 outer
+- Panel 1 - Cut 1 core and 1 outer
+- Panel 2 - Cut 2 core and 2 outer
+- Panel 3 - Cut 2 core and 2 outer
+- Panel 4 - Cut 2 core and 2 outer
+- Panel 5 - Cut 2 core and 2 outer
+- Panel 6 - Cut 2 core and 2 outer
 
 ![Pattern pieces](cathrin_cutting.png)

--- a/markdown/org/docs/patterns/cathrin/cutting/en.md
+++ b/markdown/org/docs/patterns/cathrin/cutting/en.md
@@ -1,6 +1,6 @@
 Cut 1 core fabric and 1 outer fabric of the center panel, making sure to cut on the fold.
 
-Cut 2 core and 2 outer of each side panel with *good sides together*.
+Cut 2 core and 2 outer of each side panel with _good sides together_.
 
 For example, for the 11-panel version of Cathrin:
 

--- a/markdown/org/docs/patterns/cathrin/instructions/en.md
+++ b/markdown/org/docs/patterns/cathrin/instructions/en.md
@@ -26,13 +26,13 @@ With a small stitch width (I set mine to “2”), sew a line straight down the 
 
 Take the next piece. For an 11-panel Cathrin, this will be Panel 2.
 
-Place the outer Panel 2 on the outer Panel 1, *good sides together*.
+Place the outer Panel 2 on the outer Panel 1, _good sides together_.
 
-Place the core Panel 2 on the core Panel 1, *good sides together*.
+Place the core Panel 2 on the core Panel 1, _good sides together_.
 
 Ensure that the four layers of fabric line up perfectly. Double check that you haven’t mixed up pattern pieces or flipped any over by mistake.
 
-Match up the four layers of fabric at the narrowest part, *good sides together*, and pin. Then match the top and bottom of each panel and pin. Finally, pin the rest of the edge in place. Use as many pins as needed to make sure the panels stay perfectly aligned.
+Match up the four layers of fabric at the narrowest part, _good sides together_, and pin. Then match the top and bottom of each panel and pin. Finally, pin the rest of the edge in place. Use as many pins as needed to make sure the panels stay perfectly aligned.
 
 Sew the seam.
 
@@ -52,11 +52,11 @@ Topstitch another seam parallel to the first seam, allowing a bit of extra space
 
 Take the next piece. For an 11-panel Cathrin, this will be Panel 3.
 
-Place the outer Panel 3 on the outer Panel 2, *good sides together*.
+Place the outer Panel 3 on the outer Panel 2, _good sides together_.
 
-Place the core Panel 3 on the core Panel 2, *good sides together*.
+Place the core Panel 3 on the core Panel 2, _good sides together_.
 
-Match up the four layers of fabric at the narrowest part, *good sides together*, and pin. Then match the top and bottom of each panel and pin. Finally, pin the rest of the edge in place. Use as many pins as needed to make sure the panels stay perfectly aligned.
+Match up the four layers of fabric at the narrowest part, _good sides together_, and pin. Then match the top and bottom of each panel and pin. Finally, pin the rest of the edge in place. Use as many pins as needed to make sure the panels stay perfectly aligned.
 
 Sew the seam.
 

--- a/markdown/org/docs/patterns/cathrin/needs/en.md
+++ b/markdown/org/docs/patterns/cathrin/needs/en.md
@@ -6,10 +6,10 @@ You can find a good guide to other tools at [Foundations Revealed](https://found
 
 Sample supplies list:
 
--   About 0.5 meters (0.6 yards) of core fabric ([see Fabric options](/docs/patterns/cathrin/fabric))
--   About 0.5 meters (0.6 yards) of outer fabric ([see Fabric options](/docs/patterns/cathrin/fabric))
--   Boning
--   Grommets (size 2)
--   About 2 meters of bias tape
--   About 3 meters of lacing
--   Tools: Grommet setter, awl
+- About 0.5 meters (0.6 yards) of core fabric ([see Fabric options](/docs/patterns/cathrin/fabric))
+- About 0.5 meters (0.6 yards) of outer fabric ([see Fabric options](/docs/patterns/cathrin/fabric))
+- Boning
+- Grommets (size 2)
+- About 2 meters of bias tape
+- About 3 meters of lacing
+- Tools: Grommet setter, awl

--- a/markdown/org/docs/patterns/cathrin/options/panels/en.md
+++ b/markdown/org/docs/patterns/cathrin/options/panels/en.md
@@ -2,8 +2,8 @@
 
 This options determines how many panels will be used to make up the corset. You have the choice between:
 
--   11 panels
--   13 panels
+- 11 panels
+- 13 panels
 
 More panels is a bit more work, but also allows the difference between bust/waist/hips to be evened out over more darts, which may yield to better results.
 

--- a/markdown/org/docs/patterns/charlie/cutting/en.md
+++ b/markdown/org/docs/patterns/charlie/cutting/en.md
@@ -1,24 +1,24 @@
 ##### From main fabric
 
--   Part **1**: **2 x** _with good sides together_.
--   Part **2**: **2 x** _with good sides together_.
--   Part **4**: **4 x**
--   Part **6**: **2 x**
--   Part **8**: **2 x** 2 _with good sides together_
--   Part **9**: **2 x** _with good sides together_
--   Part **10**: **1 x** on the fold
--   Part **11**: **1 x** if making a straight waistband
--   Part **11**: **2 x** _with good sides together_ if making a curved waistband
--   Part **12**: **1 x**
+- Part **1**: **2 x** _with good sides together_.
+- Part **2**: **2 x** _with good sides together_.
+- Part **4**: **4 x**
+- Part **6**: **2 x**
+- Part **8**: **2 x** 2 _with good sides together_
+- Part **9**: **2 x** _with good sides together_
+- Part **10**: **1 x** on the fold
+- Part **11**: **1 x** if making a straight waistband
+- Part **11**: **2 x** _with good sides together_ if making a curved waistband
+- Part **12**: **1 x**
 
 ##### From lining (or any material suitable for pocket bags)
 
--   Part **5**: **2 x**
--   Part **7**: **2 x**
+- Part **5**: **2 x**
+- Part **7**: **2 x**
 
 ##### From fusible interfacing
 
--   Part **3**: **2 x**
+- Part **3**: **2 x**
 
 <Tip>
 

--- a/markdown/org/docs/patterns/charlie/cutting/en.md
+++ b/markdown/org/docs/patterns/charlie/cutting/en.md
@@ -1,14 +1,14 @@
 ##### From main fabric
 
--   Part **1**: **2 x** *with good sides together*.
--   Part **2**: **2 x** *with good sides together*.
+-   Part **1**: **2 x** _with good sides together_.
+-   Part **2**: **2 x** _with good sides together_.
 -   Part **4**: **4 x**
 -   Part **6**: **2 x**
--   Part **8**: **2 x** 2 *with good sides together*
--   Part **9**: **2 x** *with good sides together*
+-   Part **8**: **2 x** 2 _with good sides together_
+-   Part **9**: **2 x** _with good sides together_
 -   Part **10**: **1 x** on the fold
 -   Part **11**: **1 x** if making a straight waistband
--   Part **11**: **2 x** *with good sides together* if making a curved waistband
+-   Part **11**: **2 x** _with good sides together_ if making a curved waistband
 -   Part **12**: **1 x**
 
 ##### From lining (or any material suitable for pocket bags)

--- a/markdown/org/docs/patterns/charlie/instructions/en.md
+++ b/markdown/org/docs/patterns/charlie/instructions/en.md
@@ -310,10 +310,10 @@ Finally, cut your length belt loops strip into 8 equal parts to make 8 belt loop
 
 We're going to divide our belt loops along the waist:
 
--   2 at the center back, each set aside a bit from the center so there's a small gap between them.
--   1 above the back dart on each side
--   1 on each side more or less where the side seam would hit the waist if it went straight up
--   1 on each side from center front. Not too close to each other so there's no room for belt buckles, but not too far either so it doesn't look weird
+- 2 at the center back, each set aside a bit from the center so there's a small gap between them.
+- 1 above the back dart on each side
+- 1 on each side more or less where the side seam would hit the waist if it went straight up
+- 1 on each side from center front. Not too close to each other so there's no room for belt buckles, but not too far either so it doesn't look weird
 
 Place the belt loop at these places with their good side down (against the good side of the fabric of your trousers, and the top aligned with the waist)
 Sew this down in the seam allowance of the waist, making sure that they are perpendicular to the waistband.

--- a/markdown/org/docs/patterns/charlie/instructions/en.md
+++ b/markdown/org/docs/patterns/charlie/instructions/en.md
@@ -2,7 +2,7 @@
 
 First thing we're going to do is close the waist dart on the back panel.
 
-To do so, fold the back panel double with *good sides together* making sure to match both sides of the dart on top of each other.
+To do so, fold the back panel double with _good sides together_ making sure to match both sides of the dart on top of each other.
 
 Now sew the dart close, making sure to use a small stitch length, and to sew all the way to the end of the dart, even a couple of stitches off the fabric.
 
@@ -28,7 +28,7 @@ the instructions) but it's a very typical finish for chinos, and makes it easier
 
 ### Attach the back pocket facing to the pocket bag
 
-Join the back pocket facing to the pocket bag by placing them with *good sides together* and sewing along the longest of the non-curved seams of the facing.
+Join the back pocket facing to the pocket bag by placing them with _good sides together_ and sewing along the longest of the non-curved seams of the facing.
 
 When you're done, press the seam allowance to the side of the pocket bag.
 
@@ -52,7 +52,7 @@ You should overlock/serge the sides of the pocketbag so they don't ravel.
 
 <Tip>
 
-If you don't have a *serger* you can always use a zig-zag stitch instead.
+If you don't have a _serger_ you can always use a zig-zag stitch instead.
 
 </Tip>
 
@@ -74,7 +74,7 @@ The front pockets are a little unusual because they have the appearance of class
 
 We have two front pocket bags, that each have two pieces of facing to attach to them.
 
-Align them with *good sides together* (\*) and sew the facing in place.
+Align them with _good sides together_ (\*) and sew the facing in place.
 
 <Note>
 
@@ -204,7 +204,7 @@ It's one of those best practices you ignore at your own peril.
 <Tip>
 
 Take extra care to carefully align the seams where both legs have their back and front panels joined together.
-Doing so will ensure your cross seam results with a perfectly aligned *cross* where 4 pattern parts meet each other in a single point.
+Doing so will ensure your cross seam results with a perfectly aligned _cross_ where 4 pattern parts meet each other in a single point.
 
 Getting it just right is one of those things you'll end up cherishing each time you wear these.
 
@@ -371,7 +371,7 @@ At the start and end of the waistband, you'll need to tuck in some more seam all
 
 ### Sew the waistband close
 
-Now with the good side up, sew exactly in the seam that was sewn before (so called *stitch in the ditch*).
+Now with the good side up, sew exactly in the seam that was sewn before (so called _stitch in the ditch_).
 
 This will catch the back of the waistband which we've made to extend slightly further, and lock all the seam allowance inside.
 

--- a/markdown/org/docs/patterns/charlie/needs/en.md
+++ b/markdown/org/docs/patterns/charlie/needs/en.md
@@ -1,7 +1,7 @@
 To make Charlie, you will need the following:
 
--   Basic sewing supplies
--   About 1.5 meters (1.7 yards) of a suitable fabric ([see Fabric options](/docs/patterns/charlie/fabric))
--   About 30 centimeters (12 inches) of lining fabric (used for pocket bags)
--   Fusible interfacing for the back pockets
--   A zipper and button for the fly
+- Basic sewing supplies
+- About 1.5 meters (1.7 yards) of a suitable fabric ([see Fabric options](/docs/patterns/charlie/fabric))
+- About 30 centimeters (12 inches) of lining fabric (used for pocket bags)
+- Fusible interfacing for the back pockets
+- A zipper and button for the fly

--- a/markdown/org/docs/patterns/charlie/options/waistheight/en.md
+++ b/markdown/org/docs/patterns/charlie/options/waistheight/en.md
@@ -1,7 +1,7 @@
 Controls the height of the waist, where:
 
--   100% : The waist of the trousers sits at the waist line
--   0% : The waist of the trousers sits at the hip line
+- 100% : The waist of the trousers sits at the waist line
+- 0% : The waist of the trousers sits at the hip line
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/cornelius/cutting/en.md
+++ b/markdown/org/docs/patterns/cornelius/cutting/en.md
@@ -4,17 +4,17 @@ title: Cornelius Cutting
 
 ### Materials
 
--   **Main fabric**
-    -   Cut **2 back** parts
-    -   Cut **2 front** parts
-    -   Cut **2 pocket facing** parts
-    -   Cut **2 waistband** parts on the fold
-    -   Cut **4 leg band** parts
-    -   Cut **1 zipper guard** part on the fold
--   **Lining (Pocket) fabric**
-    -   Cut **2 pocket** parts
--   **Interfacing**
-    -   Cut **1 waistband** part on the fold
+- **Main fabric**
+  - Cut **2 back** parts
+  - Cut **2 front** parts
+  - Cut **2 pocket facing** parts
+  - Cut **2 waistband** parts on the fold
+  - Cut **4 leg band** parts
+  - Cut **1 zipper guard** part on the fold
+- **Lining (Pocket) fabric**
+  - Cut **2 pocket** parts
+- **Interfacing**
+  - Cut **1 waistband** part on the fold
 
 <Note>
 

--- a/markdown/org/docs/patterns/cornelius/instructions/en.md
+++ b/markdown/org/docs/patterns/cornelius/instructions/en.md
@@ -4,13 +4,13 @@ title: Cornelius Construction
 
 ### Step 1: The Front Pockets
 
--   Press under the seam allowances of the non-notched edges of the pokcet facings.
--   Matching notches, pin the wrong sides of pocket facings to right side of pocket bags, _Edgestitch_ the folded edges to the pocket bags.
--   _Baste_ the seam allowances of the notched edges of the pocket facings to the pocket bags.
--   With right sides together matching double notches sew the pocket bags to the front and then press to the wrong side.
--   Fold the pockets in half along the fold line, right sides together. Stitch the bottom of the pocket bag together.
--   Alternatively you can _French Seam_ the bottom seams of the pocket bags together if you prefer.
--   _Baste_ the top and side of the pocket bags to the front seam allowances mathcing notches.
+- Press under the seam allowances of the non-notched edges of the pokcet facings.
+- Matching notches, pin the wrong sides of pocket facings to right side of pocket bags, _Edgestitch_ the folded edges to the pocket bags.
+- _Baste_ the seam allowances of the notched edges of the pocket facings to the pocket bags.
+- With right sides together matching double notches sew the pocket bags to the front and then press to the wrong side.
+- Fold the pockets in half along the fold line, right sides together. Stitch the bottom of the pocket bag together.
+- Alternatively you can _French Seam_ the bottom seams of the pocket bags together if you prefer.
+- _Baste_ the top and side of the pocket bags to the front seam allowances mathcing notches.
 
 <Note>
 
@@ -20,24 +20,24 @@ Going forward the pockets and fronts will just be referred to as the fronts.
 
 ### Step 2: The Fly
 
--   With right sides together, from the top _Baste_ along the fly line stopping at the notch on the crotch seam.
--   From where you left off with basting, stitch the crotch seam together making sure to secure your stitches where the basting ends.
--   Press open the fly and seam.
--   Lay the fronts down wrong side up so the right sides of the fly flaps are facing you.
--   Lay zipper face up on the front flaps, with the left side of the zipper touching the seam, with the bottom of the right zipper tape on the curved flap.
--   Sew the right zipper tape to the right flap close to the zipper teeth using a zipper foot. Don't sew it to the front itself!
--   Pull the zipper to the left so the right flap is pulled over.
--   Pin the left zipper tape to the left flap.
--   Sew the left zipper tape to left flap close to the zipper teeth using a zipper foot. Don't sew it to the front itself!
--   Fold the zipper guard in half wrong sides together.
--   Lay the zipper guard on the right flap, right sides touching.
--   Sew the zipper guard to the right flap, _Finish_ the right side to your liking.
--   _Finish_ the left side of the left flap to your liking.
--   Unpick the basted part of the front seam.
--   _Topstitch_ the right flap down, away from the now unpicked seam, as far down as you can.
--   Pin/_Baste_ the zipper protector over to the right side to keep it out of the way for the next step
--   On the outside side, sew the left flap down to the left, following the curved line.
--   On the outside side, _Bar-Tack_ where you like them for reinforcement.
+- With right sides together, from the top _Baste_ along the fly line stopping at the notch on the crotch seam.
+- From where you left off with basting, stitch the crotch seam together making sure to secure your stitches where the basting ends.
+- Press open the fly and seam.
+- Lay the fronts down wrong side up so the right sides of the fly flaps are facing you.
+- Lay zipper face up on the front flaps, with the left side of the zipper touching the seam, with the bottom of the right zipper tape on the curved flap.
+- Sew the right zipper tape to the right flap close to the zipper teeth using a zipper foot. Don't sew it to the front itself!
+- Pull the zipper to the left so the right flap is pulled over.
+- Pin the left zipper tape to the left flap.
+- Sew the left zipper tape to left flap close to the zipper teeth using a zipper foot. Don't sew it to the front itself!
+- Fold the zipper guard in half wrong sides together.
+- Lay the zipper guard on the right flap, right sides touching.
+- Sew the zipper guard to the right flap, _Finish_ the right side to your liking.
+- _Finish_ the left side of the left flap to your liking.
+- Unpick the basted part of the front seam.
+- _Topstitch_ the right flap down, away from the now unpicked seam, as far down as you can.
+- Pin/_Baste_ the zipper protector over to the right side to keep it out of the way for the next step
+- On the outside side, sew the left flap down to the left, following the curved line.
+- On the outside side, _Bar-Tack_ where you like them for reinforcement.
 
 <Tip>
 
@@ -54,8 +54,8 @@ If wanting something more historical than omit the zipper and make a buttonhole 
 
 ### Step 3: Attaching the front to the back
 
--   With right sides together sew the back pieces together along the back seam.
--   With right sides together sew the front and back together at the side seams and inner leg seam. Making sure to leave a gap below the notches at the bottom of the side seams. The gap will be referred to as the list when going forward.
+- With right sides together sew the back pieces together along the back seam.
+- With right sides together sew the front and back together at the side seams and inner leg seam. Making sure to leave a gap below the notches at the bottom of the side seams. The gap will be referred to as the list when going forward.
 
 ### Step 4: Leg bands
 
@@ -63,15 +63,15 @@ Use the method of the cuff style you chose as they are different depending on wh
 
 #### Traditional and Elegant
 
--   _Finish_ the raw edges of the slits.
--   Press the seam allowances of the slits to the wrongs sides. Stitch in place.
--   Sew one of the leg band pieces to each leg right sides together, matching notches.
--   Press the bands and seam allowance down and away from leg. Trim the seam allowance to reduce bulk.
--   Press the top seam allowance to the wrong side of the remaining leg band pieces. Trim the top seam allowance.
--   With right sides together sew the remaining leg and pieces to the attached leg bands along the bottoms and sides.
--   Turn the leg bands out. Press.
--   _Slipstitch_ or _Whipstitch_ the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
--   Sew the buttonhole. The buttons will be sewn later.
+- _Finish_ the raw edges of the slits.
+- Press the seam allowances of the slits to the wrongs sides. Stitch in place.
+- Sew one of the leg band pieces to each leg right sides together, matching notches.
+- Press the bands and seam allowance down and away from leg. Trim the seam allowance to reduce bulk.
+- Press the top seam allowance to the wrong side of the remaining leg band pieces. Trim the top seam allowance.
+- With right sides together sew the remaining leg and pieces to the attached leg bands along the bottoms and sides.
+- Turn the leg bands out. Press.
+- _Slipstitch_ or _Whipstitch_ the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
+- Sew the buttonhole. The buttons will be sewn later.
 
 <Note>
 
@@ -81,16 +81,16 @@ If you are worried about a draft you can create a triangle piece of fabric that 
 
 #### Keystone
 
--   If using construct plackets for the leg slits.
--   Sew the plackets to the leg slits similar to how you would sew a sleeve cuff on a shirt.
--   Close the darts on the leg band pieces.
--   Sew one of the leg band pieces to each leg right sides together, matching notches.
--   Press the bands and seam allowance down and away from leg. Trim the seam allowance to reduce bulk.
--   Press the top seam allowance to the wrong side of the remaining leg band pieces. Trim the top seam allowance.
--   With right sides together sew the remaining leg and pieces to the attached leg bands along the bottoms and sides.
--   Turn the leg bands out. Press.
--   _Slipstitch_ or _Whipstitch_ the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
--   Sew the buttonhole. The buttons will be sewn later.
+- If using construct plackets for the leg slits.
+- Sew the plackets to the leg slits similar to how you would sew a sleeve cuff on a shirt.
+- Close the darts on the leg band pieces.
+- Sew one of the leg band pieces to each leg right sides together, matching notches.
+- Press the bands and seam allowance down and away from leg. Trim the seam allowance to reduce bulk.
+- Press the top seam allowance to the wrong side of the remaining leg band pieces. Trim the top seam allowance.
+- With right sides together sew the remaining leg and pieces to the attached leg bands along the bottoms and sides.
+- Turn the leg bands out. Press.
+- _Slipstitch_ or _Whipstitch_ the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
+- Sew the buttonhole. The buttons will be sewn later.
 
 <Note>
 
@@ -108,14 +108,14 @@ You can _Edgestitch_ the leg bands together like a modern waistband if you prefe
 
 ### Step 5: Waistband
 
--   Face one of the waistband pieces using your preffered method.
--   Sew the faced waistband piece to the top of the legs right sides together.
--   Press the waistband and seam allowance up and away from leg. Trim the seam allowance to reduce bulk.
--   Press the bottom seam allowance to the wrong side of the remaining waistband piece. Trim the bottom seam allowance.
--   With right sides together sew the remaining waistband to the faced waistband along the top and sides.
--   Turn the waistband out. Press.
--   _Slipstitch_ or _Whipstitch_ the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
--   Sew the buttonhole. The buttons will be sewn later.
+- Face one of the waistband pieces using your preffered method.
+- Sew the faced waistband piece to the top of the legs right sides together.
+- Press the waistband and seam allowance up and away from leg. Trim the seam allowance to reduce bulk.
+- Press the bottom seam allowance to the wrong side of the remaining waistband piece. Trim the bottom seam allowance.
+- With right sides together sew the remaining waistband to the faced waistband along the top and sides.
+- Turn the waistband out. Press.
+- _Slipstitch_ or _Whipstitch_ the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
+- Sew the buttonhole. The buttons will be sewn later.
 
 <Note>
 
@@ -125,7 +125,7 @@ You can _Edgestitch_ the waistband together like a modern waistband if you prefe
 
 ### Step 6: Buttons
 
--   Sew the waistband and leg band buttons on.
+- Sew the waistband and leg band buttons on.
 
 ### Step 7: Enjoy!
 

--- a/markdown/org/docs/patterns/cornelius/instructions/en.md
+++ b/markdown/org/docs/patterns/cornelius/instructions/en.md
@@ -5,12 +5,12 @@ title: Cornelius Construction
 ### Step 1: The Front Pockets
 
 -   Press under the seam allowances of the non-notched edges of the pokcet facings.
--   Matching notches, pin the wrong sides of pocket facings to right side of pocket bags, *Edgestitch* the folded edges to the pocket bags.
--   *Baste* the seam allowances of the notched edges of the pocket facings to the pocket bags.
+-   Matching notches, pin the wrong sides of pocket facings to right side of pocket bags, _Edgestitch_ the folded edges to the pocket bags.
+-   _Baste_ the seam allowances of the notched edges of the pocket facings to the pocket bags.
 -   With right sides together matching double notches sew the pocket bags to the front and then press to the wrong side.
 -   Fold the pockets in half along the fold line, right sides together. Stitch the bottom of the pocket bag together.
--   Alternatively you can *French Seam* the bottom seams of the pocket bags together if you prefer.
--   *Baste* the top and side of the pocket bags to the front seam allowances mathcing notches.
+-   Alternatively you can _French Seam_ the bottom seams of the pocket bags together if you prefer.
+-   _Baste_ the top and side of the pocket bags to the front seam allowances mathcing notches.
 
 <Note>
 
@@ -20,7 +20,7 @@ Going forward the pockets and fronts will just be referred to as the fronts.
 
 ### Step 2: The Fly
 
--   With right sides together, from the top *Baste* along the fly line stopping at the notch on the crotch seam.
+-   With right sides together, from the top _Baste_ along the fly line stopping at the notch on the crotch seam.
 -   From where you left off with basting, stitch the crotch seam together making sure to secure your stitches where the basting ends.
 -   Press open the fly and seam.
 -   Lay the fronts down wrong side up so the right sides of the fly flaps are facing you.
@@ -31,13 +31,13 @@ Going forward the pockets and fronts will just be referred to as the fronts.
 -   Sew the left zipper tape to left flap close to the zipper teeth using a zipper foot. Don't sew it to the front itself!
 -   Fold the zipper guard in half wrong sides together.
 -   Lay the zipper guard on the right flap, right sides touching.
--   Sew the zipper guard to the right flap, *Finish* the right side to your liking.
--   *Finish* the left side of the left flap to your liking.
+-   Sew the zipper guard to the right flap, _Finish_ the right side to your liking.
+-   _Finish_ the left side of the left flap to your liking.
 -   Unpick the basted part of the front seam.
--   *Topstitch* the right flap down, away from the now unpicked seam, as far down as you can.
--   Pin/*Baste* the zipper protector over to the right side to keep it out of the way for the next step
+-   _Topstitch_ the right flap down, away from the now unpicked seam, as far down as you can.
+-   Pin/_Baste_ the zipper protector over to the right side to keep it out of the way for the next step
 -   On the outside side, sew the left flap down to the left, following the curved line.
--   On the outside side, *Bar-Tack* where you like them for reinforcement.
+-   On the outside side, _Bar-Tack_ where you like them for reinforcement.
 
 <Tip>
 
@@ -63,14 +63,14 @@ Use the method of the cuff style you chose as they are different depending on wh
 
 #### Traditional and Elegant
 
--   *Finish* the raw edges of the slits.
+-   _Finish_ the raw edges of the slits.
 -   Press the seam allowances of the slits to the wrongs sides. Stitch in place.
 -   Sew one of the leg band pieces to each leg right sides together, matching notches.
 -   Press the bands and seam allowance down and away from leg. Trim the seam allowance to reduce bulk.
 -   Press the top seam allowance to the wrong side of the remaining leg band pieces. Trim the top seam allowance.
 -   With right sides together sew the remaining leg and pieces to the attached leg bands along the bottoms and sides.
 -   Turn the leg bands out. Press.
--   *Slipstitch* or *Whipstitch* the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
+-   _Slipstitch_ or _Whipstitch_ the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
 -   Sew the buttonhole. The buttons will be sewn later.
 
 <Note>
@@ -89,7 +89,7 @@ If you are worried about a draft you can create a triangle piece of fabric that 
 -   Press the top seam allowance to the wrong side of the remaining leg band pieces. Trim the top seam allowance.
 -   With right sides together sew the remaining leg and pieces to the attached leg bands along the bottoms and sides.
 -   Turn the leg bands out. Press.
--   *Slipstitch* or *Whipstitch* the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
+-   _Slipstitch_ or _Whipstitch_ the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
 -   Sew the buttonhole. The buttons will be sewn later.
 
 <Note>
@@ -102,7 +102,7 @@ If you are worried about a draft you will need to construct plackets for the leg
 
 **For both Keystone, Traditional and Elegant Styles**
 
-You can *Edgestitch* the leg bands together like a modern waistband if you prefer.
+You can _Edgestitch_ the leg bands together like a modern waistband if you prefer.
 
 </Note>
 
@@ -114,12 +114,12 @@ You can *Edgestitch* the leg bands together like a modern waistband if you prefe
 -   Press the bottom seam allowance to the wrong side of the remaining waistband piece. Trim the bottom seam allowance.
 -   With right sides together sew the remaining waistband to the faced waistband along the top and sides.
 -   Turn the waistband out. Press.
--   *Slipstitch* or *Whipstitch* the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
+-   _Slipstitch_ or _Whipstitch_ the folded edge of the waistband to front, making sure the folded edge is covering the stitcing.
 -   Sew the buttonhole. The buttons will be sewn later.
 
 <Note>
 
-You can *Edgestitch* the waistband together like a modern waistband if you prefer.
+You can _Edgestitch_ the waistband together like a modern waistband if you prefer.
 
 </Note>
 

--- a/markdown/org/docs/patterns/cornelius/needs/en.md
+++ b/markdown/org/docs/patterns/cornelius/needs/en.md
@@ -4,12 +4,12 @@ title: Cornelius What you need
 
 To make Cornelius, you will need the following:
 
--   Basic sewing supplies
--   About 2 metres (2.2 yards) of a suitable fabric ([see Cornelius Fabric options](/docs/patterns/cornelius/fabric/))
--   About 0.5 metres (0.6 yards) of lining fabric ([see Cornelius Fabric options](/docs/patterns/cornelius/fabric/))
--   Interfacing for the waistband ([see Cornelius Fabric options](/docs/patterns/cornelius/fabric/))
--   A zip or 3 buttons for the fly
--   3 or 7 Buttons for waistband and leg bands
+- Basic sewing supplies
+- About 2 metres (2.2 yards) of a suitable fabric ([see Cornelius Fabric options](/docs/patterns/cornelius/fabric/))
+- About 0.5 metres (0.6 yards) of lining fabric ([see Cornelius Fabric options](/docs/patterns/cornelius/fabric/))
+- Interfacing for the waistband ([see Cornelius Fabric options](/docs/patterns/cornelius/fabric/))
+- A zip or 3 buttons for the fly
+- 3 or 7 Buttons for waistband and leg bands
 
 <Note>
 

--- a/markdown/org/docs/patterns/cornelius/options/cuffstyle/en.md
+++ b/markdown/org/docs/patterns/cornelius/options/cuffstyle/en.md
@@ -4,9 +4,9 @@ title: Cuff style
 
 This pattern supports three different cuff styles:
 
--   **Traditional**: A single buttoned _curved_ band with a pointed edge.
--   **Elegant**: A single buttoned _straight_ band with a pointed edge.
--   **Keystone**: A slightly curved band that is wider than the others using 3 buttons rather than 1. This one is based of off the one in the Keystone Draft this pattern is based on.
+- **Traditional**: A single buttoned _curved_ band with a pointed edge.
+- **Elegant**: A single buttoned _straight_ band with a pointed edge.
+- **Keystone**: A slightly curved band that is wider than the others using 3 buttons rather than 1. This one is based of off the one in the Keystone Draft this pattern is based on.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/cornelius/options/cuffstyle/en.md
+++ b/markdown/org/docs/patterns/cornelius/options/cuffstyle/en.md
@@ -4,8 +4,8 @@ title: Cuff style
 
 This pattern supports three different cuff styles:
 
--   **Traditional**: A single buttoned *curved* band with a pointed edge.
--   **Elegant**: A single buttoned *straight* band with a pointed edge.
+-   **Traditional**: A single buttoned _curved_ band with a pointed edge.
+-   **Elegant**: A single buttoned _straight_ band with a pointed edge.
 -   **Keystone**: A slightly curved band that is wider than the others using 3 buttons rather than 1. This one is based of off the one in the Keystone Draft this pattern is based on.
 
 ## Effect of this option on the pattern

--- a/markdown/org/docs/patterns/diana/cutting/en.md
+++ b/markdown/org/docs/patterns/diana/cutting/en.md
@@ -1,3 +1,3 @@
--   Cut **1 back** on the fold
--   Cut **1 front** on the fold
--   Cut **2 sleeves** with _good sides together_
+- Cut **1 back** on the fold
+- Cut **1 front** on the fold
+- Cut **2 sleeves** with _good sides together_

--- a/markdown/org/docs/patterns/diana/cutting/en.md
+++ b/markdown/org/docs/patterns/diana/cutting/en.md
@@ -1,3 +1,3 @@
 -   Cut **1 back** on the fold
 -   Cut **1 front** on the fold
--   Cut **2 sleeves** with *good sides together*
+-   Cut **2 sleeves** with _good sides together_

--- a/markdown/org/docs/patterns/diana/fabric/en.md
+++ b/markdown/org/docs/patterns/diana/fabric/en.md
@@ -1,4 +1,4 @@
 This top works best in one of these two scenarios:
 
 -   Use a stretch fabric, and chose minimal ease
--   Or use a non-stretch fabric with good *drape*, in which case you'll want to add more ease. Flowy fabrics can be cut on the bias for a body-hugging effect
+-   Or use a non-stretch fabric with good _drape_, in which case you'll want to add more ease. Flowy fabrics can be cut on the bias for a body-hugging effect

--- a/markdown/org/docs/patterns/diana/fabric/en.md
+++ b/markdown/org/docs/patterns/diana/fabric/en.md
@@ -1,4 +1,4 @@
 This top works best in one of these two scenarios:
 
--   Use a stretch fabric, and chose minimal ease
--   Or use a non-stretch fabric with good _drape_, in which case you'll want to add more ease. Flowy fabrics can be cut on the bias for a body-hugging effect
+- Use a stretch fabric, and chose minimal ease
+- Or use a non-stretch fabric with good _drape_, in which case you'll want to add more ease. Flowy fabrics can be cut on the bias for a body-hugging effect

--- a/markdown/org/docs/patterns/diana/instructions/en.md
+++ b/markdown/org/docs/patterns/diana/instructions/en.md
@@ -1,7 +1,7 @@
 ### Step 1: Finish the back neckline
 
--   Cut a strip of main fabric the length of your back neckline, and around 3 cm wide.
--   Press a fold into this strip, 1 cm from the edge.
+- Cut a strip of main fabric the length of your back neckline, and around 3 cm wide.
+- Press a fold into this strip, 1 cm from the edge.
 
 <Tip>
 
@@ -10,17 +10,17 @@ For knit fabric make a strip with the stretch of the fabric running along the lo
 
 </Tip>
 
--   With _good sides together_ align the non-folded edge of the strip with the back neckline.
--   Sew the strip to the back neckline and trim the seam.
--   Turn the strip to the wrong side of the fabric and _topstitch_ along the folded edge to keep it in place.
+- With _good sides together_ align the non-folded edge of the strip with the back neckline.
+- Sew the strip to the back neckline and trim the seam.
+- Turn the strip to the wrong side of the fabric and _topstitch_ along the folded edge to keep it in place.
 
 ### Step 2: Close shoulder seams
 
 ![This drawing was too nice not to use](neckline.jpg)
 
--   Finish the raw edge on the front neckline in a way that suits your fabric (if it doesn’t fray, you can leave it unfinished).
--   With _good sides together_, place the front on the back aligning the shoulder seams.
--   Fold the front neckline seam allowance over to the wrong side of the back.
+- Finish the raw edge on the front neckline in a way that suits your fabric (if it doesn’t fray, you can leave it unfinished).
+- With _good sides together_, place the front on the back aligning the shoulder seams.
+- Fold the front neckline seam allowance over to the wrong side of the back.
 
 <Note>
 
@@ -28,30 +28,30 @@ If you have a lightweight woven fabric you can fold this edge up again, so it wi
 
 </Note>
 
--   Stitch the shoulder seam, enclosing the raw edge of the back neckline in the fold.
--   Turn to the right side and press.
+- Stitch the shoulder seam, enclosing the raw edge of the back neckline in the fold.
+- Turn to the right side and press.
 
 ### Step 3: Finish front neckline
 
--   Press the hem formed in your fabric by the folds you made at the shoulder seam when you closed the shoulder and topstitch close to the edge.
+- Press the hem formed in your fabric by the folds you made at the shoulder seam when you closed the shoulder and topstitch close to the edge.
 
 ### Step 4: Attach sleeves
 
 The sleeve will be inserted flat, meaning the armhole seam will be sewn first and the sleeve and side seam will be closed in one go.
 
--   With _good sides together_, matching notches, pin the sleeve head along the armhole.
--   If necessary, ease in the sleeve head at the top, between the notches.
--   Sew, finish and press the seam.
--   Repeat for other sleeve.
+- With _good sides together_, matching notches, pin the sleeve head along the armhole.
+- If necessary, ease in the sleeve head at the top, between the notches.
+- Sew, finish and press the seam.
+- Repeat for other sleeve.
 
 ### Step 5: Close side and sleeve seam
 
--   With _good sides together_ pin the front to the back along the sleeve and side seams, making sure to line up the armhole seams.
--   Sew, finish and press the seam.
+- With _good sides together_ pin the front to the back along the sleeve and side seams, making sure to line up the armhole seams.
+- Sew, finish and press the seam.
 
 ### Step 6: Hem
 
--   Finish the sleeves and bottom hems in a way that works with your fabric choice.
+- Finish the sleeves and bottom hems in a way that works with your fabric choice.
 
 <Note>
 

--- a/markdown/org/docs/patterns/diana/instructions/en.md
+++ b/markdown/org/docs/patterns/diana/instructions/en.md
@@ -10,16 +10,16 @@ For knit fabric make a strip with the stretch of the fabric running along the lo
 
 </Tip>
 
--   With *good sides together* align the non-folded edge of the strip with the back neckline.
+-   With _good sides together_ align the non-folded edge of the strip with the back neckline.
 -   Sew the strip to the back neckline and trim the seam.
--   Turn the strip to the wrong side of the fabric and *topstitch* along the folded edge to keep it in place.
+-   Turn the strip to the wrong side of the fabric and _topstitch_ along the folded edge to keep it in place.
 
 ### Step 2: Close shoulder seams
 
 ![This drawing was too nice not to use](neckline.jpg)
 
 -   Finish the raw edge on the front neckline in a way that suits your fabric (if it doesn’t fray, you can leave it unfinished).
--   With *good sides together*, place the front on the back aligning the shoulder seams.
+-   With _good sides together_, place the front on the back aligning the shoulder seams.
 -   Fold the front neckline seam allowance over to the wrong side of the back.
 
 <Note>
@@ -39,14 +39,14 @@ If you have a lightweight woven fabric you can fold this edge up again, so it wi
 
 The sleeve will be inserted flat, meaning the armhole seam will be sewn first and the sleeve and side seam will be closed in one go.
 
--   With *good sides together*, matching notches, pin the sleeve head along the armhole.
+-   With _good sides together_, matching notches, pin the sleeve head along the armhole.
 -   If necessary, ease in the sleeve head at the top, between the notches.
 -   Sew, finish and press the seam.
 -   Repeat for other sleeve.
 
 ### Step 5: Close side and sleeve seam
 
--   With *good sides together* pin the front to the back along the sleeve and side seams, making sure to line up the armhole seams.
+-   With _good sides together_ pin the front to the back along the sleeve and side seams, making sure to line up the armhole seams.
 -   Sew, finish and press the seam.
 
 ### Step 6: Hem
@@ -55,7 +55,7 @@ The sleeve will be inserted flat, meaning the armhole seam will be sewn first an
 
 <Note>
 
-Again, this can mean folding the hem under twice and *topstitching*, finishing the raw edge with a serger
+Again, this can mean folding the hem under twice and _topstitching_, finishing the raw edge with a serger
 or zig zag stitch and folding it under once or leaving the edge raw, folding it under once and
 trimming close to the stitching.
 

--- a/markdown/org/docs/patterns/diana/needs/en.md
+++ b/markdown/org/docs/patterns/diana/needs/en.md
@@ -1,7 +1,7 @@
 To make Diana, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 1.5 meters (1.7 yards) (or half of that if it's wide enough to fit the sleeves next tot he body) of a suitable fabric ([see Fabric options](/docs/patterns/diana/fabric))
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 1.5 meters (1.7 yards) (or half of that if it's wide enough to fit the sleeves next tot he body) of a suitable fabric ([see Fabric options](/docs/patterns/diana/fabric))
 
 <Note>
 

--- a/markdown/org/docs/patterns/florence/cutting/en.md
+++ b/markdown/org/docs/patterns/florence/cutting/en.md
@@ -2,7 +2,7 @@
 title: Cutting
 ---
 
-Florence only has one part, the *mask*. This is half of the mask, so we will need two of them.
+Florence only has one part, the _mask_. This is half of the mask, so we will need two of them.
 In addition, we want an outer and inner layer of fabric, so we'll need four in total:
 
 -   **Main fabric**

--- a/markdown/org/docs/patterns/florence/cutting/en.md
+++ b/markdown/org/docs/patterns/florence/cutting/en.md
@@ -5,9 +5,9 @@ title: Cutting
 Florence only has one part, the _mask_. This is half of the mask, so we will need two of them.
 In addition, we want an outer and inner layer of fabric, so we'll need four in total:
 
--   **Main fabric**
-    -   Cut **2 masks** parts
--   **Lining fabric**
-    -   Cut **2 masks** parts
+- **Main fabric**
+  - Cut **2 masks** parts
+- **Lining fabric**
+  - Cut **2 masks** parts
 
 If you're using the same fabric in and out (which is fine) then simply cut **4 mask** parts.

--- a/markdown/org/docs/patterns/florence/fabric/en.md
+++ b/markdown/org/docs/patterns/florence/fabric/en.md
@@ -6,9 +6,9 @@ For the outter fabric, cotton again, or a tightly woven wool.
 
 <Note>
 
-Note that fabric that is *breathable* is not the same as fabric your can breath through.
+Note that fabric that is _breathable_ is not the same as fabric your can breath through.
 There's many so-called waterproof breathable fabrics — or MBFs — that are used for outdoor gear because they
-repel water and are *breathable* but would make a poor choice for a face mask.
+repel water and are _breathable_ but would make a poor choice for a face mask.
 Look no further than your umbrella for an example. Chances are it's more from a fabric you can breath through,
 but only with substantial effort, which would not work for our face mask.
 

--- a/markdown/org/docs/patterns/florence/instructions/en.md
+++ b/markdown/org/docs/patterns/florence/instructions/en.md
@@ -1,6 +1,6 @@
 ### Step 1: Join center seam
 
-Join the curved seam that is center of our mask by placing the *good sides together* and sewing them in place.
+Join the curved seam that is center of our mask by placing the _good sides together_ and sewing them in place.
 
 ![Join the center seam](step1.svg)
 
@@ -34,7 +34,7 @@ and attach the ribbons all in one step.
 -   Then, place two ribbons on the corners of one side (right in our example) so that
     they peak out just a bit from the mask, but the ribbon extends inwards.
 -   Now place the main fabric on top of this with the good side town.
-    You should now have both layers of your mask on top of each other with *good sides together* and
+    You should now have both layers of your mask on top of each other with _good sides together_ and
     two ribbons sandwiched between them
 -   Pin through ribbons and layers to keep them in place
 -   Now do the same on the other side

--- a/markdown/org/docs/patterns/florence/instructions/en.md
+++ b/markdown/org/docs/patterns/florence/instructions/en.md
@@ -30,14 +30,14 @@ Alternatively, you can use a tailor's ham or cushion to press.
 Now we will sew the inner (lining) fabric to the outer (main) fabric,
 and attach the ribbons all in one step.
 
--   Place your lining fabric down with the good side up.
--   Then, place two ribbons on the corners of one side (right in our example) so that
-    they peak out just a bit from the mask, but the ribbon extends inwards.
--   Now place the main fabric on top of this with the good side town.
-    You should now have both layers of your mask on top of each other with _good sides together_ and
-    two ribbons sandwiched between them
--   Pin through ribbons and layers to keep them in place
--   Now do the same on the other side
+- Place your lining fabric down with the good side up.
+- Then, place two ribbons on the corners of one side (right in our example) so that
+  they peak out just a bit from the mask, but the ribbon extends inwards.
+- Now place the main fabric on top of this with the good side town.
+  You should now have both layers of your mask on top of each other with _good sides together_ and
+  two ribbons sandwiched between them
+- Pin through ribbons and layers to keep them in place
+- Now do the same on the other side
 
 <Tip>
 

--- a/markdown/org/docs/patterns/florence/needs/en.md
+++ b/markdown/org/docs/patterns/florence/needs/en.md
@@ -4,7 +4,7 @@ title: What you need
 
 To make a Florence face mask, you will need the following:
 
--   Basic sewing supplies
--   About 15 cm (6") of a suitable fabric ([see Fabric options](/docs/patterns/florence/fabric/))
--   About 15 cm (6") of lining fabric
--   About 1.6 meters (1.8 yards) of ribbon cut in 4 equal parts
+- Basic sewing supplies
+- About 15 cm (6") of a suitable fabric ([see Fabric options](/docs/patterns/florence/fabric/))
+- About 15 cm (6") of lining fabric
+- About 1.6 meters (1.8 yards) of ribbon cut in 4 equal parts

--- a/markdown/org/docs/patterns/florent/cutting/en.md
+++ b/markdown/org/docs/patterns/florent/cutting/en.md
@@ -8,16 +8,16 @@ Warning: The pattern includes the seam allowances on the top part so if you cut 
 The brim bottom part is inset, while the brim top part is offset so that the seam falls "underneath the brim edge".
 Keep that in mind when cutting the parts, and mark them accordingly, so that you don't end up with the seam on top of the brim (I don't want to force you into this design choice, I simply want to point out the difference between the parts so that you are aware of it and act accordingly).
 
--   **Main fabric**
-    -   Cut **1 top** on the fold but don't include the center seam allowance, or **2 top** with the center seam allowance.
-    -   Cut **1 side** on the fold, or **2 side**.
-    -   Cut **1 brim top**.
-    -   Cut **1 brim bottom**.
--   **Lining fabric**
-    -   Cut **1 top** on the fold but don't include the seam allowance, or **2 top** with the center seam allowance.
-    -   Cut **1 side** on the fold, or **2 side**.
--   **Plastic**
-    -   Cut **1 brim interfacing**. Tape the pattern part to the plastic, don't cut the notches in the plastic, but you can mark it (engrave it, or with permanent marker maybe). You don't really want any sharp edge, so make sure everything is smooth and rounded a bit (especially on the pointy sides).
+- **Main fabric**
+  - Cut **1 top** on the fold but don't include the center seam allowance, or **2 top** with the center seam allowance.
+  - Cut **1 side** on the fold, or **2 side**.
+  - Cut **1 brim top**.
+  - Cut **1 brim bottom**.
+- **Lining fabric**
+  - Cut **1 top** on the fold but don't include the seam allowance, or **2 top** with the center seam allowance.
+  - Cut **1 side** on the fold, or **2 side**.
+- **Plastic**
+  - Cut **1 brim interfacing**. Tape the pattern part to the plastic, don't cut the notches in the plastic, but you can mark it (engrave it, or with permanent marker maybe). You don't really want any sharp edge, so make sure everything is smooth and rounded a bit (especially on the pointy sides).
 
 A typical Florent layout looks like this:
 

--- a/markdown/org/docs/patterns/florent/needs/en.md
+++ b/markdown/org/docs/patterns/florent/needs/en.md
@@ -4,8 +4,8 @@ title: What you need
 
 To make Florent, you will need the following:
 
--   Basic sewing supplies
--   About 0.5 meters (0.6 yards) of a suitable fabric ([see Fabric options](/docs/patterns/florent/fabric/))
--   About 0.5 meters (0.6 yards) of lining fabric
--   Tape, a bit more than **head circumference** + **ease** that you used for the pattern
--   A sheet of plastic or something rigid for the brim (1 mm thick or less)
+- Basic sewing supplies
+- About 0.5 meters (0.6 yards) of a suitable fabric ([see Fabric options](/docs/patterns/florent/fabric/))
+- About 0.5 meters (0.6 yards) of lining fabric
+- Tape, a bit more than **head circumference** + **ease** that you used for the pattern
+- A sheet of plastic or something rigid for the brim (1 mm thick or less)

--- a/markdown/org/docs/patterns/holmes/cutting/en.md
+++ b/markdown/org/docs/patterns/holmes/cutting/en.md
@@ -6,14 +6,14 @@ The **crown** pattern piece needs to be cut on the fold to create a whole piece.
 
 ### Materials
 
--   **Main fabric**
-    -   Cut the amount of **crowns** you selected in the pattern options
-    -   Cut **4 ear** parts or Cut **2 ear** from main and lining.
-    -   Cut **4 visor** parts
--   **Lining fabric**
-    -   Cut the amount of **crowns** you selected in the pattern options
--   **Visor Insert Material**
-    -   Cut **2 visor inserts**. Use your visor pattern piece with no seam allowance.
+- **Main fabric**
+  - Cut the amount of **crowns** you selected in the pattern options
+  - Cut **4 ear** parts or Cut **2 ear** from main and lining.
+  - Cut **4 visor** parts
+- **Lining fabric**
+  - Cut the amount of **crowns** you selected in the pattern options
+- **Visor Insert Material**
+  - Cut **2 visor inserts**. Use your visor pattern piece with no seam allowance.
 
 ### Optional Fabric Ties
 

--- a/markdown/org/docs/patterns/holmes/cutting/en.md
+++ b/markdown/org/docs/patterns/holmes/cutting/en.md
@@ -17,7 +17,7 @@ The **crown** pattern piece needs to be cut on the fold to create a whole piece.
 
 ### Optional Fabric Ties
 
-If you don't wish to use ribbon for your ties you can make them out of fabric. Simply cut 4 crossgrain strips of an 1" (2.5cm) or width of your choosen + seam allowances wide and sew two tubes leaving one of the short sides open for turning. Clip the corners and trim seams. Turn out an press. If desired you can ***Edgestitch*** or ***Topstitch*** the tubes to stop the fabric from shifting. The raw edge of the tubes can then be concealed in the ear flap seam when constructing the ear flaps.
+If you don't wish to use ribbon for your ties you can make them out of fabric. Simply cut 4 crossgrain strips of an 1" (2.5cm) or width of your choosen + seam allowances wide and sew two tubes leaving one of the short sides open for turning. Clip the corners and trim seams. Turn out an press. If desired you can _**Edgestitch**_ or _**Topstitch**_ the tubes to stop the fabric from shifting. The raw edge of the tubes can then be concealed in the ear flap seam when constructing the ear flaps.
 
 <Note>
 

--- a/markdown/org/docs/patterns/holmes/fabric/en.md
+++ b/markdown/org/docs/patterns/holmes/fabric/en.md
@@ -16,7 +16,7 @@ Generally you want a lightweight fabric such as **Silks** or **Cotton Lawn** but
 
 ### Interfacing
 
-Depending on your main fabric's thickness and how well it keeps its shape you may need to interface your fabric. If you are uncertain of whether your fabric requires interfacing, quickly ***Baste*** your crown pieces together and see if the crown stays up right when placed on a surface. If it doesn't it needs interfacing. As a rule of thumb you will generally need a **Medium Firm Interfacing** but if your fabric is quite thin you may need a firmer interfacing. If you are still uncertain you can face your crown pieces and once again ***Baste*** the crown pieces together and check how it looks on your head. You can either use fusible or non-fusible interfacing. If using non-fusible interfacing you will want to flat line the interfacing to your pieces wih temporary ***Pad Stitches***.
+Depending on your main fabric's thickness and how well it keeps its shape you may need to interface your fabric. If you are uncertain of whether your fabric requires interfacing, quickly _**Baste**_ your crown pieces together and see if the crown stays up right when placed on a surface. If it doesn't it needs interfacing. As a rule of thumb you will generally need a **Medium Firm Interfacing** but if your fabric is quite thin you may need a firmer interfacing. If you are still uncertain you can face your crown pieces and once again _**Baste**_ the crown pieces together and check how it looks on your head. You can either use fusible or non-fusible interfacing. If using non-fusible interfacing you will want to flat line the interfacing to your pieces wih temporary _**Pad Stitches**_.
 
 <Note>
 

--- a/markdown/org/docs/patterns/holmes/instructions/en.md
+++ b/markdown/org/docs/patterns/holmes/instructions/en.md
@@ -4,8 +4,8 @@ title: Holmes Construction
 
 ### Step 1: Prepping the Pieces
 
--   If needed, Interface the crown and half the ear flap pieces.
--   If not already done so, it is recommended to mark the seam lines on your fabric pieces by either a temporary marker or by thread marking. This is for a more precise sew which is key for hat construction.
+- If needed, Interface the crown and half the ear flap pieces.
+- If not already done so, it is recommended to mark the seam lines on your fabric pieces by either a temporary marker or by thread marking. This is for a more precise sew which is key for hat construction.
 
 <Tip>
 
@@ -27,12 +27,12 @@ These instructions assume you have marked your seam lines. They may be harder to
 
 ### Step 2: The Crown
 
--   With right sides together, matching seam lines and peaks, sew two crown pieces together.
--   Press seams open. You made need to use a tailors ham for this, if you do not have one you can use flannels or towels instead.
--   (Optional) _Edgestitch_ both sides of the seam, making sure to catch the seam allowances.
--   Repeat until you have two halves. If half the number of crown pieces is an odd number you will have to sew a single piece to each half. e.g. If you have 6 crown pieces, you make two halves of 3 sewing one piece to two sewn together pieces.
--   With right sides together, matchinig seam lines and peaks, sew the two halves together. You may find it easier to handstitch the peak together due to bulk or for precision. This seam will be refered to as the "centre crown seam" going forward.
--   (Optional) _Edgestitch_ both sides of the centre crown seam, making sure to catch the seam allowances.
+- With right sides together, matching seam lines and peaks, sew two crown pieces together.
+- Press seams open. You made need to use a tailors ham for this, if you do not have one you can use flannels or towels instead.
+- (Optional) _Edgestitch_ both sides of the seam, making sure to catch the seam allowances.
+- Repeat until you have two halves. If half the number of crown pieces is an odd number you will have to sew a single piece to each half. e.g. If you have 6 crown pieces, you make two halves of 3 sewing one piece to two sewn together pieces.
+- With right sides together, matchinig seam lines and peaks, sew the two halves together. You may find it easier to handstitch the peak together due to bulk or for precision. This seam will be refered to as the "centre crown seam" going forward.
+- (Optional) _Edgestitch_ both sides of the centre crown seam, making sure to catch the seam allowances.
 
 <Note>
 
@@ -44,14 +44,14 @@ Depending on your seam allowance you may want to trim seams as you go to reduce 
 
 #### Ear Flaps with Ties
 
--   Cut two 12" (30cm) - 16" (40cm) length of ribbon. These will be refered to as ties going forward.
--   _Baste_ a tie to the right side of an ear flap (the interfaced one if using). Repeat for other tie.
--   With right sides together, matching seam lines, sew a tie ear flap to a non-tie ear flap.
--   Clip and trim seam allowance.
--   Turn inside out and press.
--   (Optional) _Topstitch_ or _edgestitch_ the folded edge.
--   _Baste_ the raw edges together.
--   Repeat for the remaining ear flap.
+- Cut two 12" (30cm) - 16" (40cm) length of ribbon. These will be refered to as ties going forward.
+- _Baste_ a tie to the right side of an ear flap (the interfaced one if using). Repeat for other tie.
+- With right sides together, matching seam lines, sew a tie ear flap to a non-tie ear flap.
+- Clip and trim seam allowance.
+- Turn inside out and press.
+- (Optional) _Topstitch_ or _edgestitch_ the folded edge.
+- _Baste_ the raw edges together.
+- Repeat for the remaining ear flap.
 
 <Tip>
 
@@ -68,14 +68,14 @@ If you prefer you can make your custom ties with fabric, [see Holmes cutting](/d
 
 #### Ear Flaps with Buttonholes
 
--   Face the backs of two of the buttonholes. (This is not needed if two flaps have already been interfaced)
--   With right sides together, matching seam lines, sew two ear flap pieces together (one interfaced, one not).
--   Clip and trim seam allowance.
--   Turn inside out and press.
--   (Optional) _Topstitch_ or _Edgestitch_ the folded edge.
--   _Baste_ the raw edges together.
--   Sew the buttonhole in your prefered method.
--   Repeat for the remaining ear flap.
+- Face the backs of two of the buttonholes. (This is not needed if two flaps have already been interfaced)
+- With right sides together, matching seam lines, sew two ear flap pieces together (one interfaced, one not).
+- Clip and trim seam allowance.
+- Turn inside out and press.
+- (Optional) _Topstitch_ or _Edgestitch_ the folded edge.
+- _Baste_ the raw edges together.
+- Sew the buttonhole in your prefered method.
+- Repeat for the remaining ear flap.
 
 <Warning>
 
@@ -97,14 +97,14 @@ There are two methods for constructing the visors. This is due to the different 
 
 #### The Visors Method 1
 
--   Place visor insert on one visor piece inside seam lines.
--   Temporarily secure visor insert to visor with temporary _pad Stitches_. This will be refered to as "faced visor" going forward.
--   _Baste_ along the seam line of the inner curve of the faced visor, making sure not to catch the visor insert.
--   With right sides together, matching seam lines and centre fronts, sew the faced visor to another visor piece along the outer curve close to the visor insert, making sure not to catch the visor Insert.
--   Notch and trim the outer curve making sure not to clip the stitching. (You may wish to turn and check the shape before this step)
--   Turn inside out and press. Making sure that the seam allowances are on top of not under the visor insert.
--   Using the previous basting line as a guide, _baste_ the opening closed.
--   Repeat this for remaining visor pieces.
+- Place visor insert on one visor piece inside seam lines.
+- Temporarily secure visor insert to visor with temporary _pad Stitches_. This will be refered to as "faced visor" going forward.
+- _Baste_ along the seam line of the inner curve of the faced visor, making sure not to catch the visor insert.
+- With right sides together, matching seam lines and centre fronts, sew the faced visor to another visor piece along the outer curve close to the visor insert, making sure not to catch the visor Insert.
+- Notch and trim the outer curve making sure not to clip the stitching. (You may wish to turn and check the shape before this step)
+- Turn inside out and press. Making sure that the seam allowances are on top of not under the visor insert.
+- Using the previous basting line as a guide, _baste_ the opening closed.
+- Repeat this for remaining visor pieces.
 
 <Warning>
 
@@ -120,13 +120,13 @@ If preferred you can temporarily attach the visor insert another way that does n
 
 #### The Visors Method 2
 
--   With rights sides together, matching seam lines and centre fronts, sew the outer curver of two visor pieces together.
--   Notch and trim (if needed) the outer curve making sure not to clip the stitching. (You may wish to turn and check the shape before this step)
--   Turn inside out and press.
--   Insert visor insert in to sewn visor tightly so there is no gap on the outer curver and the seam allowances are all one on side of the visor insert. This will be the upper side of the visor.
--   Pin the inner curve together making sure that the outer edge is pulled tightly over the visor insert.
--   _Baste_ as close as you can to the inner curve of the visor insert, making sure you pull the fabric tightly over the outer edge as you sew.
--   Repeat for the remaining visor pieces.
+- With rights sides together, matching seam lines and centre fronts, sew the outer curver of two visor pieces together.
+- Notch and trim (if needed) the outer curve making sure not to clip the stitching. (You may wish to turn and check the shape before this step)
+- Turn inside out and press.
+- Insert visor insert in to sewn visor tightly so there is no gap on the outer curver and the seam allowances are all one on side of the visor insert. This will be the upper side of the visor.
+- Pin the inner curve together making sure that the outer edge is pulled tightly over the visor insert.
+- _Baste_ as close as you can to the inner curve of the visor insert, making sure you pull the fabric tightly over the outer edge as you sew.
+- Repeat for the remaining visor pieces.
 
 ### Step 5: Assembly and Lining
 
@@ -134,39 +134,39 @@ Once again there are two methods for final assembly and lining. Read both method
 
 #### Assembly and Lining Method 1
 
--   Matchings centres and seam lines align the ear flap with the right side of one of the panels that is not part of the centre crown seam. Making sure the faced side is placed against the crown (if faced).
--   Sew ear flap to the crown along seam lines.
--   Repeat for the remaining ear flap on the opposite side of the crown.
--   Align centre front of visor with the right side of the centre crown seam making sure the visor insert is on the bottom.
--   Hand-baste the visor to the crown matching the visor basting lines to the crown seam lines. It easier to _baste_ the centre down first and then work from the centre out.
--   Sew the visor to the crown along seam lines. You may find it easier to permanently hand-sew the visor on rather than using a machine.
--   Repeat for the remaining visor on the opposite side of the centre crown seam.
--   Remove all pad and basting stitches.
--   Press the seam allowances inwards, making sure the stitching is not visible on the outside.
--   (Optional) Loosely _whipstitch_ the seams to the inside of the crown making sure the stitching does not show on the outside.
--   Construct lining the same way as the crown ommitting _edgestitching_.
--   Fold and Press under the bottom seam allowance of the lining. You may find you need to press under more to prevent the lining from showing. You may also find you need to _baste_ the seam allowance down.
--   Matching centre crown seams and panel seams, pin the lining into the hat wrong sides together. Placing the folded edge along the stitching lines.
--   _Slipstitch_ or _whipstitch_ the lining to the seam allowance of the hat.
--   Remove lining basting if used.
--   (Optional) _Tack_ the peak of the lining to the peak of the crown. This is to help prevent the lining from falling out.
+- Matchings centres and seam lines align the ear flap with the right side of one of the panels that is not part of the centre crown seam. Making sure the faced side is placed against the crown (if faced).
+- Sew ear flap to the crown along seam lines.
+- Repeat for the remaining ear flap on the opposite side of the crown.
+- Align centre front of visor with the right side of the centre crown seam making sure the visor insert is on the bottom.
+- Hand-baste the visor to the crown matching the visor basting lines to the crown seam lines. It easier to _baste_ the centre down first and then work from the centre out.
+- Sew the visor to the crown along seam lines. You may find it easier to permanently hand-sew the visor on rather than using a machine.
+- Repeat for the remaining visor on the opposite side of the centre crown seam.
+- Remove all pad and basting stitches.
+- Press the seam allowances inwards, making sure the stitching is not visible on the outside.
+- (Optional) Loosely _whipstitch_ the seams to the inside of the crown making sure the stitching does not show on the outside.
+- Construct lining the same way as the crown ommitting _edgestitching_.
+- Fold and Press under the bottom seam allowance of the lining. You may find you need to press under more to prevent the lining from showing. You may also find you need to _baste_ the seam allowance down.
+- Matching centre crown seams and panel seams, pin the lining into the hat wrong sides together. Placing the folded edge along the stitching lines.
+- _Slipstitch_ or _whipstitch_ the lining to the seam allowance of the hat.
+- Remove lining basting if used.
+- (Optional) _Tack_ the peak of the lining to the peak of the crown. This is to help prevent the lining from falling out.
 
 #### Assembly and Lining Method 2
 
--   Matchings centres and seam lines align the ear flap with the right side of one of the panels that is not part of the centre crown seam. Making sure the faced side is placed against the crown (if faced).
--   _Baste_ the ear flap to the crown along seam lines
--   Repeat for the remaining ear flap on the opposite side of the crown.
--   Align centre front of visor with the right side of the centre crown seam making sure the visor insert is on the bottom.
--   Hand-baste the visor to the crown matching the visor basting lines to the crown seam lines. It easier to _baste_ the centre down first and then work from the centre out.
--   (Optional) Machine-baste the visor to the crown along seam lines.
--   Repeat for the remaining visor on the opposite side of the centre crown seam.
--   Construct lining the same way as the crown ommitting _edgestitching_ and leaving a gap in the centre lining seam large enough to turn the hat.
--   With right sides together, matching centre crown seams, panel seams and seam lines. Sew the lining to the the crown along seam lines. If bulky you may want to trim either the lining seams or both seams.
--   Turn hat inside out, pressing lining to inside.
--   (Optional/Alternate) _Understitch_ lining.
--   Slipstitch lining opening closed.
--   (Optional/Alternate) _Topstitch_ or _Edgestitch_ along the outside of the hat, catching the lining on the inside making sure it is not peaking whilst you sew.
--   (Optional) _Tack_ the peak of the lining to the peak of the crown. This is to help prevent the lining from falling out.
+- Matchings centres and seam lines align the ear flap with the right side of one of the panels that is not part of the centre crown seam. Making sure the faced side is placed against the crown (if faced).
+- _Baste_ the ear flap to the crown along seam lines
+- Repeat for the remaining ear flap on the opposite side of the crown.
+- Align centre front of visor with the right side of the centre crown seam making sure the visor insert is on the bottom.
+- Hand-baste the visor to the crown matching the visor basting lines to the crown seam lines. It easier to _baste_ the centre down first and then work from the centre out.
+- (Optional) Machine-baste the visor to the crown along seam lines.
+- Repeat for the remaining visor on the opposite side of the centre crown seam.
+- Construct lining the same way as the crown ommitting _edgestitching_ and leaving a gap in the centre lining seam large enough to turn the hat.
+- With right sides together, matching centre crown seams, panel seams and seam lines. Sew the lining to the the crown along seam lines. If bulky you may want to trim either the lining seams or both seams.
+- Turn hat inside out, pressing lining to inside.
+- (Optional/Alternate) _Understitch_ lining.
+- Slipstitch lining opening closed.
+- (Optional/Alternate) _Topstitch_ or _Edgestitch_ along the outside of the hat, catching the lining on the inside making sure it is not peaking whilst you sew.
+- (Optional) _Tack_ the peak of the lining to the peak of the crown. This is to help prevent the lining from falling out.
 
 <Note>
 
@@ -198,16 +198,16 @@ If you did not cut your ties down when constructing the ear flaps, now is the ti
 
 #### Finishing Ties Method 1
 
--   Fold the ends of a tie in half and cut a triangle out from the corner to the fold.
--   Unfold.
--   If you are worried about the ties fraying you can use fray check or equivalent.
--   Repeat for the remaining tie.
+- Fold the ends of a tie in half and cut a triangle out from the corner to the fold.
+- Unfold.
+- If you are worried about the ties fraying you can use fray check or equivalent.
+- Repeat for the remaining tie.
 
 #### Finishing Ties Method 2
 
--   Fold under 1/8" (3mm) and another 1/8" (3mm) on one of the ties. Pin if needed.
--   _Whipstitch_ the folded edge down to the tie
--   Repeat for the remaining tie.
+- Fold under 1/8" (3mm) and another 1/8" (3mm) on one of the ties. Pin if needed.
+- _Whipstitch_ the folded edge down to the tie
+- Repeat for the remaining tie.
 
 <Note>
 
@@ -219,9 +219,9 @@ To determine which way you want to fold the ties, you may find it easier to tie 
 
 Unless you are doing the Buttonhole Ear Flaps you do not have to sew a button on but it may be useful if you want to hide any misaligned seams at the crown peak.
 
--   Construct a covered button.
--   Attach the button via the shank to the peak of the crown doing your best to keep it in the middle of the seams.
--   Alternatively if you are not using the button with the ear flaps you can bend the shank down and _whipstitch_ the edge of the button to the crown instead so it does not move.
+- Construct a covered button.
+- Attach the button via the shank to the peak of the crown doing your best to keep it in the middle of the seams.
+- Alternatively if you are not using the button with the ear flaps you can bend the shank down and _whipstitch_ the edge of the button to the crown instead so it does not move.
 
 <Note>
 

--- a/markdown/org/docs/patterns/holmes/instructions/en.md
+++ b/markdown/org/docs/patterns/holmes/instructions/en.md
@@ -29,10 +29,10 @@ These instructions assume you have marked your seam lines. They may be harder to
 
 -   With right sides together, matching seam lines and peaks, sew two crown pieces together.
 -   Press seams open. You made need to use a tailors ham for this, if you do not have one you can use flannels or towels instead.
--   (Optional) *Edgestitch* both sides of the seam, making sure to catch the seam allowances.
+-   (Optional) _Edgestitch_ both sides of the seam, making sure to catch the seam allowances.
 -   Repeat until you have two halves. If half the number of crown pieces is an odd number you will have to sew a single piece to each half. e.g. If you have 6 crown pieces, you make two halves of 3 sewing one piece to two sewn together pieces.
 -   With right sides together, matchinig seam lines and peaks, sew the two halves together. You may find it easier to handstitch the peak together due to bulk or for precision. This seam will be refered to as the "centre crown seam" going forward.
--   (Optional) *Edgestitch* both sides of the centre crown seam, making sure to catch the seam allowances.
+-   (Optional) _Edgestitch_ both sides of the centre crown seam, making sure to catch the seam allowances.
 
 <Note>
 
@@ -45,12 +45,12 @@ Depending on your seam allowance you may want to trim seams as you go to reduce 
 #### Ear Flaps with Ties
 
 -   Cut two 12" (30cm) - 16" (40cm) length of ribbon. These will be refered to as ties going forward.
--   *Baste* a tie to the right side of an ear flap (the interfaced one if using). Repeat for other tie.
+-   _Baste_ a tie to the right side of an ear flap (the interfaced one if using). Repeat for other tie.
 -   With right sides together, matching seam lines, sew a tie ear flap to a non-tie ear flap.
 -   Clip and trim seam allowance.
 -   Turn inside out and press.
--   (Optional) *Topstitch* or *edgestitch* the folded edge.
--   *Baste* the raw edges together.
+-   (Optional) _Topstitch_ or _edgestitch_ the folded edge.
+-   _Baste_ the raw edges together.
 -   Repeat for the remaining ear flap.
 
 <Tip>
@@ -72,8 +72,8 @@ If you prefer you can make your custom ties with fabric, [see Holmes cutting](/d
 -   With right sides together, matching seam lines, sew two ear flap pieces together (one interfaced, one not).
 -   Clip and trim seam allowance.
 -   Turn inside out and press.
--   (Optional) *Topstitch* or *Edgestitch* the folded edge.
--   *Baste* the raw edges together.
+-   (Optional) _Topstitch_ or _Edgestitch_ the folded edge.
+-   _Baste_ the raw edges together.
 -   Sew the buttonhole in your prefered method.
 -   Repeat for the remaining ear flap.
 
@@ -87,7 +87,7 @@ The ear flaps will need to be long enough to go over the top of the peak so they
 
 **For both Ear Flaps with Ties and Button Holes**
 
-It is recommended to at least *topstitch* the ear flaps but this may not be desirable with certain patterns so has been marked as optional.
+It is recommended to at least _topstitch_ the ear flaps but this may not be desirable with certain patterns so has been marked as optional.
 
 </Note>
 
@@ -98,12 +98,12 @@ There are two methods for constructing the visors. This is due to the different 
 #### The Visors Method 1
 
 -   Place visor insert on one visor piece inside seam lines.
--   Temporarily secure visor insert to visor with temporary *pad Stitches*. This will be refered to as "faced visor" going forward.
--   *Baste* along the seam line of the inner curve of the faced visor, making sure not to catch the visor insert.
+-   Temporarily secure visor insert to visor with temporary _pad Stitches_. This will be refered to as "faced visor" going forward.
+-   _Baste_ along the seam line of the inner curve of the faced visor, making sure not to catch the visor insert.
 -   With right sides together, matching seam lines and centre fronts, sew the faced visor to another visor piece along the outer curve close to the visor insert, making sure not to catch the visor Insert.
 -   Notch and trim the outer curve making sure not to clip the stitching. (You may wish to turn and check the shape before this step)
 -   Turn inside out and press. Making sure that the seam allowances are on top of not under the visor insert.
--   Using the previous basting line as a guide, *baste* the opening closed.
+-   Using the previous basting line as a guide, _baste_ the opening closed.
 -   Repeat this for remaining visor pieces.
 
 <Warning>
@@ -125,7 +125,7 @@ If preferred you can temporarily attach the visor insert another way that does n
 -   Turn inside out and press.
 -   Insert visor insert in to sewn visor tightly so there is no gap on the outer curver and the seam allowances are all one on side of the visor insert. This will be the upper side of the visor.
 -   Pin the inner curve together making sure that the outer edge is pulled tightly over the visor insert.
--   *Baste* as close as you can to the inner curve of the visor insert, making sure you pull the fabric tightly over the outer edge as you sew.
+-   _Baste_ as close as you can to the inner curve of the visor insert, making sure you pull the fabric tightly over the outer edge as you sew.
 -   Repeat for the remaining visor pieces.
 
 ### Step 5: Assembly and Lining
@@ -138,35 +138,35 @@ Once again there are two methods for final assembly and lining. Read both method
 -   Sew ear flap to the crown along seam lines.
 -   Repeat for the remaining ear flap on the opposite side of the crown.
 -   Align centre front of visor with the right side of the centre crown seam making sure the visor insert is on the bottom.
--   Hand-baste the visor to the crown matching the visor basting lines to the crown seam lines. It easier to *baste* the centre down first and then work from the centre out.
+-   Hand-baste the visor to the crown matching the visor basting lines to the crown seam lines. It easier to _baste_ the centre down first and then work from the centre out.
 -   Sew the visor to the crown along seam lines. You may find it easier to permanently hand-sew the visor on rather than using a machine.
 -   Repeat for the remaining visor on the opposite side of the centre crown seam.
 -   Remove all pad and basting stitches.
 -   Press the seam allowances inwards, making sure the stitching is not visible on the outside.
--   (Optional) Loosely *whipstitch* the seams to the inside of the crown making sure the stitching does not show on the outside.
--   Construct lining the same way as the crown ommitting *edgestitching*.
--   Fold and Press under the bottom seam allowance of the lining. You may find you need to press under more to prevent the lining from showing. You may also find you need to *baste* the seam allowance down.
+-   (Optional) Loosely _whipstitch_ the seams to the inside of the crown making sure the stitching does not show on the outside.
+-   Construct lining the same way as the crown ommitting _edgestitching_.
+-   Fold and Press under the bottom seam allowance of the lining. You may find you need to press under more to prevent the lining from showing. You may also find you need to _baste_ the seam allowance down.
 -   Matching centre crown seams and panel seams, pin the lining into the hat wrong sides together. Placing the folded edge along the stitching lines.
--   *Slipstitch* or *whipstitch* the lining to the seam allowance of the hat.
+-   _Slipstitch_ or _whipstitch_ the lining to the seam allowance of the hat.
 -   Remove lining basting if used.
--   (Optional) *Tack* the peak of the lining to the peak of the crown. This is to help prevent the lining from falling out.
+-   (Optional) _Tack_ the peak of the lining to the peak of the crown. This is to help prevent the lining from falling out.
 
 #### Assembly and Lining Method 2
 
 -   Matchings centres and seam lines align the ear flap with the right side of one of the panels that is not part of the centre crown seam. Making sure the faced side is placed against the crown (if faced).
--   *Baste* the ear flap to the crown along seam lines
+-   _Baste_ the ear flap to the crown along seam lines
 -   Repeat for the remaining ear flap on the opposite side of the crown.
 -   Align centre front of visor with the right side of the centre crown seam making sure the visor insert is on the bottom.
--   Hand-baste the visor to the crown matching the visor basting lines to the crown seam lines. It easier to *baste* the centre down first and then work from the centre out.
+-   Hand-baste the visor to the crown matching the visor basting lines to the crown seam lines. It easier to _baste_ the centre down first and then work from the centre out.
 -   (Optional) Machine-baste the visor to the crown along seam lines.
 -   Repeat for the remaining visor on the opposite side of the centre crown seam.
--   Construct lining the same way as the crown ommitting *edgestitching* and leaving a gap in the centre lining seam large enough to turn the hat.
+-   Construct lining the same way as the crown ommitting _edgestitching_ and leaving a gap in the centre lining seam large enough to turn the hat.
 -   With right sides together, matching centre crown seams, panel seams and seam lines. Sew the lining to the the crown along seam lines. If bulky you may want to trim either the lining seams or both seams.
 -   Turn hat inside out, pressing lining to inside.
--   (Optional/Alternate) *Understitch* lining.
+-   (Optional/Alternate) _Understitch_ lining.
 -   Slipstitch lining opening closed.
--   (Optional/Alternate) *Topstitch* or *Edgestitch* along the outside of the hat, catching the lining on the inside making sure it is not peaking whilst you sew.
--   (Optional) *Tack* the peak of the lining to the peak of the crown. This is to help prevent the lining from falling out.
+-   (Optional/Alternate) _Topstitch_ or _Edgestitch_ along the outside of the hat, catching the lining on the inside making sure it is not peaking whilst you sew.
+-   (Optional) _Tack_ the peak of the lining to the peak of the crown. This is to help prevent the lining from falling out.
 
 <Note>
 
@@ -206,7 +206,7 @@ If you did not cut your ties down when constructing the ear flaps, now is the ti
 #### Finishing Ties Method 2
 
 -   Fold under 1/8" (3mm) and another 1/8" (3mm) on one of the ties. Pin if needed.
--   *Whipstitch* the folded edge down to the tie
+-   _Whipstitch_ the folded edge down to the tie
 -   Repeat for the remaining tie.
 
 <Note>
@@ -221,7 +221,7 @@ Unless you are doing the Buttonhole Ear Flaps you do not have to sew a button on
 
 -   Construct a covered button.
 -   Attach the button via the shank to the peak of the crown doing your best to keep it in the middle of the seams.
--   Alternatively if you are not using the button with the ear flaps you can bend the shank down and *whipstitch* the edge of the button to the crown instead so it does not move.
+-   Alternatively if you are not using the button with the ear flaps you can bend the shank down and _whipstitch_ the edge of the button to the crown instead so it does not move.
 
 <Note>
 

--- a/markdown/org/docs/patterns/holmes/needs/en.md
+++ b/markdown/org/docs/patterns/holmes/needs/en.md
@@ -4,20 +4,20 @@ title: Holmes What you need
 
 To make Holmes, you will need the following:
 
--   Basic sewing supplies
--   About 0.5 metres (0.6 yards) of a suitable fabric ([see Holmes Fabric options](/docs/patterns/holmes/fabric/))
--   About 0.5 metres (0.6 yards) of lining fabric ([see Holmes Fabric options](/docs/patterns/holmes/fabric/))
--   A rigid material for the visor insert ([see Holmes Fabric options](/docs/patterns/holmes/fabric/))
--   (Optional) About 1 metre of 1" (2.5cm) crossgrain ribbon or petersham.
--   (Optional) 1 covered button about 3/4" (2cm) - 7/8" (2.2cm)
+- Basic sewing supplies
+- About 0.5 metres (0.6 yards) of a suitable fabric ([see Holmes Fabric options](/docs/patterns/holmes/fabric/))
+- About 0.5 metres (0.6 yards) of lining fabric ([see Holmes Fabric options](/docs/patterns/holmes/fabric/))
+- A rigid material for the visor insert ([see Holmes Fabric options](/docs/patterns/holmes/fabric/))
+- (Optional) About 1 metre of 1" (2.5cm) crossgrain ribbon or petersham.
+- (Optional) 1 covered button about 3/4" (2cm) - 7/8" (2.2cm)
 
 <Note>
 
 Depending on style the ties and buttons are optional.
 
--   If you are making Buttonhole Ear Flaps you can omit the ties.
--   If you are making Tie Ear Flaps you can omit the button.
--   Ties can also be made from fabric if you prefer ([see Holmes Cutting](/docs/patterns/holmes/cutting/))
--   You can also use different width and type ribbons for the ties if you prefer.
+- If you are making Buttonhole Ear Flaps you can omit the ties.
+- If you are making Tie Ear Flaps you can omit the button.
+- Ties can also be made from fabric if you prefer ([see Holmes Cutting](/docs/patterns/holmes/cutting/))
+- You can also use different width and type ribbons for the ties if you prefer.
 
 </Note>

--- a/markdown/org/docs/patterns/hortensia/cutting/en.md
+++ b/markdown/org/docs/patterns/hortensia/cutting/en.md
@@ -1,13 +1,13 @@
 ### Materials
 
--   **Main fabric**
-    -   Cut **2 SidePanel** parts
-    -   Cut **2 FrontBackPanel** parts
-    -   Cut **1 BottomPanel**
-    -   Cut **2 SidePanelReinforcement** parts
-    -   Cut **2 Strap** parts
-    -   Cut **1 ZipperPanel** part
--   **Lining fabric**
-    -   Cut **2 SidePanel** parts
-    -   Cut **2 FrontBackPanel** parts
-    -   Cut **1 BottomPanel**
+- **Main fabric**
+  - Cut **2 SidePanel** parts
+  - Cut **2 FrontBackPanel** parts
+  - Cut **1 BottomPanel**
+  - Cut **2 SidePanelReinforcement** parts
+  - Cut **2 Strap** parts
+  - Cut **1 ZipperPanel** part
+- **Lining fabric**
+  - Cut **2 SidePanel** parts
+  - Cut **2 FrontBackPanel** parts
+  - Cut **1 BottomPanel**

--- a/markdown/org/docs/patterns/hortensia/instructions/en.md
+++ b/markdown/org/docs/patterns/hortensia/instructions/en.md
@@ -4,18 +4,18 @@
 
 ### Step 2: Sew the front and back panels to the bottom
 
--   With *good sides together* sew the front and back panels to the bottom panel.
+-   With _good sides together_ sew the front and back panels to the bottom panel.
 -   Press the seam allowances towards the bottom panel.
--   On the outside *Edgestitch* the seam allowance to the bottom panel.
+-   On the outside _Edgestitch_ the seam allowance to the bottom panel.
 
 ### Step 3: Create and attach straps
 
 -   If needed, face your straps.
--   Fold the straps in half lengthwise with *good sides matching*.
+-   Fold the straps in half lengthwise with _good sides matching_.
 -   Sew the raw edges together making sure to leave a gap for turning.
 -   Turn inside out.
--   *Slipstich* the opening closed.
--   Alternatively *Edgestitch* all the edges.
+-   _Slipstich_ the opening closed.
+-   Alternatively _Edgestitch_ all the edges.
 -   Attach one strap to the front panel and one strap to the back panel by sewing a rectangle and a cross.
 
 <Warning>
@@ -36,12 +36,12 @@ If using bag strap webbing instead of fabric made straps do the following,
 
 ### Step 4: The zipper
 
--   Insert the zipper into the zipper panel making sure that the zipper pull is on the *good side*.
+-   Insert the zipper into the zipper panel making sure that the zipper pull is on the _good side_.
 
 ### (Optional) Step 5: Construct tabs.
 
 -   Construct tabs the same as the straps just shorter.
--   *Baste* the tabs *good sides together* to the short edges of the zipper panel so the tabs face inward.
+-   _Baste_ the tabs _good sides together_ to the short edges of the zipper panel so the tabs face inward.
 
 <Tip>
 
@@ -51,22 +51,22 @@ We recommend the tabs to be about a quarter length of the straps.
 
 ### Step 6: Attach the zipper panel
 
--   With *good sides together* sew the zipper panel to the front and pack panels. We will now refer to this as **the tube**.
+-   With _good sides together_ sew the zipper panel to the front and pack panels. We will now refer to this as **the tube**.
 
 ### Step 7: Prep the side panels
 
 -   Press under the top seam allowance of the side panel reinforcement parts.
 -   Place the side panel reinforcement parts on top of the side panels matching the raw edges.
--   *Edgestitch* the folded edge of the reinforcement parts to the side panels.
--   *Baste* the raw edges together.
+-   _Edgestitch_ the folded edge of the reinforcement parts to the side panels.
+-   _Baste_ the raw edges together.
 
 ### Step 8: Attach the side panels to the tube
 
--   With *good sides together* sew the side panels to the tube matching notches to the bottom and zipper panel seams.
--   If binding the edges rather than turning, sew with *wrong sides together* instead.
+-   With _good sides together_ sew the side panels to the tube matching notches to the bottom and zipper panel seams.
+-   If binding the edges rather than turning, sew with _wrong sides together_ instead.
 -   If not binding the edges leave a gap in one of the sides for turning.
--   Turn inside out and *Slipstich* the opening closed.
--   If sewn *wrong sides together* bind the raw edges of the side panels.
+-   Turn inside out and _Slipstich_ the opening closed.
+-   If sewn _wrong sides together_ bind the raw edges of the side panels.
 
 <Note>
 
@@ -76,12 +76,12 @@ It is recommended to leave the gap for turning on the side rather than the top o
 
 ### Step 9: Lining
 
--   With *good sides together* sew the front and back lining panels to the bottom lining panel.
--   With *good sides together* attach the lining side panels.
+-   With _good sides together_ sew the front and back lining panels to the bottom lining panel.
+-   With _good sides together_ attach the lining side panels.
 -   Press under the top seam allowances.
 -   Alernatively you can bind the top edges.
--   Place the lining inside the bag *wrong sides facing* eachother.
--   *Slipstitch* or *Whipstitch* the lining to the zipper panel.
+-   Place the lining inside the bag _wrong sides facing_ eachother.
+-   _Slipstitch_ or _Whipstitch_ the lining to the zipper panel.
 
 ### Step 10: Enjoy!
 

--- a/markdown/org/docs/patterns/hortensia/instructions/en.md
+++ b/markdown/org/docs/patterns/hortensia/instructions/en.md
@@ -1,22 +1,22 @@
 ### (Optional) Step 1: Face the main fabric
 
--   If needed, Interface your main fabric pieces.
+- If needed, Interface your main fabric pieces.
 
 ### Step 2: Sew the front and back panels to the bottom
 
--   With _good sides together_ sew the front and back panels to the bottom panel.
--   Press the seam allowances towards the bottom panel.
--   On the outside _Edgestitch_ the seam allowance to the bottom panel.
+- With _good sides together_ sew the front and back panels to the bottom panel.
+- Press the seam allowances towards the bottom panel.
+- On the outside _Edgestitch_ the seam allowance to the bottom panel.
 
 ### Step 3: Create and attach straps
 
--   If needed, face your straps.
--   Fold the straps in half lengthwise with _good sides matching_.
--   Sew the raw edges together making sure to leave a gap for turning.
--   Turn inside out.
--   _Slipstich_ the opening closed.
--   Alternatively _Edgestitch_ all the edges.
--   Attach one strap to the front panel and one strap to the back panel by sewing a rectangle and a cross.
+- If needed, face your straps.
+- Fold the straps in half lengthwise with _good sides matching_.
+- Sew the raw edges together making sure to leave a gap for turning.
+- Turn inside out.
+- _Slipstich_ the opening closed.
+- Alternatively _Edgestitch_ all the edges.
+- Attach one strap to the front panel and one strap to the back panel by sewing a rectangle and a cross.
 
 <Warning>
 
@@ -28,20 +28,20 @@ The placement of the straps are not on the pattern and need to be determined. Yo
 
 If using bag strap webbing instead of fabric made straps do the following,
 
--   Cut the webbing to the the length of the straps with seam allowance.
--   Press under the short edge seam allowance.
--   Attach the webbing the same way as the fabric straps.
+- Cut the webbing to the the length of the straps with seam allowance.
+- Press under the short edge seam allowance.
+- Attach the webbing the same way as the fabric straps.
 
 </Note>
 
 ### Step 4: The zipper
 
--   Insert the zipper into the zipper panel making sure that the zipper pull is on the _good side_.
+- Insert the zipper into the zipper panel making sure that the zipper pull is on the _good side_.
 
 ### (Optional) Step 5: Construct tabs.
 
--   Construct tabs the same as the straps just shorter.
--   _Baste_ the tabs _good sides together_ to the short edges of the zipper panel so the tabs face inward.
+- Construct tabs the same as the straps just shorter.
+- _Baste_ the tabs _good sides together_ to the short edges of the zipper panel so the tabs face inward.
 
 <Tip>
 
@@ -51,22 +51,22 @@ We recommend the tabs to be about a quarter length of the straps.
 
 ### Step 6: Attach the zipper panel
 
--   With _good sides together_ sew the zipper panel to the front and pack panels. We will now refer to this as **the tube**.
+- With _good sides together_ sew the zipper panel to the front and pack panels. We will now refer to this as **the tube**.
 
 ### Step 7: Prep the side panels
 
--   Press under the top seam allowance of the side panel reinforcement parts.
--   Place the side panel reinforcement parts on top of the side panels matching the raw edges.
--   _Edgestitch_ the folded edge of the reinforcement parts to the side panels.
--   _Baste_ the raw edges together.
+- Press under the top seam allowance of the side panel reinforcement parts.
+- Place the side panel reinforcement parts on top of the side panels matching the raw edges.
+- _Edgestitch_ the folded edge of the reinforcement parts to the side panels.
+- _Baste_ the raw edges together.
 
 ### Step 8: Attach the side panels to the tube
 
--   With _good sides together_ sew the side panels to the tube matching notches to the bottom and zipper panel seams.
--   If binding the edges rather than turning, sew with _wrong sides together_ instead.
--   If not binding the edges leave a gap in one of the sides for turning.
--   Turn inside out and _Slipstich_ the opening closed.
--   If sewn _wrong sides together_ bind the raw edges of the side panels.
+- With _good sides together_ sew the side panels to the tube matching notches to the bottom and zipper panel seams.
+- If binding the edges rather than turning, sew with _wrong sides together_ instead.
+- If not binding the edges leave a gap in one of the sides for turning.
+- Turn inside out and _Slipstich_ the opening closed.
+- If sewn _wrong sides together_ bind the raw edges of the side panels.
 
 <Note>
 
@@ -76,12 +76,12 @@ It is recommended to leave the gap for turning on the side rather than the top o
 
 ### Step 9: Lining
 
--   With _good sides together_ sew the front and back lining panels to the bottom lining panel.
--   With _good sides together_ attach the lining side panels.
--   Press under the top seam allowances.
--   Alernatively you can bind the top edges.
--   Place the lining inside the bag _wrong sides facing_ eachother.
--   _Slipstitch_ or _Whipstitch_ the lining to the zipper panel.
+- With _good sides together_ sew the front and back lining panels to the bottom lining panel.
+- With _good sides together_ attach the lining side panels.
+- Press under the top seam allowances.
+- Alernatively you can bind the top edges.
+- Place the lining inside the bag _wrong sides facing_ eachother.
+- _Slipstitch_ or _Whipstitch_ the lining to the zipper panel.
 
 ### Step 10: Enjoy!
 

--- a/markdown/org/docs/patterns/hortensia/needs/en.md
+++ b/markdown/org/docs/patterns/hortensia/needs/en.md
@@ -1,12 +1,12 @@
 To make Hortensia, you will need the following:
 
--   Basic sewing supplies
--   About 0.5 - 2 metres (0.6 - 2.2 yards) of a suitable fabric ([see Hortensia Fabric options](/docs/patterns/hortensia/fabric/))
--   About 0.5 - 2 metres (0.6 - 2.2 yards) of lining fabric ([see Hortensia Fabric options](/docs/patterns/hortensia/fabric/))
--   A zipper shorter in length than the zipper panel and matching the [coil width](/docs/patterns/hortensia/options/zippersize/) selected
--   (Optional) About 1 - 2 metres (1.1 - 2.2 yards) of bias biniding if you want to bind the side panel edges on the outside.
--   (Optional) Bag strap webbing double the length of the strap part with seam allowance and similar width if you don't wish to make your own straps
--   (Optional) Interfacing if needed to strengthen fabric and/or for the strap
+- Basic sewing supplies
+- About 0.5 - 2 metres (0.6 - 2.2 yards) of a suitable fabric ([see Hortensia Fabric options](/docs/patterns/hortensia/fabric/))
+- About 0.5 - 2 metres (0.6 - 2.2 yards) of lining fabric ([see Hortensia Fabric options](/docs/patterns/hortensia/fabric/))
+- A zipper shorter in length than the zipper panel and matching the [coil width](/docs/patterns/hortensia/options/zippersize/) selected
+- (Optional) About 1 - 2 metres (1.1 - 2.2 yards) of bias biniding if you want to bind the side panel edges on the outside.
+- (Optional) Bag strap webbing double the length of the strap part with seam allowance and similar width if you don't wish to make your own straps
+- (Optional) Interfacing if needed to strengthen fabric and/or for the strap
 
 <Note>
 

--- a/markdown/org/docs/patterns/hortensia/options/size/en.md
+++ b/markdown/org/docs/patterns/hortensia/options/size/en.md
@@ -2,8 +2,8 @@ Controls the overall size of the handbag.
 
 Rather than using measurements, Hortensia's size is determined by scaling fixed values.
 
--   20% : Will scale these values by 0.2
--   200% : Will scale these values by 2
+- 20% : Will scale these values by 0.2
+- 200% : Will scale these values by 2
 
 The two fixed values that are used the most are Width: 23cm and Height: 33cm.
 

--- a/markdown/org/docs/patterns/huey/cutting/en.md
+++ b/markdown/org/docs/patterns/huey/cutting/en.md
@@ -1,12 +1,12 @@
 **Main fabric**
 
--   Cut **2 front** parts
--   Cut **1 back** part on the fold
--   Cut **2 sleeves** parts
--   Cut **2 pocket** parts
--   Cut **4 Hood** parts
+- Cut **2 front** parts
+- Cut **1 back** part on the fold
+- Cut **2 sleeves** parts
+- Cut **2 pocket** parts
+- Cut **4 Hood** parts
 
 **Ribbing**
 
--   Cut **2 cuff** parts
--   Cut **1 waistband**
+- Cut **2 cuff** parts
+- Cut **1 waistband**

--- a/markdown/org/docs/patterns/huey/instructions/en.md
+++ b/markdown/org/docs/patterns/huey/instructions/en.md
@@ -1,22 +1,22 @@
 <Note>
 
-This pattern can be sewn with or with out a overlocker/serger. If not using a overlocker or serger you will have to *Finish* the seams.
+This pattern can be sewn with or with out a overlocker/serger. If not using a overlocker or serger you will have to _Finish_ the seams.
 
 </Note>
 
 ### Step 1: Attaching the pockets
 
 -   Press under seam allowance of top, curved and slanted edges.
--   *Topstitch* or *Edgestitch* the curved seam allowance in place. This will form the openings of the pockets.
+-   _Topstitch_ or _Edgestitch_ the curved seam allowance in place. This will form the openings of the pockets.
 -   Pin the pockets to the fronts using the guidelines and match raw edges.
 -   Baste the raw edges of the pockets and fronts together.
--   *Topstitch* or *Edgestitch* the top and slanted edges of the pockets to the fronts leaving the curved edges open.
+-   _Topstitch_ or _Edgestitch_ the top and slanted edges of the pockets to the fronts leaving the curved edges open.
 
 ### Step 2: Making the Body
 
--   With *good sides together*, sew the Fronts to the backs at the shoulder seams.
--   With *good sides together*, sew the sleeves to the front and back matching notches.
--   With *good sides together*, sew up the sleeves and side seams.
+-   With _good sides together_, sew the Fronts to the backs at the shoulder seams.
+-   With _good sides together_, sew the sleeves to the front and back matching notches.
+-   With _good sides together_, sew up the sleeves and side seams.
 
 ### Step 3: Making drawstring holes (Optional)
 
@@ -44,17 +44,17 @@ The drawstrings will be threaded after the hoodie is constructed.
 
 ### Step 4: Prepping the hood
 
--   With *good sides together*, matching sets, sew the hood pieces together along the outer curve edge.
--   With *good sides together*, matching seams, sew the inner hood to the outer hood along the inner curve edge.
+-   With _good sides together_, matching sets, sew the hood pieces together along the outer curve edge.
+-   With _good sides together_, matching seams, sew the inner hood to the outer hood along the inner curve edge.
 -   Turn good sides out.
 -   Baste the front and bottom raw edges together.
 -   Create a casing for the drawstring by stitching about 2.5cm (1 inch) away from the inner edge on the side with the drawstring holes.
--   (Optionaly) If not using a drawstring, *Topstitch* or *Edgestitch* the inner curve.
+-   (Optionaly) If not using a drawstring, _Topstitch_ or _Edgestitch_ the inner curve.
 
 <Note>
 
 When creating the casing or topstitching, make sure the inner curve seam is slightly inside of the hood to stop it from peaking out in the future.
-Alternatively if not using a drawstring you can *Understitch* the inner curve seam.
+Alternatively if not using a drawstring you can _Understitch_ the inner curve seam.
 
 </Note>
 
@@ -68,43 +68,43 @@ A neckband can be useful to stablise and cover the neck seams but it is optional
 
 ### Step 6: Attaching the hood
 
--   Pin the hood to the neck with outer hood matching *good side* of neck.
--   If using, pin the neckband *good side* to inner hood matching raw edges.
+-   Pin the hood to the neck with outer hood matching _good side_ of neck.
+-   If using, pin the neckband _good side_ to inner hood matching raw edges.
 -   Sew the neckband seam.
--   *Finish* seam if not using neckband then proceed to Step 7.
+-   _Finish_ seam if not using neckband then proceed to Step 7.
 -   Press neckband down.
--   On outside *Topstitch* neckband in place.
+-   On outside _Topstitch_ neckband in place.
 -   On inside, trim neckband down to topstitching.
 
 ### Step 7: Attaching the waistband
 
 -   Fold the waistband in half lengthwise matching wrong sides. Press.
--   With *good sides* together sew the waistband to the bottom of the back and front.
+-   With _good sides_ together sew the waistband to the bottom of the back and front.
 -   Press the seam allowance up.
--   *Topstitch* or *Edgestitch* waistband seam allowance to the body.
+-   _Topstitch_ or _Edgestitch_ waistband seam allowance to the body.
 
 ### Step 8: Attching the cuffs
 
--   With *good sides together* sew the short egdes of the cuffs together to create two bands.
+-   With _good sides together_ sew the short egdes of the cuffs together to create two bands.
 -   Press open the seam allowances.
--   (Optional) *Edgestitch* the seam allowances down.
+-   (Optional) _Edgestitch_ the seam allowances down.
 -   Fold the cuffs in half lengthwise matching wrong sides. Press.
--   Matching seams and raw edges, pin the cuffs to the sleeves *good sides together*.
+-   Matching seams and raw edges, pin the cuffs to the sleeves _good sides together_.
 -   Sew the cuffs to the sleeves.
 -   Press the seam allowances up.
--   *Topstitch* or *Edgestitch* cuffs seam allowances to the sleeves.
+-   _Topstitch_ or _Edgestitch_ cuffs seam allowances to the sleeves.
 
 ### Step 9: The zipper
 
 -   If need be, face the front edges of the hoodie.
 -   Unzip the zipper part way.
--   Fold the top of the zipper tape down to the *good side* of the zipper tape. Trim if need be.
--   Pin the zipper along one of the front edges of the hood, front and waistband. Making sure the zipper pull is faced the *good sides* of the hoodie and the bottoms are lined up. The zipper teeth should just be slightly over the seam line with the edge of the tape either matching or being slightly over from the hoodie edge.
+-   Fold the top of the zipper tape down to the _good side_ of the zipper tape. Trim if need be.
+-   Pin the zipper along one of the front edges of the hood, front and waistband. Making sure the zipper pull is faced the _good sides_ of the hoodie and the bottoms are lined up. The zipper teeth should just be slightly over the seam line with the edge of the tape either matching or being slightly over from the hoodie edge.
 -   Using a zipper foot stitch the zipper to the hoodie using you seam allownace width. When you reach the zipper pull, stop, put your needle down, lift the presser foot, pull the zipper pull past the presser foot, lower the presser foot. Then you can continue sewing the seam.
 -   Unzip the zipper.
 -   Pin and sew the unattached zipper tape to the other side of the hoodie the same way.
 -   Press the seams to the inside being careful not to melt the zipper teeth with your iron.
--   *Topstitch* the zipper tapes in place. You may need to use a zipper foot.
+-   _Topstitch_ the zipper tapes in place. You may need to use a zipper foot.
 
 <Tip>
 

--- a/markdown/org/docs/patterns/huey/instructions/en.md
+++ b/markdown/org/docs/patterns/huey/instructions/en.md
@@ -6,29 +6,29 @@ This pattern can be sewn with or with out a overlocker/serger. If not using a ov
 
 ### Step 1: Attaching the pockets
 
--   Press under seam allowance of top, curved and slanted edges.
--   _Topstitch_ or _Edgestitch_ the curved seam allowance in place. This will form the openings of the pockets.
--   Pin the pockets to the fronts using the guidelines and match raw edges.
--   Baste the raw edges of the pockets and fronts together.
--   _Topstitch_ or _Edgestitch_ the top and slanted edges of the pockets to the fronts leaving the curved edges open.
+- Press under seam allowance of top, curved and slanted edges.
+- _Topstitch_ or _Edgestitch_ the curved seam allowance in place. This will form the openings of the pockets.
+- Pin the pockets to the fronts using the guidelines and match raw edges.
+- Baste the raw edges of the pockets and fronts together.
+- _Topstitch_ or _Edgestitch_ the top and slanted edges of the pockets to the fronts leaving the curved edges open.
 
 ### Step 2: Making the Body
 
--   With _good sides together_, sew the Fronts to the backs at the shoulder seams.
--   With _good sides together_, sew the sleeves to the front and back matching notches.
--   With _good sides together_, sew up the sleeves and side seams.
+- With _good sides together_, sew the Fronts to the backs at the shoulder seams.
+- With _good sides together_, sew the sleeves to the front and back matching notches.
+- With _good sides together_, sew up the sleeves and side seams.
 
 ### Step 3: Making drawstring holes (Optional)
 
 If you don't wish to add a drawstring you can skip to Step 4.
 
--   Take one matching set of the Hood pieces, that you intend to feature on the outside of the finished hoodie.
--   Mark the place for a hole on each hood piece, along the inner curve.
-    -   The hole should be about 1.5-2cm from the edge of the fabric. This is to keep your seam allowance out of the way.
-    -   The hole should be located slightly up from the bottom of the inner curve. This is to keep it away from the front seams.
--   On the wrong side of the fabric, face where you are making the hole to stabilise the fabric.
--   Make a buttonhole at your mark either by hand or by your machine's method.
--   Alternatively construct or use eyelets at the mark.
+- Take one matching set of the Hood pieces, that you intend to feature on the outside of the finished hoodie.
+- Mark the place for a hole on each hood piece, along the inner curve.
+  - The hole should be about 1.5-2cm from the edge of the fabric. This is to keep your seam allowance out of the way.
+  - The hole should be located slightly up from the bottom of the inner curve. This is to keep it away from the front seams.
+- On the wrong side of the fabric, face where you are making the hole to stabilise the fabric.
+- Make a buttonhole at your mark either by hand or by your machine's method.
+- Alternatively construct or use eyelets at the mark.
 
 <Tip>
 
@@ -44,12 +44,12 @@ The drawstrings will be threaded after the hoodie is constructed.
 
 ### Step 4: Prepping the hood
 
--   With _good sides together_, matching sets, sew the hood pieces together along the outer curve edge.
--   With _good sides together_, matching seams, sew the inner hood to the outer hood along the inner curve edge.
--   Turn good sides out.
--   Baste the front and bottom raw edges together.
--   Create a casing for the drawstring by stitching about 2.5cm (1 inch) away from the inner edge on the side with the drawstring holes.
--   (Optionaly) If not using a drawstring, _Topstitch_ or _Edgestitch_ the inner curve.
+- With _good sides together_, matching sets, sew the hood pieces together along the outer curve edge.
+- With _good sides together_, matching seams, sew the inner hood to the outer hood along the inner curve edge.
+- Turn good sides out.
+- Baste the front and bottom raw edges together.
+- Create a casing for the drawstring by stitching about 2.5cm (1 inch) away from the inner edge on the side with the drawstring holes.
+- (Optionaly) If not using a drawstring, _Topstitch_ or _Edgestitch_ the inner curve.
 
 <Note>
 
@@ -62,49 +62,49 @@ Alternatively if not using a drawstring you can _Understitch_ the inner curve se
 
 A neckband can be useful to stablise and cover the neck seams but it is optional if you wish to skip it.
 
--   Cut a cross-wise strip of fabric out of your main fabric:
-    -   Your neck opening + double your front seam allowance long
-    -   Triple your neck seam allowance wide.
+- Cut a cross-wise strip of fabric out of your main fabric:
+  - Your neck opening + double your front seam allowance long
+  - Triple your neck seam allowance wide.
 
 ### Step 6: Attaching the hood
 
--   Pin the hood to the neck with outer hood matching _good side_ of neck.
--   If using, pin the neckband _good side_ to inner hood matching raw edges.
--   Sew the neckband seam.
--   _Finish_ seam if not using neckband then proceed to Step 7.
--   Press neckband down.
--   On outside _Topstitch_ neckband in place.
--   On inside, trim neckband down to topstitching.
+- Pin the hood to the neck with outer hood matching _good side_ of neck.
+- If using, pin the neckband _good side_ to inner hood matching raw edges.
+- Sew the neckband seam.
+- _Finish_ seam if not using neckband then proceed to Step 7.
+- Press neckband down.
+- On outside _Topstitch_ neckband in place.
+- On inside, trim neckband down to topstitching.
 
 ### Step 7: Attaching the waistband
 
--   Fold the waistband in half lengthwise matching wrong sides. Press.
--   With _good sides_ together sew the waistband to the bottom of the back and front.
--   Press the seam allowance up.
--   _Topstitch_ or _Edgestitch_ waistband seam allowance to the body.
+- Fold the waistband in half lengthwise matching wrong sides. Press.
+- With _good sides_ together sew the waistband to the bottom of the back and front.
+- Press the seam allowance up.
+- _Topstitch_ or _Edgestitch_ waistband seam allowance to the body.
 
 ### Step 8: Attching the cuffs
 
--   With _good sides together_ sew the short egdes of the cuffs together to create two bands.
--   Press open the seam allowances.
--   (Optional) _Edgestitch_ the seam allowances down.
--   Fold the cuffs in half lengthwise matching wrong sides. Press.
--   Matching seams and raw edges, pin the cuffs to the sleeves _good sides together_.
--   Sew the cuffs to the sleeves.
--   Press the seam allowances up.
--   _Topstitch_ or _Edgestitch_ cuffs seam allowances to the sleeves.
+- With _good sides together_ sew the short egdes of the cuffs together to create two bands.
+- Press open the seam allowances.
+- (Optional) _Edgestitch_ the seam allowances down.
+- Fold the cuffs in half lengthwise matching wrong sides. Press.
+- Matching seams and raw edges, pin the cuffs to the sleeves _good sides together_.
+- Sew the cuffs to the sleeves.
+- Press the seam allowances up.
+- _Topstitch_ or _Edgestitch_ cuffs seam allowances to the sleeves.
 
 ### Step 9: The zipper
 
--   If need be, face the front edges of the hoodie.
--   Unzip the zipper part way.
--   Fold the top of the zipper tape down to the _good side_ of the zipper tape. Trim if need be.
--   Pin the zipper along one of the front edges of the hood, front and waistband. Making sure the zipper pull is faced the _good sides_ of the hoodie and the bottoms are lined up. The zipper teeth should just be slightly over the seam line with the edge of the tape either matching or being slightly over from the hoodie edge.
--   Using a zipper foot stitch the zipper to the hoodie using you seam allownace width. When you reach the zipper pull, stop, put your needle down, lift the presser foot, pull the zipper pull past the presser foot, lower the presser foot. Then you can continue sewing the seam.
--   Unzip the zipper.
--   Pin and sew the unattached zipper tape to the other side of the hoodie the same way.
--   Press the seams to the inside being careful not to melt the zipper teeth with your iron.
--   _Topstitch_ the zipper tapes in place. You may need to use a zipper foot.
+- If need be, face the front edges of the hoodie.
+- Unzip the zipper part way.
+- Fold the top of the zipper tape down to the _good side_ of the zipper tape. Trim if need be.
+- Pin the zipper along one of the front edges of the hood, front and waistband. Making sure the zipper pull is faced the _good sides_ of the hoodie and the bottoms are lined up. The zipper teeth should just be slightly over the seam line with the edge of the tape either matching or being slightly over from the hoodie edge.
+- Using a zipper foot stitch the zipper to the hoodie using you seam allownace width. When you reach the zipper pull, stop, put your needle down, lift the presser foot, pull the zipper pull past the presser foot, lower the presser foot. Then you can continue sewing the seam.
+- Unzip the zipper.
+- Pin and sew the unattached zipper tape to the other side of the hoodie the same way.
+- Press the seams to the inside being careful not to melt the zipper teeth with your iron.
+- _Topstitch_ the zipper tapes in place. You may need to use a zipper foot.
 
 <Tip>
 
@@ -120,8 +120,8 @@ You only need to face your fabric if it is very stretchy or needs a bit more sta
 
 ### Step 10: Thread the drawstring
 
--   Thread the drawing string through the drawstring holes.
--   If needed secure the ends of the drawstring e.g. with something like aglets.
+- Thread the drawing string through the drawstring holes.
+- If needed secure the ends of the drawstring e.g. with something like aglets.
 
 <Tip>
 
@@ -131,7 +131,7 @@ Use a safety pin to help thread the drawstring.
 
 ### Step 11: Enjoy!
 
--   That's it! Your all done! Now go feel warm and comfy in your new hoodie!
+- That's it! Your all done! Now go feel warm and comfy in your new hoodie!
 
 <Note>
 

--- a/markdown/org/docs/patterns/huey/needs/en.md
+++ b/markdown/org/docs/patterns/huey/needs/en.md
@@ -1,7 +1,7 @@
 To make Huey, you will need the following:
 
--   Basic sewing supplies
--   About 2 metres (2.2 yards) of a suitable fabric ([see Fabric options](/docs/patterns/huey/fabric))
--   Ribbing fabric for the hem and cuffs.
--   1 open ended zipper the length of front seam including hood and waistband.
--   (Optional) Cording or suitable alternate for hood strings.
+- Basic sewing supplies
+- About 2 metres (2.2 yards) of a suitable fabric ([see Fabric options](/docs/patterns/huey/fabric))
+- Ribbing fabric for the hem and cuffs.
+- 1 open ended zipper the length of front seam including hood and waistband.
+- (Optional) Cording or suitable alternate for hood strings.

--- a/markdown/org/docs/patterns/huey/options/s3armhole/en.md
+++ b/markdown/org/docs/patterns/huey/options/s3armhole/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the armhole side.
 
--   Increase this option to shift the shoulder seam forward on the armhole side
--   Decrease this option to shift the shoulder seam backward on the armhole side
+- Increase this option to shift the shoulder seam forward on the armhole side
+- Decrease this option to shift the shoulder seam backward on the armhole side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/huey/options/s3collar/en.md
+++ b/markdown/org/docs/patterns/huey/options/s3collar/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the collar side.
 
--   Increase this option to shift the shoulder seam forward on the collar side
--   Decrease this option to shift the shoulder seam backward on the collar side
+- Increase this option to shift the shoulder seam forward on the collar side
+- Decrease this option to shift the shoulder seam backward on the collar side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/hugo/cutting/en.md
+++ b/markdown/org/docs/patterns/hugo/cutting/en.md
@@ -1,22 +1,22 @@
--   **Main fabric**
-    -   Cut **1 front** on the fold
-    -   Cut **1 back** on the fold
-    -   Cut **2 sleeves**, good sides together
-    -   Cut **1 pocket** on the fold
-    -   Cut **2 pocket facing(s)**, good sides together
-    -   Cut **4 Hood side(s)**, 2x2 good sides together
-    -   Cut **2 hood center(s)**, good sides together
-    -   Cut **1 neck binding**
--   **Ribbing**
-    -   Cut **2 cuff(s)**
-    -   Cut **1 waistband**
+- **Main fabric**
+  - Cut **1 front** on the fold
+  - Cut **1 back** on the fold
+  - Cut **2 sleeves**, good sides together
+  - Cut **1 pocket** on the fold
+  - Cut **2 pocket facing(s)**, good sides together
+  - Cut **4 Hood side(s)**, 2x2 good sides together
+  - Cut **2 hood center(s)**, good sides together
+  - Cut **1 neck binding**
+- **Ribbing**
+  - Cut **2 cuff(s)**
+  - Cut **1 waistband**
 
 <Warning>
 
 ###### Caveats
 
--   **sleeve**: There's a single notch at the front, and a double notch at the back. These notches match on the front and back parts respectively.
--   **pocket facing** and **hood**: Watch out for the grainlines on these parts
+- **sleeve**: There's a single notch at the front, and a double notch at the back. These notches match on the front and back parts respectively.
+- **pocket facing** and **hood**: Watch out for the grainlines on these parts
 
 Because Hugo's raglan sleeve also covers a portion of the back and front,
 the sleeve is the dominant feature of your draft.

--- a/markdown/org/docs/patterns/hugo/instructions/en.md
+++ b/markdown/org/docs/patterns/hugo/instructions/en.md
@@ -21,93 +21,93 @@ This 6-episode series shows you how to make your hoodie start to finish:
 
 ### Step 1: Prepare the Pocket
 
--   Place the Pocket Facing pieces together with the edges of the Pocket piece, good sides together.
--   Stitch the facing pieces to the pocket with a 1cm seam allowance.  Stitch both the long edge, and the shorter edge at the bottom of the pocket.
--   Carefully trim the seam allowance on the facing pieces.
--   Flip and turn the facing pieces good sides out.  Then hand-roll and press the seams.
--   Topstitch or edge-stitch 0.5 cm along both upper and lower edges on each side of the pocket, to anchor the facing and the seam allowance.
--   Topstitch another line 0.5 cm from the inside upper edge of the facing on each side of the pocket.  This topstitch line will end at the lower edge stitch line.
--   Trim away the excess facing on the inside of the pocket.
--   Press the edges.
+- Place the Pocket Facing pieces together with the edges of the Pocket piece, good sides together.
+- Stitch the facing pieces to the pocket with a 1cm seam allowance.  Stitch both the long edge, and the shorter edge at the bottom of the pocket.
+- Carefully trim the seam allowance on the facing pieces.
+- Flip and turn the facing pieces good sides out.  Then hand-roll and press the seams.
+- Topstitch or edge-stitch 0.5 cm along both upper and lower edges on each side of the pocket, to anchor the facing and the seam allowance.
+- Topstitch another line 0.5 cm from the inside upper edge of the facing on each side of the pocket.  This topstitch line will end at the lower edge stitch line.
+- Trim away the excess facing on the inside of the pocket.
+- Press the edges.
 
 ### Step 2: Attach the Pocket
 
--   Match the Pocket to the front, good sides together.
--   The upper pocket seam line is marked by notches on the pattern.  The pocket bottom edge should point towards the neckline.  Align the pocket edges horizontally with the notches on the pattern. Overlap the top of the pocket over the seam line by a little less than 1 cm seam allowance.
--   Stitch the top seam of the Pocket to the Shirt Front.
--   Flip the pocket over the seam line so the bottom now lines up with the edge at the waist.
--   Using a long basting stitch (4mm or longer), baste the pocket into place at the waist, with a ½ cm seam allowance.  This is optional, but keeps the pocket in place while you work on the rest of the shirt.
+- Match the Pocket to the front, good sides together.
+- The upper pocket seam line is marked by notches on the pattern.  The pocket bottom edge should point towards the neckline.  Align the pocket edges horizontally with the notches on the pattern. Overlap the top of the pocket over the seam line by a little less than 1 cm seam allowance.
+- Stitch the top seam of the Pocket to the Shirt Front.
+- Flip the pocket over the seam line so the bottom now lines up with the edge at the waist.
+- Using a long basting stitch (4mm or longer), baste the pocket into place at the waist, with a ½ cm seam allowance.  This is optional, but keeps the pocket in place while you work on the rest of the shirt.
 
 ### Step 3: Attach the Sleeves
 
--   The side of the sleeve with the pointy edge at top is the back of the sleeve piece.  It is also marked by a double notch on the pattern.
+- The side of the sleeve with the pointy edge at top is the back of the sleeve piece.  It is also marked by a double notch on the pattern.
 
--   Match good sides of the sleeve seam to good sides of the front, matching the single notch on front to single notch on the sleeve piece. Stitch the seam.  Do this for both sleeve pieces.
+- Match good sides of the sleeve seam to good sides of the front, matching the single notch on front to single notch on the sleeve piece. Stitch the seam.  Do this for both sleeve pieces.
 
--   To finish the seam, you can use one of these methods:
+- To finish the seam, you can use one of these methods:
 
-    -   Use a serger to sew and finish the seam in one step.  This is fast and convenient, but produces a less-refined look.
-    -   If you do not have a serger, or would like a more refined look, sew a seam with a straight stitch on your conventional machine. Press the seam allowances apart on the wrong side.  Then, edgestitch along both sides of the seam from the right side.  Finally, trim the excess seam allowance.  This produces a refined look, but takes longer.
-    -   Another serger-free option is to sew the seam with a straight stitch. Then stitch together the seam allowances with an additional line of zig-zag alongside the straight stitch.  Finally, trim the excess seam allowance.  This simulates what a serger would do, and is quicker than option (2).
+  - Use a serger to sew and finish the seam in one step.  This is fast and convenient, but produces a less-refined look.
+  - If you do not have a serger, or would like a more refined look, sew a seam with a straight stitch on your conventional machine. Press the seam allowances apart on the wrong side.  Then, edgestitch along both sides of the seam from the right side.  Finally, trim the excess seam allowance.  This produces a refined look, but takes longer.
+  - Another serger-free option is to sew the seam with a straight stitch. Then stitch together the seam allowances with an additional line of zig-zag alongside the straight stitch.  Finally, trim the excess seam allowance.  This simulates what a serger would do, and is quicker than option (2).
 
--   Match the good sides of the sleeve to the good sides of the back, matching the double notch on back to the double notch on the sleeve seam.  Stitch the seam, then finish the seams as you did for the front.
+- Match the good sides of the sleeve to the good sides of the back, matching the double notch on back to the double notch on the sleeve seam.  Stitch the seam, then finish the seams as you did for the front.
 
 ### Step 4: Close the Sides
 
--   Match the good sides together along sides and sleeves.
--   Stitch the side seam and the sleeves together in one long seam, starting at the waist and going all the way through to the end of the sleeve.  You can stop at the underarm point to change colors for the sleeve, if your design calls for it.
--   Finish the seam allowances as you did in step 2.  If you finish the sleeves with the edgestitch method, you will need to go slow for finishing the sleeve seam, as you will be .sewing in the tunnel..
+- Match the good sides together along sides and sleeves.
+- Stitch the side seam and the sleeves together in one long seam, starting at the waist and going all the way through to the end of the sleeve.  You can stop at the underarm point to change colors for the sleeve, if your design calls for it.
+- Finish the seam allowances as you did in step 2.  If you finish the sleeves with the edgestitch method, you will need to go slow for finishing the sleeve seam, as you will be .sewing in the tunnel..
 
 ### Step 5: Add a Drawstring to the Hood (Optional)
 
--   Take one matching set of the Hood Side pieces, that you intend to feature on the outside of the finished hoodie.
--   Mark the place for a hole on each side hood piece, along the rim.
--   The hole should be located about 1.5-2cm from the edge of the fabric.  This is to allow for the seam allowance, as well as for the hood
--   The hole should be located above the notch on the hood rim.  The notch shows where the sides of the hood overlap at center front , so the cord should exit above that point.
--   You can consider using the buttonhole feature of your sewing machine, if it has one, to sew a buttonhole at this point.
--   Cut open a hole at the points you marked.
--   After the hood is prepared, you can run a cord around the front edge of the hood.  Sneaker shoelaces work well for this.
+- Take one matching set of the Hood Side pieces, that you intend to feature on the outside of the finished hoodie.
+- Mark the place for a hole on each side hood piece, along the rim.
+- The hole should be located about 1.5-2cm from the edge of the fabric.  This is to allow for the seam allowance, as well as for the hood
+- The hole should be located above the notch on the hood rim.  The notch shows where the sides of the hood overlap at center front , so the cord should exit above that point.
+- You can consider using the buttonhole feature of your sewing machine, if it has one, to sew a buttonhole at this point.
+- Cut open a hole at the points you marked.
+- After the hood is prepared, you can run a cord around the front edge of the hood.  Sneaker shoelaces work well for this.
 
 ### Step 6: Prepare Inside and Outside Hood
 
 > Follow this set of steps twice, once for the outer hood and again for the inside hood.
 
--   Run a Center Panel piece around one outer edge of the Hood Side, good sides together, and pin in place.  Stitch.
--   Pin the Center Panel piece around the remaining outer edge of the hood, good sides together. Stitch.
--   Press the seam allowances, and finish them as in Step 2.  Trim the seam allowances.
+- Run a Center Panel piece around one outer edge of the Hood Side, good sides together, and pin in place.  Stitch.
+- Pin the Center Panel piece around the remaining outer edge of the hood, good sides together. Stitch.
+- Press the seam allowances, and finish them as in Step 2.  Trim the seam allowances.
 
 ### Step 7: Join Inside and Outside Hood
 
--   With both hoods inside out, put them on top of each other, good sides together.
--   Align the center panel seams and pin.
--   Stitch along the outer edge of the hood with a 1cm seam allowance.  Do not trim the seam allowance.
--   Flip the hood pieces right side out, then press the outer edge flat.
--   Topstitch along the edge of the hood, about 1.5-2 cm from the edge.  Ensure that you go beyond the seam allowance, and that it is not caught in this line of stitching. This creates a decorative rim.  The enclosed seam allowance helps make the rim a bit poofy.
--   To close the hood, serge together the bottom layers along the neckline.  If you do not have a serger, use a zig-zag stitch.
--   (Optional) If you added holes for a drawstring, you can thread the drawstring now.
+- With both hoods inside out, put them on top of each other, good sides together.
+- Align the center panel seams and pin.
+- Stitch along the outer edge of the hood with a 1cm seam allowance.  Do not trim the seam allowance.
+- Flip the hood pieces right side out, then press the outer edge flat.
+- Topstitch along the edge of the hood, about 1.5-2 cm from the edge.  Ensure that you go beyond the seam allowance, and that it is not caught in this line of stitching. This creates a decorative rim.  The enclosed seam allowance helps make the rim a bit poofy.
+- To close the hood, serge together the bottom layers along the neckline.  If you do not have a serger, use a zig-zag stitch.
+- (Optional) If you added holes for a drawstring, you can thread the drawstring now.
 
 ### Step 8: Preparing a Neckband and Attaching the Hood
 
--   Cut a cross-wise strip of fabric out of your main fabric, your neck opening + 2cm (3/4 inch) long and triple your neck seam allowance wide.
--   Place good sides together on the neck binding piece, then sew a 1cm seam allowance along the short side to make the binding into a circular band.
--   Starting from the back, match the outside of the hood to the right side of the neckline. Align the hood panel to the back of the neckline.
--   Working around to the front, pin the hood to the neckline.
--   Match the good side of the neck binding to the outer neckline (this will be the inside of the hood). Pin the binding to the hood.
--   Serge or zig-zag all layers together with 1cm seam allowance.  Check around the neckline to make sure all layers were caught by the stitching.
--   Reinforce the points where the neckline intersects with the sleeve seams.  Use a straight stitch on the sewing machine to stabilize these seams.
--   Fold the binding over the raw edge of the neckline, and pin.
--   From the outside, topstitch along and approx 1cm away from the neck edge to catch and secure the binding.  You should be able to use a straight stitch here as long as the neck fits somewhat loosely when you try it on.  If the neck fits snug, then use a zigzag stitch.
--   Trim excess binding from the inside.
+- Cut a cross-wise strip of fabric out of your main fabric, your neck opening + 2cm (3/4 inch) long and triple your neck seam allowance wide.
+- Place good sides together on the neck binding piece, then sew a 1cm seam allowance along the short side to make the binding into a circular band.
+- Starting from the back, match the outside of the hood to the right side of the neckline. Align the hood panel to the back of the neckline.
+- Working around to the front, pin the hood to the neckline.
+- Match the good side of the neck binding to the outer neckline (this will be the inside of the hood). Pin the binding to the hood.
+- Serge or zig-zag all layers together with 1cm seam allowance.  Check around the neckline to make sure all layers were caught by the stitching.
+- Reinforce the points where the neckline intersects with the sleeve seams.  Use a straight stitch on the sewing machine to stabilize these seams.
+- Fold the binding over the raw edge of the neckline, and pin.
+- From the outside, topstitch along and approx 1cm away from the neck edge to catch and secure the binding.  You should be able to use a straight stitch here as long as the neck fits somewhat loosely when you try it on.  If the neck fits snug, then use a zigzag stitch.
+- Trim excess binding from the inside.
 
 ### Step 9: Attach the Cuffs and Waistband
 
--   If the ribbing is light or thin, you can cut the cuff and waistband pieces twice as high, then double-fold them.
--   Place good sides together on the cuffs and waistband pieces, then sew a 1cm seam allowance along the short side to make them into circular bands.
--   Fold along the long side to make cuffs and waistband into double-thick tubes. Sew or serge along the open edges to close.
--   Align the seam on the cuff to the seam on the sleeve.  Pin, good sides together.
--   Pin the opposite side.
--   Serge (or zig-zag stitch) the ribbing to the cuff, stretching gently until the ribbing and cuff are the same length.  Remove pins before they enter the serger.
--   Trim the bottom edge of the pocket if it extends past the waistband edge.
--   Ensure the ribbing is gathered as uniformly as possible around the waistband.
--   Serge or zig-zag the waistband, again gently stretching untill the ribbing and waistband are the same length.  Stitch with the hoodie on top so you can see it gets caught in the seam.
--   Topstitch the lower pocket edges to the body of the shirt to anchor the bottom of the pocket.
+- If the ribbing is light or thin, you can cut the cuff and waistband pieces twice as high, then double-fold them.
+- Place good sides together on the cuffs and waistband pieces, then sew a 1cm seam allowance along the short side to make them into circular bands.
+- Fold along the long side to make cuffs and waistband into double-thick tubes. Sew or serge along the open edges to close.
+- Align the seam on the cuff to the seam on the sleeve.  Pin, good sides together.
+- Pin the opposite side.
+- Serge (or zig-zag stitch) the ribbing to the cuff, stretching gently until the ribbing and cuff are the same length.  Remove pins before they enter the serger.
+- Trim the bottom edge of the pocket if it extends past the waistband edge.
+- Ensure the ribbing is gathered as uniformly as possible around the waistband.
+- Serge or zig-zag the waistband, again gently stretching untill the ribbing and waistband are the same length.  Stitch with the hoodie on top so you can see it gets caught in the seam.
+- Topstitch the lower pocket edges to the body of the shirt to anchor the bottom of the pocket.

--- a/markdown/org/docs/patterns/hugo/needs/en.md
+++ b/markdown/org/docs/patterns/hugo/needs/en.md
@@ -1,5 +1,5 @@
 To make Hugo, you will need the following:
 
--   Basic sewing supplies
--   About 2 meters (2.2 yards) of a suitable fabric ([see Fabric options](/docs/patterns/hugo/fabric))
--   Ribbing fabric for the hem and cuffs
+- Basic sewing supplies
+- About 2 meters (2.2 yards) of a suitable fabric ([see Fabric options](/docs/patterns/hugo/fabric))
+- Ribbing fabric for the hem and cuffs

--- a/markdown/org/docs/patterns/hugo/options/ribbingstretch/en.md
+++ b/markdown/org/docs/patterns/hugo/options/ribbingstretch/en.md
@@ -8,7 +8,7 @@ This way, 9cm of ribbing will be stretched to 10cm.
 <Note>
 
 If you're not sure what to pick, best is to take the ribbing you are going to use see how much of it
-you need to stretch out to get to 10 cm with a *good* stretch.
+you need to stretch out to get to 10 cm with a _good_ stretch.
 
 </Note>
 

--- a/markdown/org/docs/patterns/jaeger/cutting/en.md
+++ b/markdown/org/docs/patterns/jaeger/cutting/en.md
@@ -1,29 +1,29 @@
--   **Main fabric**
-    -   Cut **2 fronts** (part 1)
-    -   Cut **2 front facings** (look for the facing/lining boundary on the front part)
-    -   Cut **2 backs** (part 2)
-    -   Cut **2 sides** (part 3)
-    -   Cut **2 topsleeves** (part 4)
-    -   Cut **2 undersleeves** (part 5)
-    -   Cut **1 collar** (part 6)
-    -   Cut **1 collarstand** (part 8)
-    -   Cut **2 pockets** (part 9)
-    -   Cut **1 chest pocket welt** (part 10)
--   **lining fabric**
-    -   Cut **2 fronts** (part 1)
-    -   Cut **2 front linings** (look for the facing/lining boundary on the front part, and don't forget to attach the inner pocket facing extension)
-    -   Cut **2 backs** (part 2)
-    -   Cut **2 sides** (part 3)
-    -   Cut **2 topsleeves** (part 4) Note: Some people like to use different lining for the sleeves
-    -   Cut **2 undersleeves** (part 5) Note: Some people like to use different lining for the sleeves
-    -   Cut **2 chest pocket bags** )(part 11)
-    -   Cut **2 inner pocket welts**
-    -   Cut **2 inner pocket bags** (part 13)
--   **Canvas**
-    -   Cut **2 fronts** on bias (part 1) Note: Don't include seam allowance
-    -   Cut **2 chest pieces** on bias. Look for the indication on the front part. Note: Don't include seam allowance
--   **Undercollar fabric**
-    -   Cut **1 undercollar** (part 7)
+- **Main fabric**
+  - Cut **2 fronts** (part 1)
+  - Cut **2 front facings** (look for the facing/lining boundary on the front part)
+  - Cut **2 backs** (part 2)
+  - Cut **2 sides** (part 3)
+  - Cut **2 topsleeves** (part 4)
+  - Cut **2 undersleeves** (part 5)
+  - Cut **1 collar** (part 6)
+  - Cut **1 collarstand** (part 8)
+  - Cut **2 pockets** (part 9)
+  - Cut **1 chest pocket welt** (part 10)
+- **lining fabric**
+  - Cut **2 fronts** (part 1)
+  - Cut **2 front linings** (look for the facing/lining boundary on the front part, and don't forget to attach the inner pocket facing extension)
+  - Cut **2 backs** (part 2)
+  - Cut **2 sides** (part 3)
+  - Cut **2 topsleeves** (part 4) Note: Some people like to use different lining for the sleeves
+  - Cut **2 undersleeves** (part 5) Note: Some people like to use different lining for the sleeves
+  - Cut **2 chest pocket bags** )(part 11)
+  - Cut **2 inner pocket welts**
+  - Cut **2 inner pocket bags** (part 13)
+- **Canvas**
+  - Cut **2 fronts** on bias (part 1) Note: Don't include seam allowance
+  - Cut **2 chest pieces** on bias. Look for the indication on the front part. Note: Don't include seam allowance
+- **Undercollar fabric**
+  - Cut **1 undercollar** (part 7)
 
 <Note>
 
@@ -40,9 +40,9 @@ When you cut them individually, remember that they need to be mirror images of e
 
 ###### Cutting caveats
 
--   The chest piece is marked on the front.
--   Don't include seam allowance when cutting out canvas, and cut it on bias.
--   The front facing and lining is marked on the front piece. They split the front part in two along the boundary line. You can cut the front part along that line after cutting out the front from the main fabric. The inner pocket extension for the facing is printed separately, and you can tape it back in its place after cutting the patern piece. **Do not forget to add seam allowance to both the facing and the lining for this boundary seam**.
+- The chest piece is marked on the front.
+- Don't include seam allowance when cutting out canvas, and cut it on bias.
+- The front facing and lining is marked on the front piece. They split the front part in two along the boundary line. You can cut the front part along that line after cutting out the front from the main fabric. The inner pocket extension for the facing is printed separately, and you can tape it back in its place after cutting the patern piece. **Do not forget to add seam allowance to both the facing and the lining for this boundary seam**.
 
 ![Trace the front facing and lining from the front part](cuttingCaveat.svg)
 

--- a/markdown/org/docs/patterns/jaeger/fabric/en.md
+++ b/markdown/org/docs/patterns/jaeger/fabric/en.md
@@ -1,5 +1,5 @@
 Sportscoats are typically made from a heavier wool, often with some texture or pattern in the weave.
-In general, they are made in *busier* fabrics.
+In general, they are made in _busier_ fabrics.
 
 Style purists will argue that sportscoats should never be made out of suiting fabric, as a sportscoat
 is not a suit jacket. You can tell them go feck off and do whatever you want, it's your jacket.

--- a/markdown/org/docs/patterns/jaeger/instructions/en.md
+++ b/markdown/org/docs/patterns/jaeger/instructions/en.md
@@ -162,9 +162,9 @@ This will also secure the canvas to the front here and there.
 
 Keep in mind that:
 
--   The tape along the roll line should be placed inside the roll line.
--   The tape along the roll line should be about half a centimeter shorter than the distance it spans. The slight tension this creates helps the lapel roll nicely and contour to your body.
--   The tape along the lapel edge should be placed inside the seam line
+- The tape along the roll line should be placed inside the roll line.
+- The tape along the roll line should be about half a centimeter shorter than the distance it spans. The slight tension this creates helps the lapel roll nicely and contour to your body.
+- The tape along the lapel edge should be placed inside the seam line
 
 > ##### Don't sew through your fabric
 >

--- a/markdown/org/docs/patterns/jaeger/needs/en.md
+++ b/markdown/org/docs/patterns/jaeger/needs/en.md
@@ -1,15 +1,15 @@
 To make Jaeger, you will need the following:
 
--   About 2.5 meters (2.8 yards) of a suitable fabric (see [Fabric options](#fabric-options))
--   Lining fabric, optionally different sleeve lining fabric
--   Two larger buttons for the front, and 8 buttons for the sleeves
--   A bit of lightweight fusible interfacing for local enforcement
--   Canvas for the fronts and collar
--   Tailor's tape for the front edges
--   Some domette for interlining
--   Shoulder pads
--   Sleevehead wadding, with canvas if possible
--   Undercollar fabric
+- About 2.5 meters (2.8 yards) of a suitable fabric (see [Fabric options](#fabric-options))
+- Lining fabric, optionally different sleeve lining fabric
+- Two larger buttons for the front, and 8 buttons for the sleeves
+- A bit of lightweight fusible interfacing for local enforcement
+- Canvas for the fronts and collar
+- Tailor's tape for the front edges
+- Some domette for interlining
+- Shoulder pads
+- Sleevehead wadding, with canvas if possible
+- Undercollar fabric
 
 <Note>
 

--- a/markdown/org/docs/patterns/jaeger/options/backvent/en.md
+++ b/markdown/org/docs/patterns/jaeger/options/backvent/en.md
@@ -2,9 +2,9 @@
 
 How do you like your back vents?
 
--   Two back vents (shown on the left)
--   One central back vent (shown in the middle)
--   No back vents (shown on the right)
+- Two back vents (shown on the left)
+- One central back vent (shown in the middle)
+- No back vents (shown on the right)
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/jaeger/options/frontpocketradius/en.md
+++ b/markdown/org/docs/patterns/jaeger/options/frontpocketradius/en.md
@@ -1,7 +1,7 @@
 The radius by which the front pocket is rounded.
 
--   Increase this option to curve the bottom of the front pocket
--   Decrease this option to straighten out the bottom of the front pocket
+- Increase this option to curve the bottom of the front pocket
+- Decrease this option to straighten out the bottom of the front pocket
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/jaeger/options/innerpocketdepth/en.md
+++ b/markdown/org/docs/patterns/jaeger/options/innerpocketdepth/en.md
@@ -1,7 +1,7 @@
 How deep you would like the inner pocket to be.
 
--   Increase this option to make a deeper inner pocket
--   Decrease this option to make a shallower inner pocket
+- Increase this option to make a deeper inner pocket
+- Decrease this option to make a shallower inner pocket
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/jaeger/options/innerpocketplacement/en.md
+++ b/markdown/org/docs/patterns/jaeger/options/innerpocketplacement/en.md
@@ -1,7 +1,7 @@
 The location of the inner pocket.
 
--   Increase this option to shift the inner pocket towards the side seam
--   Decrease this option to shift the inner pocket towards the centre front
+- Increase this option to shift the inner pocket towards the side seam
+- Decrease this option to shift the inner pocket towards the centre front
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/jaeger/options/innerpocketweltheight/en.md
+++ b/markdown/org/docs/patterns/jaeger/options/innerpocketweltheight/en.md
@@ -1,7 +1,7 @@
 Controls the width of the inner pocket welts.
 
--   Increase this option to increase the width of the inner pocket welts
--   Decrease this option to decrease the width of the inner pocket welts
+- Increase this option to increase the width of the inner pocket welts
+- Decrease this option to decrease the width of the inner pocket welts
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/jaeger/options/lapelreduction/en.md
+++ b/markdown/org/docs/patterns/jaeger/options/lapelreduction/en.md
@@ -2,8 +2,8 @@ How much the tip of the lapels turns inwards.
 
 It is common to have the edge of the lapels not be entirely straight, but rather turn inwards a bit towards the top of the lapels. This option controls by how much it does that.
 
--   Increase this option to shift the lapel tip inward
--   Decrease this option to shift the lapel tip outward
+- Increase this option to shift the lapel tip inward
+- Decrease this option to shift the lapel tip outward
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/lunetius/cutting/en.md
+++ b/markdown/org/docs/patterns/lunetius/cutting/en.md
@@ -2,8 +2,8 @@
 title: Cutting 
 ---
 
--   Cut **1 lacerna** part on the fold
--   or Cut **2 lacerna** parts
+- Cut **1 lacerna** part on the fold
+- or Cut **2 lacerna** parts
 
 The way to cut Lunetius is going to depend on what fabric you have chosen to use. If you have enough fabric width you can cut it _on the fold_. If you don’t, you can cut two halves and later sew them together. To not have to later finish the centre back edge you can cut with the centre back edge on the selvage.
 

--- a/markdown/org/docs/patterns/lunetius/cutting/en.md
+++ b/markdown/org/docs/patterns/lunetius/cutting/en.md
@@ -5,14 +5,14 @@ title: Cutting
 -   Cut **1 lacerna** part on the fold
 -   or Cut **2 lacerna** parts
 
-The way to cut Lunetius is going to depend on what fabric you have chosen to use. If you have enough fabric width you can cut it *on the fold*. If you don’t, you can cut two halves and later sew them together. To not have to later finish the centre back edge you can cut with the centre back edge on the selvage.
+The way to cut Lunetius is going to depend on what fabric you have chosen to use. If you have enough fabric width you can cut it _on the fold_. If you don’t, you can cut two halves and later sew them together. To not have to later finish the centre back edge you can cut with the centre back edge on the selvage.
 
 A lot of garments were woven to shape in the Roman era, so this is one aspect where you don’t need to worry about historical accuracy at all, unless you would like to weave your Lunetius to shape.
 
 <Comment by="Zee">In that case I salute you and please share the results [in our discord](https://discord.freesewing.org/)! </Comment>
 
 If you want to learn more about this you can read about it in:\
-Granger-Taylor, H. (1982) *Weaving Clothes To Shape in the Ancient World: The Tunic and Toga of the Arringatore* in Textile History 13 (1), pp 3-25
+Granger-Taylor, H. (1982) _Weaving Clothes To Shape in the Ancient World: The Tunic and Toga of the Arringatore_ in Textile History 13 (1), pp 3-25
 
 ### On Historical Accuracy
 

--- a/markdown/org/docs/patterns/lunetius/fabric/en.md
+++ b/markdown/org/docs/patterns/lunetius/fabric/en.md
@@ -11,4 +11,4 @@ Otherwise, any wool or linen in both plain and other weaves would be a good choi
 If you are not working with any historicalness in mind Lunetius can be made out of a variety of fabrics. A woven fabric would drape in a different way compared to a stretch or knitted fabric but you are only limited by your imagination.
 
 More information on Roman cloak fabrics can be found in:\
-Jorgensen, L. B. (2004)  *A Matter of Material: Changes in Textiles from Roman Sites in Egypt’s Eastern Desert*,  in An Tard 11, pp 87-99
+Jorgensen, L. B. (2004)  _A Matter of Material: Changes in Textiles from Roman Sites in Egypt’s Eastern Desert_,  in An Tard 11, pp 87-99

--- a/markdown/org/docs/patterns/lunetius/instructions/en.md
+++ b/markdown/org/docs/patterns/lunetius/instructions/en.md
@@ -10,7 +10,7 @@ All the sewing can be done by machine or by hand as you prefer. If you want to s
 
 ### Step 1: Sewing and finishing the centre back seam
 
--   If you cut Lunetius with a centre back seam, sew this up first and finish the seam in some way. You can do this by binding it, or by felling it to the fabric. On a stretch fabric simply sewing up the centre back seam is enough.
+- If you cut Lunetius with a centre back seam, sew this up first and finish the seam in some way. You can do this by binding it, or by felling it to the fabric. On a stretch fabric simply sewing up the centre back seam is enough.
 
 <Tip>
 
@@ -24,7 +24,7 @@ Felling the edges by hand can be done with a felling stitch, or a running stitch
 
 ### Step 2: Hemming the edges
 
--   The next and last step is to finish the edges. This can be done by turning a hem on the whole edge, or by using a binding. Once this is done, you are finished!
+- The next and last step is to finish the edges. This can be done by turning a hem on the whole edge, or by using a binding. Once this is done, you are finished!
 
 <Tip>
 

--- a/markdown/org/docs/patterns/lunetius/instructions/en.md
+++ b/markdown/org/docs/patterns/lunetius/instructions/en.md
@@ -36,4 +36,4 @@ On the machine, a straight stitch is a good option, but if you have a blind hem 
 
 ### Step 3: Enjoy!
 
-That's it you are all done! Now take a *fibula* (a brooch, pin or clasp) to fasten your cloak over your right shoulder (that is how the Romans did it, you can of course also take the left shoulder, or the middle, or whatever you prefer) and enjoy looking dramatic.
+That's it you are all done! Now take a _fibula_ (a brooch, pin or clasp) to fasten your cloak over your right shoulder (that is how the Romans did it, you can of course also take the left shoulder, or the middle, or whatever you prefer) and enjoy looking dramatic.

--- a/markdown/org/docs/patterns/lunetius/needs/en.md
+++ b/markdown/org/docs/patterns/lunetius/needs/en.md
@@ -1,5 +1,5 @@
 To make Lunetius, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 2 meters (2.2 yards) of a suitable fabric (see [Fabric options](/docs/patterns/lunetius/fabric))
--   (a _fibula_ (brooch, pin, clasp) to wear and close it)
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 2 meters (2.2 yards) of a suitable fabric (see [Fabric options](/docs/patterns/lunetius/fabric))
+- (a _fibula_ (brooch, pin, clasp) to wear and close it)

--- a/markdown/org/docs/patterns/lunetius/needs/en.md
+++ b/markdown/org/docs/patterns/lunetius/needs/en.md
@@ -2,4 +2,4 @@ To make Lunetius, you will need the following:
 
 -   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
 -   About 2 meters (2.2 yards) of a suitable fabric (see [Fabric options](/docs/patterns/lunetius/fabric))
--   (a *fibula* (brooch, pin, clasp) to wear and close it)
+-   (a _fibula_ (brooch, pin, clasp) to wear and close it)

--- a/markdown/org/docs/patterns/paco/cutting/en.md
+++ b/markdown/org/docs/patterns/paco/cutting/en.md
@@ -8,14 +8,14 @@ If a pattern part is not printed, it means you don't need it.
 </Tip>
 
 -   From your main fabric:
-    -   2x **part 1**: This is the back panel. Cut these from your **main fabric** with *good sides together*
-    -   2x **part 2**: This is the front panel. Cut these from your **main fabric** with *good sides together*
+    -   2x **part 1**: This is the back panel. Cut these from your **main fabric** with _good sides together_
+    -   2x **part 2**: This is the front panel. Cut these from your **main fabric** with _good sides together_
     -   2x **part 3**: This is the waistband. Cut it from your **main fabric**
-    -   2x **part 4**: This is the ankle cuff. Cut these, from your **main fabric** with *good sides together* (not needed if your chose not to have an elasticated hem)
-    -   2x **part 7**: This is the back pocket welt. Cut 2 of these from your **main fabric** with *good sides together*
+    -   2x **part 4**: This is the ankle cuff. Cut these, from your **main fabric** with _good sides together_ (not needed if your chose not to have an elasticated hem)
+    -   2x **part 7**: This is the back pocket welt. Cut 2 of these from your **main fabric** with _good sides together_
 -   From your lining fabric:
-    -   2x **part 5**: This is the front pocket bag. Cut these, from your **lining fabric** *on the fold* (not needed if you chose to not have front pockets)
-    -   2x **part 6**: This is the back pocket bag. Cut 2 of these from your **lining fabric** *on the fold*
+    -   2x **part 5**: This is the front pocket bag. Cut these, from your **lining fabric** _on the fold_ (not needed if you chose to not have front pockets)
+    -   2x **part 6**: This is the back pocket bag. Cut 2 of these from your **lining fabric** _on the fold_
 -   From interfacing:
     -   2x **part 8**: This is the back pocket welt interfacing. Cut 2 of these from **interfacing**
 

--- a/markdown/org/docs/patterns/paco/cutting/en.md
+++ b/markdown/org/docs/patterns/paco/cutting/en.md
@@ -7,24 +7,24 @@ If a pattern part is not printed, it means you don't need it.
 
 </Tip>
 
--   From your main fabric:
-    -   2x **part 1**: This is the back panel. Cut these from your **main fabric** with _good sides together_
-    -   2x **part 2**: This is the front panel. Cut these from your **main fabric** with _good sides together_
-    -   2x **part 3**: This is the waistband. Cut it from your **main fabric**
-    -   2x **part 4**: This is the ankle cuff. Cut these, from your **main fabric** with _good sides together_ (not needed if your chose not to have an elasticated hem)
-    -   2x **part 7**: This is the back pocket welt. Cut 2 of these from your **main fabric** with _good sides together_
--   From your lining fabric:
-    -   2x **part 5**: This is the front pocket bag. Cut these, from your **lining fabric** _on the fold_ (not needed if you chose to not have front pockets)
-    -   2x **part 6**: This is the back pocket bag. Cut 2 of these from your **lining fabric** _on the fold_
--   From interfacing:
-    -   2x **part 8**: This is the back pocket welt interfacing. Cut 2 of these from **interfacing**
+- From your main fabric:
+  - 2x **part 1**: This is the back panel. Cut these from your **main fabric** with _good sides together_
+  - 2x **part 2**: This is the front panel. Cut these from your **main fabric** with _good sides together_
+  - 2x **part 3**: This is the waistband. Cut it from your **main fabric**
+  - 2x **part 4**: This is the ankle cuff. Cut these, from your **main fabric** with _good sides together_ (not needed if your chose not to have an elasticated hem)
+  - 2x **part 7**: This is the back pocket welt. Cut 2 of these from your **main fabric** with _good sides together_
+- From your lining fabric:
+  - 2x **part 5**: This is the front pocket bag. Cut these, from your **lining fabric** _on the fold_ (not needed if you chose to not have front pockets)
+  - 2x **part 6**: This is the back pocket bag. Cut 2 of these from your **lining fabric** _on the fold_
+- From interfacing:
+  - 2x **part 8**: This is the back pocket welt interfacing. Cut 2 of these from **interfacing**
 
 <Warning>
 
 #### Caveats
 
--   There is no seam allowance on the interfacing
--   There is extra seam allowance on the waist band and hem
--   The waistband is a mere rectangle, so it's not fully printed to save paper
+- There is no seam allowance on the interfacing
+- There is extra seam allowance on the waist band and hem
+- The waistband is a mere rectangle, so it's not fully printed to save paper
 
 </Warning>

--- a/markdown/org/docs/patterns/paco/needs/en.md
+++ b/markdown/org/docs/patterns/paco/needs/en.md
@@ -1,8 +1,8 @@
 To make Paco, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 1.25 meters (1.4 yards) (depending on your height) of a suitable fabric ([see Fabric options](/docs/patterns/paco/fabric))
--   30cm (12") of lining for the pocket bags
--   A little bit of interfacing for the pocket welts (only needed if you opted for back pockets)
--   A drawstring and two eyelets (optional)
--   Enough wide flat elastic for your waist and cuffs
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 1.25 meters (1.4 yards) (depending on your height) of a suitable fabric ([see Fabric options](/docs/patterns/paco/fabric))
+- 30cm (12") of lining for the pocket bags
+- A little bit of interfacing for the pocket welts (only needed if you opted for back pockets)
+- A drawstring and two eyelets (optional)
+- Enough wide flat elastic for your waist and cuffs

--- a/markdown/org/docs/patterns/paco/options/waistheight/en.md
+++ b/markdown/org/docs/patterns/paco/options/waistheight/en.md
@@ -1,7 +1,7 @@
 Controls the height of the waist, where:
 
--   100% : The waist of the trousers sits at the waist line
--   0% : The waist of the trousers sits at the hip line
+- 100% : The waist of the trousers sits at the waist line
+- 0% : The waist of the trousers sits at the hip line
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/penelope/cutting/en.md
+++ b/markdown/org/docs/patterns/penelope/cutting/en.md
@@ -8,14 +8,14 @@ Due to this, the cutting list does not specify how many back parts to cut as the
 
 **Main Fabric**
 
--   Cut **1 front** part on fold.
--   Cut **back** part(s).
--   (Optional) Cut **1 waistband** parts on the fold.
+- Cut **1 front** part on fold.
+- Cut **back** part(s).
+- (Optional) Cut **1 waistband** parts on the fold.
 
 **Lining Fabric (Optional)**
 
--   Cut **1 front** part on fold.
--   Cut **back** part(s).
+- Cut **1 front** part on fold.
+- Cut **back** part(s).
 
 <Note>
 
@@ -25,7 +25,7 @@ Due to this, the cutting list does not specify how many back parts to cut as the
 
 **Interfacing**
 
--   Cut **1 waistband** part on the fold.
+- Cut **1 waistband** part on the fold.
 
 <Tip>
 

--- a/markdown/org/docs/patterns/penelope/instructions/en.md
+++ b/markdown/org/docs/patterns/penelope/instructions/en.md
@@ -77,7 +77,7 @@ web, both in writen form, and on video. If you do get stuck, you can always reac
 
 ### Step 2: The zipper
 
--   With *good sides together*, sew the seam that has the zipper leaving the top open for the zipper.
+-   With _good sides together_, sew the seam that has the zipper leaving the top open for the zipper.
 -   Insert the zipper into the seam following the procedure that is appropriate for the type of zipper you're using.
 
 <Note>
@@ -88,8 +88,8 @@ If using a different closure, construct it during this step.
 
 ### Step 3: Sew the side seams
 
--   With *good sides together*, sew up both the side seams.
--   With *good sides together*, if not the zipper seam, sew the centre back seam either completely or down to the vent if included.
+-   With _good sides together_, sew up both the side seams.
+-   With _good sides together_, if not the zipper seam, sew the centre back seam either completely or down to the vent if included.
 
 ### Step 4: The lining (Optional)
 
@@ -116,17 +116,17 @@ If you prefer to insert the zipper with the main and lining fabric as one, you w
 
 -   Face lengthwise half of the waistband.
 -   Press a fold the waistband in half lengthwise.
--   With *good sides together* sew the face half of the waistband to the top of the skirt. Part of this waistband should overhang the zipper seam.
+-   With _good sides together_ sew the face half of the waistband to the top of the skirt. Part of this waistband should overhang the zipper seam.
 -   Press the waistband up and away from the skirt.
 -   Press the remaining waistband seam allowances to the inside of the waistband.
 -   Fold and press the waistband to the inside along fold line.
--   *Stitch in the ditch* to secure the waistband.
--   *Slipstitch* or *Whipstitch* the gap in the waistband that goes over the zipper seam
+-   _Stitch in the ditch_ to secure the waistband.
+-   _Slipstitch_ or _Whipstitch_ the gap in the waistband that goes over the zipper seam
 -   Construct your preferred choice of closure where the waistband overlaps.
 
 <Note>
 
-Alternatively you can *Edgestitch* the waistband in place which will admit the need to hand-stitch the gap closed but this will leave visible stitching.\
+Alternatively you can _Edgestitch_ the waistband in place which will admit the need to hand-stitch the gap closed but this will leave visible stitching.\
 The closure can be a button and buttonhole, snaps or simple dress hooks. It's really up to you.
 
 </Note>
@@ -139,7 +139,7 @@ This step is only needed if you have not lined your skirt as the hem and vents w
 -   Construct the vents with your preferred method
 -   Press under the hem allowances of the skirt.
 -   If hem is large enough and/or the fabric press under a small amount along the top, this will help to prevent farying.
--   Secure the hem in place with your preferred method. For instance you can sew from the outside or *Slipstitch* from the inside. This comes down to how you want the finished product to look.
+-   Secure the hem in place with your preferred method. For instance you can sew from the outside or _Slipstitch_ from the inside. This comes down to how you want the finished product to look.
 
 <Tip>
 

--- a/markdown/org/docs/patterns/penelope/instructions/en.md
+++ b/markdown/org/docs/patterns/penelope/instructions/en.md
@@ -70,15 +70,15 @@ web, both in writen form, and on video. If you do get stuck, you can always reac
 
 ### Step 1: Darts
 
--   Sew all the darts.
--   Press the darts towards the back.
-    -   For the back piece(s), that means you press the darts towards eachother.
-    -   For the front piece, that means you press the darts towards the side seams.
+- Sew all the darts.
+- Press the darts towards the back.
+  - For the back piece(s), that means you press the darts towards eachother.
+  - For the front piece, that means you press the darts towards the side seams.
 
 ### Step 2: The zipper
 
--   With _good sides together_, sew the seam that has the zipper leaving the top open for the zipper.
--   Insert the zipper into the seam following the procedure that is appropriate for the type of zipper you're using.
+- With _good sides together_, sew the seam that has the zipper leaving the top open for the zipper.
+- Insert the zipper into the seam following the procedure that is appropriate for the type of zipper you're using.
 
 <Note>
 
@@ -88,17 +88,17 @@ If using a different closure, construct it during this step.
 
 ### Step 3: Sew the side seams
 
--   With _good sides together_, sew up both the side seams.
--   With _good sides together_, if not the zipper seam, sew the centre back seam either completely or down to the vent if included.
+- With _good sides together_, sew up both the side seams.
+- With _good sides together_, if not the zipper seam, sew the centre back seam either completely or down to the vent if included.
 
 ### Step 4: The lining (Optional)
 
 You can skip this step if not making a lining.
 
--   Follow Step 1 - 4 to construct the lining with the following changes:
-    -   Adjust the darts to compensate for the extra 'ease' in the lining pieces.
-    -   Do not include the zipper but leave the opening in the zipper seam.
--   Attach the lining to the body in your prefered way. You will need to construct the vent during this and connect the lining to the zipper.
+- Follow Step 1 - 4 to construct the lining with the following changes:
+  - Adjust the darts to compensate for the extra 'ease' in the lining pieces.
+  - Do not include the zipper but leave the opening in the zipper seam.
+- Attach the lining to the body in your prefered way. You will need to construct the vent during this and connect the lining to the zipper.
 
 <Note>
 
@@ -114,15 +114,15 @@ If you prefer to insert the zipper with the main and lining fabric as one, you w
 
 ### Step 5: The waistband
 
--   Face lengthwise half of the waistband.
--   Press a fold the waistband in half lengthwise.
--   With _good sides together_ sew the face half of the waistband to the top of the skirt. Part of this waistband should overhang the zipper seam.
--   Press the waistband up and away from the skirt.
--   Press the remaining waistband seam allowances to the inside of the waistband.
--   Fold and press the waistband to the inside along fold line.
--   _Stitch in the ditch_ to secure the waistband.
--   _Slipstitch_ or _Whipstitch_ the gap in the waistband that goes over the zipper seam
--   Construct your preferred choice of closure where the waistband overlaps.
+- Face lengthwise half of the waistband.
+- Press a fold the waistband in half lengthwise.
+- With _good sides together_ sew the face half of the waistband to the top of the skirt. Part of this waistband should overhang the zipper seam.
+- Press the waistband up and away from the skirt.
+- Press the remaining waistband seam allowances to the inside of the waistband.
+- Fold and press the waistband to the inside along fold line.
+- _Stitch in the ditch_ to secure the waistband.
+- _Slipstitch_ or _Whipstitch_ the gap in the waistband that goes over the zipper seam
+- Construct your preferred choice of closure where the waistband overlaps.
 
 <Note>
 
@@ -135,11 +135,11 @@ The closure can be a button and buttonhole, snaps or simple dress hooks. It's re
 
 This step is only needed if you have not lined your skirt as the hem and vents would have been taken care of in that step.
 
--   If desired, face the hem and vents.
--   Construct the vents with your preferred method
--   Press under the hem allowances of the skirt.
--   If hem is large enough and/or the fabric press under a small amount along the top, this will help to prevent farying.
--   Secure the hem in place with your preferred method. For instance you can sew from the outside or _Slipstitch_ from the inside. This comes down to how you want the finished product to look.
+- If desired, face the hem and vents.
+- Construct the vents with your preferred method
+- Press under the hem allowances of the skirt.
+- If hem is large enough and/or the fabric press under a small amount along the top, this will help to prevent farying.
+- Secure the hem in place with your preferred method. For instance you can sew from the outside or _Slipstitch_ from the inside. This comes down to how you want the finished product to look.
 
 <Tip>
 
@@ -149,4 +149,4 @@ If the seam allowances are big enough you can sew the hems as narrow hems. This 
 
 ### Step 7: Enjoy!
 
--   Now all that's left to do is to enjoy you new skirt!
+- Now all that's left to do is to enjoy you new skirt!

--- a/markdown/org/docs/patterns/penelope/needs/en.md
+++ b/markdown/org/docs/patterns/penelope/needs/en.md
@@ -1,8 +1,8 @@
 To make Penelope, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 1 meter (1.1 yards) of a suitable main fabric ([see Penelope Fabric options](/docs/patterns/penelope/fabric))
--   An invisible or regular closed end zipper
--   Some interfacing for the waistband (if using) and maybe for the vent and hem
--   Some sort of closure for the waistband (if using)
--   (Optional) About 1 meter (1.1 yards) of suitable lining fabric ([see Penelope Fabric options](/docs/patterns/penelope/fabric))
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 1 meter (1.1 yards) of a suitable main fabric ([see Penelope Fabric options](/docs/patterns/penelope/fabric))
+- An invisible or regular closed end zipper
+- Some interfacing for the waistband (if using) and maybe for the vent and hem
+- Some sort of closure for the waistband (if using)
+- (Optional) About 1 meter (1.1 yards) of suitable lining fabric ([see Penelope Fabric options](/docs/patterns/penelope/fabric))

--- a/markdown/org/docs/patterns/sandy/cutting/en.md
+++ b/markdown/org/docs/patterns/sandy/cutting/en.md
@@ -6,17 +6,17 @@ If not using seamless follow the default list, If using seamless follow the seam
 
 **Main Fabric**
 
--   (If default) Cut **1 skirt** part on the fold.
--   (If seamless) Cut **1 skirt** part on double fold.
--   (If default) Cut **2 waistband** parts.
--   (If seamless) Cut **1 waistband** part.
+- (If default) Cut **1 skirt** part on the fold.
+- (If seamless) Cut **1 skirt** part on double fold.
+- (If default) Cut **2 waistband** parts.
+- (If seamless) Cut **1 waistband** part.
 
 **Lining Fabric (Optional)**
 
--   (If default) Cut **1 skirt** part on the fold.
--   (If seamless) Cut **1 skirt** part on double fold.
+- (If default) Cut **1 skirt** part on the fold.
+- (If seamless) Cut **1 skirt** part on double fold.
 
 **Interfacing**
 
--   (If default) Cut **2 waistband** parts.
--   (If seamless) Cut **1 waistband** part.
+- (If default) Cut **2 waistband** parts.
+- (If seamless) Cut **1 waistband** part.

--- a/markdown/org/docs/patterns/sandy/fabric/en.md
+++ b/markdown/org/docs/patterns/sandy/fabric/en.md
@@ -2,11 +2,11 @@
 
 A circle skirt is a very versatile garment and can be made from a variety of fabric. It all depends on your intended use and preferred style.
 
--   If you wish for an everday, easy to wash skirt then **Linen** and **Cotton** is the way to go.
--   If you are looking for something more formal you may want to try **Suiting Fabrics**.
--   If you want something warm for the winter you can try **Wools**.
--   If wish for something flowy that drapes you can try lightweight materials such as **Chiffon**.
--   If you are want something for a special occasion who may wish to try **Brocades** and **Silks**.
+- If you wish for an everday, easy to wash skirt then **Linen** and **Cotton** is the way to go.
+- If you are looking for something more formal you may want to try **Suiting Fabrics**.
+- If you want something warm for the winter you can try **Wools**.
+- If wish for something flowy that drapes you can try lightweight materials such as **Chiffon**.
+- If you are want something for a special occasion who may wish to try **Brocades** and **Silks**.
 
 Basically any fabric can be used to make a circle skirt you just need to find one that is right for you.
 

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -15,10 +15,10 @@ Due to seamless and closure Sandy's needing different constructions we have sepa
 
 ### Step 1: Prepping the Skirt
 
--   With _good sides together_ sew the skirt seam up to where you intend the opening to start.
--   Add Pockets if using.
--   If using lining, prep the same as the skirt.
--   _Finish_ if not lining.
+- With _good sides together_ sew the skirt seam up to where you intend the opening to start.
+- Add Pockets if using.
+- If using lining, prep the same as the skirt.
+- _Finish_ if not lining.
 
 <Note>
 
@@ -28,8 +28,8 @@ Pockets are not included in Sandy as it has one seam by default, if you cut mult
 
 ### Step 2: Prep the opening
 
--   Insert zipper or placket into opening if using.
--   If not using, press the openings seam allowance to the inside and _Edgestitch_/_Topstitch_ in place. You may also wish to continue the topstiching down the seam.
+- Insert zipper or placket into opening if using.
+- If not using, press the openings seam allowance to the inside and _Edgestitch_/_Topstitch_ in place. You may also wish to continue the topstiching down the seam.
 
 <Note>
 
@@ -39,10 +39,10 @@ Skip this step if you are including the zipper in the waistband.
 
 ### Step 3: Lining
 
--   Face the skirt if desired.
--   Attach Lining to skirt at hem and opening by your preferred method.
--   _Baste_ Lining to skirt at waist.
--   Gather skirt and lining skit if needed.
+- Face the skirt if desired.
+- Attach Lining to skirt at hem and opening by your preferred method.
+- _Baste_ Lining to skirt at waist.
+- Gather skirt and lining skit if needed.
 
 <Note>
 
@@ -53,18 +53,18 @@ If not lining you should face the skirt when hemming later.
 
 ### Step 4: The waistband
 
--   Face half the waistbands parts lengthwise.
--   With _good sides together_ sew the waistbands together along one of the short edges.
--   Press under the seam allowance on the long edge of the waistband that is not faced.
--   Attach the faced side of the waistband, _good sides together_ to the skirt. There will be some overhang, the side you wish not to overlap should be overhang by your seam allowance. The side intended to overlap will have a greater overhang. Trim seam.
--   Press the waistband and seam allowance up and away from the skirt.
--   If inserting a zipper now is the time to do so, attach the zipper from the fold line down. Then follow the rest of the instructions ommiting overhangs and other closures. You will need to attach the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
--   Press the waistband _good sides together_ along fold-line.
--   Sew the overhangs with your seam allowance.
--   Turn the waistband out and to the inside, Press.
--   _Egdestitch_ the waistband in place, this should also close the gap of the over-lap.
--   Alternatively, _Slipstich_ or _Whipstitch_ the waistband in place on the inside and close the gap of the over-lap with _Slipstiching_.
--   Add button and buttonhole, snaps or dress hooks, whatever is your preferred closure to the waistband overhang.
+- Face half the waistbands parts lengthwise.
+- With _good sides together_ sew the waistbands together along one of the short edges.
+- Press under the seam allowance on the long edge of the waistband that is not faced.
+- Attach the faced side of the waistband, _good sides together_ to the skirt. There will be some overhang, the side you wish not to overlap should be overhang by your seam allowance. The side intended to overlap will have a greater overhang. Trim seam.
+- Press the waistband and seam allowance up and away from the skirt.
+- If inserting a zipper now is the time to do so, attach the zipper from the fold line down. Then follow the rest of the instructions ommiting overhangs and other closures. You will need to attach the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
+- Press the waistband _good sides together_ along fold-line.
+- Sew the overhangs with your seam allowance.
+- Turn the waistband out and to the inside, Press.
+- _Egdestitch_ the waistband in place, this should also close the gap of the over-lap.
+- Alternatively, _Slipstich_ or _Whipstitch_ the waistband in place on the inside and close the gap of the over-lap with _Slipstiching_.
+- Add button and buttonhole, snaps or dress hooks, whatever is your preferred closure to the waistband overhang.
 
 <Tip>
 
@@ -76,9 +76,9 @@ If you are having trouble keeping the pressed under seam allowance of the waistb
 
 If you have hemmed the skirt with the lining you can skip this step.
 
--   Faced the skirt if desired.
--   Line the facing if desired.
--   Hem the skirt if you have not already done so with the lining.
+- Faced the skirt if desired.
+- Line the facing if desired.
+- Hem the skirt if you have not already done so with the lining.
 
 <Note>  
 
@@ -94,11 +94,11 @@ You are all done! Now go enjoy your wonderful new skirt!
 
 ### Step 1: Lining and Skirt
 
--   Face skirt if desired.
--   Attach Lining to skirt at hem by your preferred method if using.
--   _Baste_ Lining to skirt at waist.
--   _Finish_ seams if not lining.
--   Gather skirt and lining skit if needed.
+- Face skirt if desired.
+- Attach Lining to skirt at hem by your preferred method if using.
+- _Baste_ Lining to skirt at waist.
+- _Finish_ seams if not lining.
+- Gather skirt and lining skit if needed.
 
 <Note>
 
@@ -109,17 +109,17 @@ If not lining you should face the skirt when hemming later.
 
 ### Step 2: The waistband
 
--   With _good sides together_ sew the waistband in half along the short seams, leaving a gap for the elastic that will be on the inside.
--   Press under the seam allowance on the long edge of the waistband that is intended to be on the inside.
--   With _good sides together_ attach the waistband to the skirt along the unpressed seam. Trim seam.
--   Press waistband and seam allowance up away from skirt.
--   Press the waistband to the inside along the fold-line.
--   _Edgestitch_ the waistband in place.
--   Alternatively you can _Slipstitch_ or _Whipstitch_ the waistband in place on the inside.
--   Cut the elastic to your waist.
--   Thread the elastic through the opening of the waistband making sure not to lose the end.
--   Overlap the ends by 1cm (3/8 inch) and zig-zag stitch in place.
--   Tuck elastic into waistband and close the opening with hand-sewing.
+- With _good sides together_ sew the waistband in half along the short seams, leaving a gap for the elastic that will be on the inside.
+- Press under the seam allowance on the long edge of the waistband that is intended to be on the inside.
+- With _good sides together_ attach the waistband to the skirt along the unpressed seam. Trim seam.
+- Press waistband and seam allowance up away from skirt.
+- Press the waistband to the inside along the fold-line.
+- _Edgestitch_ the waistband in place.
+- Alternatively you can _Slipstitch_ or _Whipstitch_ the waistband in place on the inside.
+- Cut the elastic to your waist.
+- Thread the elastic through the opening of the waistband making sure not to lose the end.
+- Overlap the ends by 1cm (3/8 inch) and zig-zag stitch in place.
+- Tuck elastic into waistband and close the opening with hand-sewing.
 
 <Tip>
 
@@ -131,9 +131,9 @@ If you are having trouble keeping the pressed under seam allowance of the waistb
 
 If you have hemmed the skirt with the lining you can skip this step.
 
--   Faced the skirt if desired.
--   Line the facing if desired.
--   Hem the skirt if you have not already done so with the lining.
+- Faced the skirt if desired.
+- Line the facing if desired.
+- Hem the skirt if you have not already done so with the lining.
 
 <Note>  
 

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -15,10 +15,10 @@ Due to seamless and closure Sandy's needing different constructions we have sepa
 
 ### Step 1: Prepping the Skirt
 
--   With *good sides together* sew the skirt seam up to where you intend the opening to start.
+-   With _good sides together_ sew the skirt seam up to where you intend the opening to start.
 -   Add Pockets if using.
 -   If using lining, prep the same as the skirt.
--   *Finish* if not lining.
+-   _Finish_ if not lining.
 
 <Note>
 
@@ -29,7 +29,7 @@ Pockets are not included in Sandy as it has one seam by default, if you cut mult
 ### Step 2: Prep the opening
 
 -   Insert zipper or placket into opening if using.
--   If not using, press the openings seam allowance to the inside and *Edgestitch*/*Topstitch* in place. You may also wish to continue the topstiching down the seam.
+-   If not using, press the openings seam allowance to the inside and _Edgestitch_/_Topstitch_ in place. You may also wish to continue the topstiching down the seam.
 
 <Note>
 
@@ -41,7 +41,7 @@ Skip this step if you are including the zipper in the waistband.
 
 -   Face the skirt if desired.
 -   Attach Lining to skirt at hem and opening by your preferred method.
--   *Baste* Lining to skirt at waist.
+-   _Baste_ Lining to skirt at waist.
 -   Gather skirt and lining skit if needed.
 
 <Note>
@@ -54,21 +54,21 @@ If not lining you should face the skirt when hemming later.
 ### Step 4: The waistband
 
 -   Face half the waistbands parts lengthwise.
--   With *good sides together* sew the waistbands together along one of the short edges.
+-   With _good sides together_ sew the waistbands together along one of the short edges.
 -   Press under the seam allowance on the long edge of the waistband that is not faced.
--   Attach the faced side of the waistband, *good sides together* to the skirt. There will be some overhang, the side you wish not to overlap should be overhang by your seam allowance. The side intended to overlap will have a greater overhang. Trim seam.
+-   Attach the faced side of the waistband, _good sides together_ to the skirt. There will be some overhang, the side you wish not to overlap should be overhang by your seam allowance. The side intended to overlap will have a greater overhang. Trim seam.
 -   Press the waistband and seam allowance up and away from the skirt.
 -   If inserting a zipper now is the time to do so, attach the zipper from the fold line down. Then follow the rest of the instructions ommiting overhangs and other closures. You will need to attach the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
--   Press the waistband *good sides together* along fold-line.
+-   Press the waistband _good sides together_ along fold-line.
 -   Sew the overhangs with your seam allowance.
 -   Turn the waistband out and to the inside, Press.
--   *Egdestitch* the waistband in place, this should also close the gap of the over-lap.
--   Alternatively, *Slipstich* or *Whipstitch* the waistband in place on the inside and close the gap of the over-lap with *Slipstiching*.
+-   _Egdestitch_ the waistband in place, this should also close the gap of the over-lap.
+-   Alternatively, _Slipstich_ or _Whipstitch_ the waistband in place on the inside and close the gap of the over-lap with _Slipstiching_.
 -   Add button and buttonhole, snaps or dress hooks, whatever is your preferred closure to the waistband overhang.
 
 <Tip>
 
-If you are having trouble keeping the pressed under seam allowance of the waistband folded/not staying pressed you may find it helpful to *Baste* the fold in place.
+If you are having trouble keeping the pressed under seam allowance of the waistband folded/not staying pressed you may find it helpful to _Baste_ the fold in place.
 
 </Tip>
 
@@ -96,8 +96,8 @@ You are all done! Now go enjoy your wonderful new skirt!
 
 -   Face skirt if desired.
 -   Attach Lining to skirt at hem by your preferred method if using.
--   *Baste* Lining to skirt at waist.
--   *Finish* seams if not lining.
+-   _Baste_ Lining to skirt at waist.
+-   _Finish_ seams if not lining.
 -   Gather skirt and lining skit if needed.
 
 <Note>
@@ -109,13 +109,13 @@ If not lining you should face the skirt when hemming later.
 
 ### Step 2: The waistband
 
--   With *good sides together* sew the waistband in half along the short seams, leaving a gap for the elastic that will be on the inside.
+-   With _good sides together_ sew the waistband in half along the short seams, leaving a gap for the elastic that will be on the inside.
 -   Press under the seam allowance on the long edge of the waistband that is intended to be on the inside.
--   With *good sides together* attach the waistband to the skirt along the unpressed seam. Trim seam.
+-   With _good sides together_ attach the waistband to the skirt along the unpressed seam. Trim seam.
 -   Press waistband and seam allowance up away from skirt.
 -   Press the waistband to the inside along the fold-line.
--   *Edgestitch* the waistband in place.
--   Alternatively you can *Slipstitch* or *Whipstitch* the waistband in place on the inside.
+-   _Edgestitch_ the waistband in place.
+-   Alternatively you can _Slipstitch_ or _Whipstitch_ the waistband in place on the inside.
 -   Cut the elastic to your waist.
 -   Thread the elastic through the opening of the waistband making sure not to lose the end.
 -   Overlap the ends by 1cm (3/8 inch) and zig-zag stitch in place.
@@ -123,7 +123,7 @@ If not lining you should face the skirt when hemming later.
 
 <Tip>
 
-If you are having trouble keeping the pressed under seam allowance of the waistband folded/not staying pressed you may find it helpful to *Baste* the fold in place.
+If you are having trouble keeping the pressed under seam allowance of the waistband folded/not staying pressed you may find it helpful to _Baste_ the fold in place.
 
 </Tip>
 

--- a/markdown/org/docs/patterns/sandy/needs/en.md
+++ b/markdown/org/docs/patterns/sandy/needs/en.md
@@ -1,12 +1,12 @@
 To make Sandy, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 2 - 6 metres (2.2 - 6.6 yards) of a suitable main fabric ([see Sandy Fabric options](/docs/patterns/sandy/fabric))
--   Some interfacing for the waistband
--   (Optional) Facing for the hem.
--   Some sort of closure for the waistband (if not seamless)
--   (Optional) About 2 - 6 metres (2.2 - 6.6 yards) of suitable lining fabric ([see Sandy Fabric options](/docs/patterns/sandy/fabric))
--   Elastic (if needed)
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 2 - 6 metres (2.2 - 6.6 yards) of a suitable main fabric ([see Sandy Fabric options](/docs/patterns/sandy/fabric))
+- Some interfacing for the waistband
+- (Optional) Facing for the hem.
+- Some sort of closure for the waistband (if not seamless)
+- (Optional) About 2 - 6 metres (2.2 - 6.6 yards) of suitable lining fabric ([see Sandy Fabric options](/docs/patterns/sandy/fabric))
+- Elastic (if needed)
 
 Due to the many different styles of Sandy it is difficult to precisely say what you need so we will go through some of the options.
 

--- a/markdown/org/docs/patterns/sandy/options/seamlessfullcircle/en.md
+++ b/markdown/org/docs/patterns/sandy/options/seamlessfullcircle/en.md
@@ -5,7 +5,7 @@ Since it has no openings, you'll need an elastic waistband.
 
 <Note>
 
-This produces a full circle ignoring the *Circle percent* option.
+This produces a full circle ignoring the _Circle percent_ option.
 
 </Note>
 

--- a/markdown/org/docs/patterns/shin/cutting/en.md
+++ b/markdown/org/docs/patterns/shin/cutting/en.md
@@ -1,11 +1,11 @@
--   Cut **2 backs** with good sides together
--   Cut **4 fronts** 2 x 2 with good sides together
--   Cut **1 waistband**
+- Cut **2 backs** with good sides together
+- Cut **4 fronts** 2 x 2 with good sides together
+- Cut **1 waistband**
 
 ## Caveats
 
--   To save paper, the waistband is not completely printed on the pattern since it's just a long rectangle. So look for the length indicator, and cut out a rectangle of that size.
--   The hem allowance is double the standard seam allowance.
+- To save paper, the waistband is not completely printed on the pattern since it's just a long rectangle. So look for the length indicator, and cut out a rectangle of that size.
+- The hem allowance is double the standard seam allowance.
 
 Shin is a very simply pattern, and consists of two main parts plus the waistband.
 

--- a/markdown/org/docs/patterns/shin/fabric/en.md
+++ b/markdown/org/docs/patterns/shin/fabric/en.md
@@ -2,6 +2,6 @@ Swim trunks should be made out of a material with stretch that is suitable for b
 
 Typically, this falls apart in a few categories:
 
--   Nylon mixed with elastene, spandex, or lycra is soft and stretchy. This is what most casual swimwear is made from.
--   Polyester mixed with PBT (polybutylene terephthalate) is less soft to the touch, but resistant to chlorine and salt water. This is what a lot of competitive swimwear is made from.
--   Neoprene, also known as scuba, is heavier and less tretchy. It's the stuff scuba suits are made from.
+- Nylon mixed with elastene, spandex, or lycra is soft and stretchy. This is what most casual swimwear is made from.
+- Polyester mixed with PBT (polybutylene terephthalate) is less soft to the touch, but resistant to chlorine and salt water. This is what a lot of competitive swimwear is made from.
+- Neoprene, also known as scuba, is heavier and less tretchy. It's the stuff scuba suits are made from.

--- a/markdown/org/docs/patterns/shin/needs/en.md
+++ b/markdown/org/docs/patterns/shin/needs/en.md
@@ -1,8 +1,8 @@
 To make Shin, you will need the following:
 
--   Basic sewing supplies
--   About 0.75 meters (0.8 yards) of a suitable fabric ([see Fabric options](/docs/patterns/shin/fabric))
--   two eyelets and a drawstring
+- Basic sewing supplies
+- About 0.75 meters (0.8 yards) of a suitable fabric ([see Fabric options](/docs/patterns/shin/fabric))
+- two eyelets and a drawstring
 
 > ## A serger/overlock is nice, but optional
 >

--- a/markdown/org/docs/patterns/simon/cutting/en.md
+++ b/markdown/org/docs/patterns/simon/cutting/en.md
@@ -1,22 +1,22 @@
--   **Main fabric**
-    -   Cut **1 front left**
-    -   Cut **1 button placket** (only if you opted for a separate button placket)
-    -   Cut **1 front right**
-    -   Cut **1 buttonhole placket** (only if you opted for a separate buttonhole placket)
-    -   Cut **1 back**
-    -   Cut **1 collar**
-    -   Cut **1 undercollar**
-    -   Cut **2 yoke(s)** or **4 yokes** if you've chosen a split yoke
-    -   Cut **2 sleeve(s)**
-    -   Cut **2 collar stand(s)**
-    -   Cut **2 sleeve placket underlap(s)**
-    -   Cut **2 sleeve placket overlap(s)**
-    -   Cut **4 cuff(s)**
--   **Fusible interfacing**
-    -   Cut **1 collar**
-    -   Cut **1 undercollar**
-    -   Cut **2 collar stand(s)**
-    -   Cut **2 cuff(s)**
+- **Main fabric**
+  - Cut **1 front left**
+  - Cut **1 button placket** (only if you opted for a separate button placket)
+  - Cut **1 front right**
+  - Cut **1 buttonhole placket** (only if you opted for a separate buttonhole placket)
+  - Cut **1 back**
+  - Cut **1 collar**
+  - Cut **1 undercollar**
+  - Cut **2 yoke(s)** or **4 yokes** if you've chosen a split yoke
+  - Cut **2 sleeve(s)**
+  - Cut **2 collar stand(s)**
+  - Cut **2 sleeve placket underlap(s)**
+  - Cut **2 sleeve placket overlap(s)**
+  - Cut **4 cuff(s)**
+- **Fusible interfacing**
+  - Cut **1 collar**
+  - Cut **1 undercollar**
+  - Cut **2 collar stand(s)**
+  - Cut **2 cuff(s)**
 
 <Note>
 
@@ -31,8 +31,8 @@ When you cut them individually, remember that they need to be mirror images of e
 
 ###### Caveats
 
--   The **front right**, **front left**, and **sleeve** have seams that should be made into flat-felled seams. As such, they have extra seam allowance on those seams. When cutting out these pieces, you **must** include this extra seam allowance.
--   The cuff guard and cuff placket have no seam allowance. That is normal, just cut them out as they are drawn on the pattern.
--   Do not cut out the darts in the **back** piece. You should mark them, but not cut them out.
+- The **front right**, **front left**, and **sleeve** have seams that should be made into flat-felled seams. As such, they have extra seam allowance on those seams. When cutting out these pieces, you **must** include this extra seam allowance.
+- The cuff guard and cuff placket have no seam allowance. That is normal, just cut them out as they are drawn on the pattern.
+- Do not cut out the darts in the **back** piece. You should mark them, but not cut them out.
 
 </Warning>

--- a/markdown/org/docs/patterns/simon/instructions/en.md
+++ b/markdown/org/docs/patterns/simon/instructions/en.md
@@ -48,8 +48,8 @@ Place both parts of your cuff (one with interfacing, one without) together with 
 
 > **Ensure you**
 >
-> -   Do not sew together the side that we will attach to the sleeve later
-> -   Stop at the seam allowance distance from the edge on the sleeve side
+> - Do not sew together the side that we will attach to the sleeve later
+> - Stop at the seam allowance distance from the edge on the sleeve side
 
 #### Trim seam allowance
 
@@ -282,9 +282,9 @@ Place your front with the good side down, and press the seam allowance to the bu
 
 Your placket has a bunch of lines on it, so let's first clarify what they are:
 
--   The buttonhole line has long dashes with buttonholes on it. It marks where the buttonholes should go
--   The two fold lines have long dashes and sit at an equal distance right and left of the buttonhole line
--   The two+two sew lines are dotted lines that sit at an equal distance of each fold line
+- The buttonhole line has long dashes with buttonholes on it. It marks where the buttonholes should go
+- The two fold lines have long dashes and sit at an equal distance right and left of the buttonhole line
+- The two+two sew lines are dotted lines that sit at an equal distance of each fold line
 
 #### Trim back seam allowance
 
@@ -388,17 +388,17 @@ Since you've just pressed these shoulder seams, everything should lie nice and f
 ![Press the cuff guard](13b.png)
 ![Edge-stitch the cuff guard in place](13c.png)
 
--   Place your sleeve with the good side down, and your cuff guard on top, also with the good side down.
--   Align the edge of your cuff guard (aka sleeve placket underlap) with the cut in your sleeve, on the side shortest to the side seam.
--   Now sew along the fold line marked on the cuff guard, closest to the edge.
+- Place your sleeve with the good side down, and your cuff guard on top, also with the good side down.
+- Align the edge of your cuff guard (aka sleeve placket underlap) with the cut in your sleeve, on the side shortest to the side seam.
+- Now sew along the fold line marked on the cuff guard, closest to the edge.
 
 > If during cutting out your pattern pieces you had not cut into your sleeve on the line where the sleeve placket needs to be put in, you need to do that first.
 
--   Fold over the cuff guard, and press down this seam.
--   Turn your sleeve over with the good side up, and bring your cuff guard through the slit in your sleeve.
--   Fold it twice on the lines so that the unfinished seam is tucked inwards.
--   Make your folds so that the upper fold sits ever so slightly further than the seam you already made.
--   Press everything down, and then edge-stitch the cuff guard in place.
+- Fold over the cuff guard, and press down this seam.
+- Turn your sleeve over with the good side up, and bring your cuff guard through the slit in your sleeve.
+- Fold it twice on the lines so that the unfinished seam is tucked inwards.
+- Make your folds so that the upper fold sits ever so slightly further than the seam you already made.
+- Press everything down, and then edge-stitch the cuff guard in place.
 
 #### Fold and press the placket
 
@@ -406,10 +406,10 @@ Since you've just pressed these shoulder seams, everything should lie nice and f
 
 Origami time! We're going to fold the sleeve placket overlap using the marked fold lines as our guide. This will be a lot easier if you press between each fold.
 
--   First, fold the outer edges of the placket inwards.
--   Next, fold the entire thing in half.
--   Then, fold down both tips into a nice pointy shape.
--   Now give it a final good press.
+- First, fold the outer edges of the placket inwards.
+- Next, fold the entire thing in half.
+- Then, fold down both tips into a nice pointy shape.
+- Now give it a final good press.
 
 #### Pin placket in place
 
@@ -463,9 +463,9 @@ Now place your sleeve on top with the good side down, matching the top of the sl
 
 You now need to pin the sleeve to the armhole. To do so, make sure to:
 
--   Match the start and end of the sleevehead to the start and end of the armhole
--   Match the notches on the sleevehead to the notches on the back and fronts
--   Distribute the sleevecap ease between the notches as shown
+- Match the start and end of the sleevehead to the start and end of the armhole
+- Match the notches on the sleevehead to the notches on the back and fronts
+- Distribute the sleevecap ease between the notches as shown
 
 #### Distribute sleevecap ease
 

--- a/markdown/org/docs/patterns/simon/needs/en.md
+++ b/markdown/org/docs/patterns/simon/needs/en.md
@@ -1,5 +1,5 @@
 To make Simon, you will need the following:
 
--   About 2 meters (2.2 yards) of a suitable fabric (see [Fabric options](/docs/patterns/simon/fabric/))
--   Buttons
--   Fusible interfacing for collar and cuffs (and possibly for the front placket)
+- About 2 meters (2.2 yards) of a suitable fabric (see [Fabric options](/docs/patterns/simon/fabric/))
+- Buttons
+- Fusible interfacing for collar and cuffs (and possibly for the front placket)

--- a/markdown/org/docs/patterns/simon/options/buttonholeplacketstyle/en.md
+++ b/markdown/org/docs/patterns/simon/options/buttonholeplacketstyle/en.md
@@ -10,7 +10,7 @@ Seamless is less work, and it looks great.
 
 <Note>
 
-As seamless is only possible on a *cut-on* placket, this option is ignored if you choose a seperate buttonhole placket.
+As seamless is only possible on a _cut-on_ placket, this option is ignored if you choose a seperate buttonhole placket.
 
 </Note>
 

--- a/markdown/org/docs/patterns/simon/options/buttonplacketstyle/en.md
+++ b/markdown/org/docs/patterns/simon/options/buttonplacketstyle/en.md
@@ -10,7 +10,7 @@ Seamless is less work, and it looks great.
 
 <Note>
 
-As seamless is only possible on a *cut-on* placket, this option is ignored if you choose a seperate button placket.
+As seamless is only possible on a _cut-on_ placket, this option is ignored if you choose a seperate button placket.
 
 </Note>
 

--- a/markdown/org/docs/patterns/simon/options/cuffdrape/en.md
+++ b/markdown/org/docs/patterns/simon/options/cuffdrape/en.md
@@ -5,7 +5,7 @@ How much the end of the sleeve is wider than the wrist.
 <Note>
 
 This changes the look of the sleeve a bit.
-More drape makes the sleeve wider and gives you a more *blousy* effect, whereas less drape makes the sleeve more narrow.
+More drape makes the sleeve wider and gives you a more _blousy_ effect, whereas less drape makes the sleeve more narrow.
 
 The drape will be worked into the cuff with pleats.
 

--- a/markdown/org/docs/patterns/simon/options/cuffstyle/en.md
+++ b/markdown/org/docs/patterns/simon/options/cuffstyle/en.md
@@ -2,12 +2,12 @@
 
 What style of cuff do you want?
 
--   Rounded barrel cuff
--   Chamfer barrel cuff
--   Straight barrel cuff
--   Rounded French cuff
--   Chamfer French cuff
--   Straight French cuff
+- Rounded barrel cuff
+- Chamfer barrel cuff
+- Straight barrel cuff
+- Rounded French cuff
+- Chamfer French cuff
+- Straight French cuff
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simon/options/hemcurve/en.md
+++ b/markdown/org/docs/patterns/simon/options/hemcurve/en.md
@@ -4,9 +4,9 @@ How much do you want the hem to curve upwards?
 
 <Note>
 
--   This applies only to the baseball and slashed hem styles. If you chose a straight hem, this will be ignored.
--   This value can never be more than the length bonus. If it is, it will silently be set to the length bonus value.
--   If you set this to zero, you'll get a straight hem regardless of what hem style you pick.
+- This applies only to the baseball and slashed hem styles. If you chose a straight hem, this will be ignored.
+- This value can never be more than the length bonus. If it is, it will silently be set to the length bonus value.
+- If you set this to zero, you'll get a straight hem regardless of what hem style you pick.
 
 </Note>
 

--- a/markdown/org/docs/patterns/simon/options/hemstyle/en.md
+++ b/markdown/org/docs/patterns/simon/options/hemstyle/en.md
@@ -2,9 +2,9 @@
 
 What style of hem line do you want?
 
--   Straight
--   Baseball
--   Slashed
+- Straight
+- Baseball
+- Slashed
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simon/options/roundback/en.md
+++ b/markdown/org/docs/patterns/simon/options/roundback/en.md
@@ -3,8 +3,8 @@
 
 Controls how round the back yoke seam is by adding length to the center back at the yoke that tapers of towards the sides.
 
--   Increase this option to round the back yoke seam
--   Decrease this option to straighten the back yoke seam
+- Increase this option to round the back yoke seam
+- Decrease this option to straighten the back yoke seam
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simon/options/s3armhole/en.md
+++ b/markdown/org/docs/patterns/simon/options/s3armhole/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the armhole side.
 
--   Increase this option to shift the shoulder seam forward on the armhole side
--   Decrease this option to shift the shoulder seam backward on the armhole side
+- Increase this option to shift the shoulder seam forward on the armhole side
+- Decrease this option to shift the shoulder seam backward on the armhole side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simon/options/s3collar/en.md
+++ b/markdown/org/docs/patterns/simon/options/s3collar/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the collar side.
 
--   Increase this option to shift the shoulder seam forward on the collar side
--   Decrease this option to shift the shoulder seam backward on the collar side
+- Increase this option to shift the shoulder seam forward on the collar side
+- Decrease this option to shift the shoulder seam backward on the collar side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simon/options/yokeheight/en.md
+++ b/markdown/org/docs/patterns/simon/options/yokeheight/en.md
@@ -1,7 +1,7 @@
 Controls the height of the yoke seam.
 
--   Increase this option to lower the height and lengthen the yoke
--   Decrease this option to raise the height and shorten the yoke
+- Increase this option to lower the height and lengthen the yoke
+- Decrease this option to raise the height and shorten the yoke
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simone/instructions/en.md
+++ b/markdown/org/docs/patterns/simone/instructions/en.md
@@ -1,6 +1,6 @@
 ### Step 1: Bust Darts
 
--   Close the Front bust darts.
+- Close the Front bust darts.
 
 ### Step 2: Follow Simon's Instructions
 

--- a/markdown/org/docs/patterns/simone/options/bustdartangle/en.md
+++ b/markdown/org/docs/patterns/simone/options/bustdartangle/en.md
@@ -1,7 +1,7 @@
 Controls the angle by which the (side) bust dart slopes downward.
 
--   Increase this option to angle the bust darts downwards and towards the floor
--   Decrease this option to angle the bust darts upwards and towards the armscye
+- Increase this option to angle the bust darts downwards and towards the floor
+- Decrease this option to angle the bust darts upwards and towards the armscye
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simone/options/bustdartlength/en.md
+++ b/markdown/org/docs/patterns/simone/options/bustdartlength/en.md
@@ -1,7 +1,7 @@
 Controls how close the **bust darts** approach the bust points.
 
--   Increase this option to lengthen the bust darts moving them closer to the bust points
--   Decrease this option to shorten the bust darts moving them further away from the bust points
+- Increase this option to lengthen the bust darts moving them closer to the bust points
+- Decrease this option to shorten the bust darts moving them further away from the bust points
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simone/options/buttonholeplacketstyle/en.md
+++ b/markdown/org/docs/patterns/simone/options/buttonholeplacketstyle/en.md
@@ -10,7 +10,7 @@ Seamless is less work, and it looks great.
 
 <Note>
 
-As seamless is only possible on a *cut-on* placket, this option is ignored if you choose a seperate buttonhole placket.
+As seamless is only possible on a _cut-on_ placket, this option is ignored if you choose a seperate buttonhole placket.
 
 </Note>
 

--- a/markdown/org/docs/patterns/simone/options/buttonplacketstyle/en.md
+++ b/markdown/org/docs/patterns/simone/options/buttonplacketstyle/en.md
@@ -10,7 +10,7 @@ Seamless is less work, and it looks great.
 
 <Note>
 
-As seamless is only possible on a *cut-on* placket, this option is ignored if you choose a seperate button placket.
+As seamless is only possible on a _cut-on_ placket, this option is ignored if you choose a seperate button placket.
 
 </Note>
 

--- a/markdown/org/docs/patterns/simone/options/contour/en.md
+++ b/markdown/org/docs/patterns/simone/options/contour/en.md
@@ -1,7 +1,7 @@
 Controls how sharply the extra room for breasts is removed again below the chest.
 
--   Increase this option to sharpen the curve below the bust darts
--   Decrease this option to loosen the curve below the bust darts
+- Increase this option to sharpen the curve below the bust darts
+- Decrease this option to loosen the curve below the bust darts
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simone/options/cuffdrape/en.md
+++ b/markdown/org/docs/patterns/simone/options/cuffdrape/en.md
@@ -5,7 +5,7 @@ How much the end of the sleeve is wider than the wrist.
 <Note>
 
 This changes the look of the sleeve a bit.
-More drape makes the sleeve wider and gives you a more *blousy* effect, whereas less drape makes the sleeve more narrow.
+More drape makes the sleeve wider and gives you a more _blousy_ effect, whereas less drape makes the sleeve more narrow.
 
 The drape will be worked into the cuff with pleats.
 

--- a/markdown/org/docs/patterns/simone/options/cuffstyle/en.md
+++ b/markdown/org/docs/patterns/simone/options/cuffstyle/en.md
@@ -2,12 +2,12 @@
 
 What style of cuff do you want?
 
--   Rounded barrel cuff
--   Chamfer barrel cuff
--   Straight barrel cuff
--   Rounded French cuff
--   Chamfer French cuff
--   Straight French cuff
+- Rounded barrel cuff
+- Chamfer barrel cuff
+- Straight barrel cuff
+- Rounded French cuff
+- Chamfer French cuff
+- Straight French cuff
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simone/options/frontdartlength/en.md
+++ b/markdown/org/docs/patterns/simone/options/frontdartlength/en.md
@@ -1,7 +1,7 @@
 Controls how close the **front waist darts** approach the bust points.
 
--   Increase this option to lengthen the front waist darts moving them closer to the bust points
--   Decrease this option to shorten the front waist darts moving them further away from the bust points
+- Increase this option to lengthen the front waist darts moving them closer to the bust points
+- Decrease this option to shorten the front waist darts moving them further away from the bust points
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simone/options/hemcurve/en.md
+++ b/markdown/org/docs/patterns/simone/options/hemcurve/en.md
@@ -4,9 +4,9 @@ How much do you want the hem to curve upwards?
 
 <Note>
 
--   This applies only to the baseball and slashed hem styles. If you chose a straight hem, this will be ignored.
--   This value can never be more than the length bonus. If it is, it will silently be set to the length bonus value.
--   If you set this to zero, you'll get a straight hem regardless of what hem style you pick.
+- This applies only to the baseball and slashed hem styles. If you chose a straight hem, this will be ignored.
+- This value can never be more than the length bonus. If it is, it will silently be set to the length bonus value.
+- If you set this to zero, you'll get a straight hem regardless of what hem style you pick.
 
 </Note>
 

--- a/markdown/org/docs/patterns/simone/options/hemstyle/en.md
+++ b/markdown/org/docs/patterns/simone/options/hemstyle/en.md
@@ -2,9 +2,9 @@
 
 What style of hem line do you want?
 
--   Straight
--   Baseball
--   Slashed
+- Straight
+- Baseball
+- Slashed
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simone/options/s3armhole/en.md
+++ b/markdown/org/docs/patterns/simone/options/s3armhole/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the armhole side.
 
--   Increase this option to shift the shoulder seam forward on the armhole side
--   Decrease this option to shift the shoulder seam backward on the armhole side
+- Increase this option to shift the shoulder seam forward on the armhole side
+- Decrease this option to shift the shoulder seam backward on the armhole side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simone/options/s3collar/en.md
+++ b/markdown/org/docs/patterns/simone/options/s3collar/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the collar side.
 
--   Increase this option to shift the shoulder seam forward on the collar side
--   Decrease this option to shift the shoulder seam backward on the collar side
+- Increase this option to shift the shoulder seam forward on the collar side
+- Decrease this option to shift the shoulder seam backward on the collar side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/simone/options/yokeheight/en.md
+++ b/markdown/org/docs/patterns/simone/options/yokeheight/en.md
@@ -1,7 +1,7 @@
 Controls the height of the yoke seam.
 
--   Increase this option to lower the height and lengthen the yoke
--   Decrease this option to raise the height and shorten the yoke
+- Increase this option to lower the height and lengthen the yoke
+- Decrease this option to raise the height and shorten the yoke
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/sven/cutting/en.md
+++ b/markdown/org/docs/patterns/sven/cutting/en.md
@@ -1,13 +1,13 @@
 Sven is a very simply pattern, and consists of two main parts plus some strips for the neck and armhole binding.
 
--   **Main fabric**
-    -   Cut **1 back** on the fold
-    -   Cut **1 front** on the fold
-    -   Cut **2 sleeves** with good sides together
--   **Ribbing fabric**
-    -   Cut **1 strip** for the neck opening binding
-    -   Cut **2 strips**  for the cuffs
-    -   Cut **1 strip**  for the hem
+- **Main fabric**
+  - Cut **1 back** on the fold
+  - Cut **1 front** on the fold
+  - Cut **2 sleeves** with good sides together
+- **Ribbing fabric**
+  - Cut **1 strip** for the neck opening binding
+  - Cut **2 strips**  for the cuffs
+  - Cut **1 strip**  for the hem
 
 <Warning>
 

--- a/markdown/org/docs/patterns/sven/instructions/en.md
+++ b/markdown/org/docs/patterns/sven/instructions/en.md
@@ -1,54 +1,54 @@
 ### Step 1: Close shoulder seams
 
--   Place the back and front on top of each other with the good sides toghether.
--   Align the shoulder seam, and sew/serge it at the standard seam allowance.
--   Repeat for the other shoulder seam.
+- Place the back and front on top of each other with the good sides toghether.
+- Align the shoulder seam, and sew/serge it at the standard seam allowance.
+- Repeat for the other shoulder seam.
 
 ### Step 2: Set in the sleeves
 
--   Place your now attached front and back with the good side up.
--   Place a sleeve on top if it with the good side down
--   Align the top of the sleevecap with the shoulder seam, your sleeve should lie over your front/back extending to the other shoulder seam
--   Pin sleeve in place along the entire armhole. There's a bit of sleevecap ease, which means that the sleevehead is slightly longer than the armhole. Ease this in the top part of the sleeve head while pinning.
--   Sew/serge your pinned sleeve in place
--   Repeat for the other sleeve
+- Place your now attached front and back with the good side up.
+- Place a sleeve on top if it with the good side down
+- Align the top of the sleevecap with the shoulder seam, your sleeve should lie over your front/back extending to the other shoulder seam
+- Pin sleeve in place along the entire armhole. There's a bit of sleevecap ease, which means that the sleevehead is slightly longer than the armhole. Ease this in the top part of the sleeve head while pinning.
+- Sew/serge your pinned sleeve in place
+- Repeat for the other sleeve
 
 ### Step 3: Finish the neck binding
 
--   Measure the length of the neck opening
--   Cut a piece of ribbing that is this length and 6cm/2.5inch wide
--   Fold the ribbing double with the good side outward, and pin it to your neckopening starting from the back
--   The cut off side of your ribbing should align with the edge of your neck opening, while the ribbing extends over your sweatshirt
--   Pin the ribbing in place around the neck opening, starting at the back and stretching it gently as you do so
--   First, join the ribbing at center back, with good sides together. As you've been stretching the ribbing as you were pinning it, it will be too long. Simply cut that away
--   Then, sew the ribbing to the neck opening
+- Measure the length of the neck opening
+- Cut a piece of ribbing that is this length and 6cm/2.5inch wide
+- Fold the ribbing double with the good side outward, and pin it to your neckopening starting from the back
+- The cut off side of your ribbing should align with the edge of your neck opening, while the ribbing extends over your sweatshirt
+- Pin the ribbing in place around the neck opening, starting at the back and stretching it gently as you do so
+- First, join the ribbing at center back, with good sides together. As you've been stretching the ribbing as you were pinning it, it will be too long. Simply cut that away
+- Then, sew the ribbing to the neck opening
 
 ### Step 4: Close the side seams and sleeves
 
--   Fold Sven double at the shoulder seams with good sides together
--   Align the side seams and sleeves and pin them together
--   Now, sew the side seam and continue sewing to close the arms all the way to the cuff
--   Repeat on the other side
+- Fold Sven double at the shoulder seams with good sides together
+- Align the side seams and sleeves and pin them together
+- Now, sew the side seam and continue sewing to close the arms all the way to the cuff
+- Repeat on the other side
 
 ### Step 5: Attach the cuffs
 
--   Measure the width of the sleeve at the cuff
--   Cut a piece of ribbing that is (twice this length - 2cm/1inch) and 7cm/3inch wide
--   Fold the ribbing double along the longest side, and sew together the edge so you have a continous ring
--   Turn your Sven inside-out
--   Fold the ribbing ring with the good side outwards, and slip the folded side into your inside/out Sven sleeve
--   Align the cut off side of the ribbing with the edge of the sleeve and pin it in place. The ribbing is a bit shorter, so stretch it a bit while pinning to work this into the sleeve.
--   Now, sew/serge the ribbing to the sleeve
--   Repeat for the other cuff
+- Measure the width of the sleeve at the cuff
+- Cut a piece of ribbing that is (twice this length - 2cm/1inch) and 7cm/3inch wide
+- Fold the ribbing double along the longest side, and sew together the edge so you have a continous ring
+- Turn your Sven inside-out
+- Fold the ribbing ring with the good side outwards, and slip the folded side into your inside/out Sven sleeve
+- Align the cut off side of the ribbing with the edge of the sleeve and pin it in place. The ribbing is a bit shorter, so stretch it a bit while pinning to work this into the sleeve.
+- Now, sew/serge the ribbing to the sleeve
+- Repeat for the other cuff
 
 ### Step 6: Attach the hem
 
--   Do for the hem as your did for the cuffs
--   Measure the width of Sven at the hem
--   Cut a piece of ribbing that 1.9 times this length and 7cm/3inch wide
--   You may need to attach different pieces if your ribbing fabric isn't wide enough
--   Fold the ribbing double along the longest side, and sew together the edge so you have a continous ring
--   Turn your Sven inside-out
--   Fold the ribbing ring with the good side outwards, and slip the folded side into your inside/out Sven body
--   Align the cut off side of the ribbing with the edge of the body and pin it in place. The ribbing is a bit shorter, so stretch it a bit while pinning to work this into the body.
--   Now, sew/serge the ribbing to the body
+- Do for the hem as your did for the cuffs
+- Measure the width of Sven at the hem
+- Cut a piece of ribbing that 1.9 times this length and 7cm/3inch wide
+- You may need to attach different pieces if your ribbing fabric isn't wide enough
+- Fold the ribbing double along the longest side, and sew together the edge so you have a continous ring
+- Turn your Sven inside-out
+- Fold the ribbing ring with the good side outwards, and slip the folded side into your inside/out Sven body
+- Align the cut off side of the ribbing with the edge of the body and pin it in place. The ribbing is a bit shorter, so stretch it a bit while pinning to work this into the body.
+- Now, sew/serge the ribbing to the body

--- a/markdown/org/docs/patterns/sven/needs/en.md
+++ b/markdown/org/docs/patterns/sven/needs/en.md
@@ -1,8 +1,8 @@
 To make Sven, you will need the following:
 
--   Basic sewing supplies
--   About 1.75 meters (1.9 yards) of a suitable fabric ([see Fabric options](#fabric-options))
--   Ribbing fabric for the cuffs and neck opening
+- Basic sewing supplies
+- About 1.75 meters (1.9 yards) of a suitable fabric ([see Fabric options](#fabric-options))
+- Ribbing fabric for the cuffs and neck opening
 
 <Note>
 

--- a/markdown/org/docs/patterns/sven/options/s3armhole/en.md
+++ b/markdown/org/docs/patterns/sven/options/s3armhole/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the armhole side.
 
--   Increase this option to shift the shoulder seam forward on the armhole side
--   Decrease this option to shift the shoulder seam backward on the armhole side
+- Increase this option to shift the shoulder seam forward on the armhole side
+- Decrease this option to shift the shoulder seam backward on the armhole side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/sven/options/s3collar/en.md
+++ b/markdown/org/docs/patterns/sven/options/s3collar/en.md
@@ -3,8 +3,8 @@
 
 Controls the shoulder seam location on the collar side.
 
--   Increase this option to shift the shoulder seam forward on the collar side
--   Decrease this option to shift the shoulder seam backward on the collar side
+- Increase this option to shift the shoulder seam forward on the collar side
+- Decrease this option to shift the shoulder seam backward on the collar side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/tamiko/cutting/en.md
+++ b/markdown/org/docs/patterns/tamiko/cutting/en.md
@@ -1,5 +1,5 @@
--   **Main fabric**
-    -   Cut **1 Tamiko top** on the fold
+- **Main fabric**
+  - Cut **1 Tamiko top** on the fold
 
 Tamiko is a zero-waste pattern. It's a rectangle that's cut out on the fold. Not more than that.
 There's only one part to this top, we will simply refer to it at the **Tamiko top**.

--- a/markdown/org/docs/patterns/tamiko/instructions/en.md
+++ b/markdown/org/docs/patterns/tamiko/instructions/en.md
@@ -2,7 +2,7 @@
 
 ![Finsh the armhole seam](step03.png)
 
--   Finish the armhole seam with a narrow hem.
+- Finish the armhole seam with a narrow hem.
 
 ### Step 2: Finish the top
 
@@ -15,7 +15,7 @@ This way, your top can't shift around while we finish it.
 
 </Note>
 
--   Sew the three seamlines that are marked on your draft. F-H, C and I-J in the diagram, represented by lines and notches on the pattern.
+- Sew the three seamlines that are marked on your draft. F-H, C and I-J in the diagram, represented by lines and notches on the pattern.
 
 ### Step 3: Enjoy!
 

--- a/markdown/org/docs/patterns/tamiko/needs/en.md
+++ b/markdown/org/docs/patterns/tamiko/needs/en.md
@@ -1,4 +1,4 @@
 To make Tamiko, you will need the following:
 
--   Basic sewing supplies
--   About 1 meter (1.1 yards) of a suitable fabric ([see Fabric options](/docs/patterns/tamiko/fabric))
+- Basic sewing supplies
+- About 1 meter (1.1 yards) of a suitable fabric ([see Fabric options](/docs/patterns/tamiko/fabric))

--- a/markdown/org/docs/patterns/teagan/cutting/en.md
+++ b/markdown/org/docs/patterns/teagan/cutting/en.md
@@ -1,6 +1,6 @@
 -   Cut 1 back on the fold.
 -   Cut 1 front on the fold.
--   Cut 2 sleeves *with good sides together*
+-   Cut 2 sleeves _with good sides together_
     -   If you cut sleeves separately, remember that one has to be a mirror image of the other.
 -   Cut 1 strip for neck opening. It should be 6 cm wide and the length of your neck opening.
 

--- a/markdown/org/docs/patterns/teagan/cutting/en.md
+++ b/markdown/org/docs/patterns/teagan/cutting/en.md
@@ -1,10 +1,10 @@
--   Cut 1 back on the fold.
--   Cut 1 front on the fold.
--   Cut 2 sleeves _with good sides together_
-    -   If you cut sleeves separately, remember that one has to be a mirror image of the other.
--   Cut 1 strip for neck opening. It should be 6 cm wide and the length of your neck opening.
+- Cut 1 back on the fold.
+- Cut 1 front on the fold.
+- Cut 2 sleeves _with good sides together_
+  - If you cut sleeves separately, remember that one has to be a mirror image of the other.
+- Cut 1 strip for neck opening. It should be 6 cm wide and the length of your neck opening.
 
 ## Caveats
 
--   There is no seam allowance on the neck opening.
--   There is extra hem allowance at the hem and armholes.
+- There is no seam allowance on the neck opening.
+- There is extra hem allowance at the hem and armholes.

--- a/markdown/org/docs/patterns/teagan/instructions/en.md
+++ b/markdown/org/docs/patterns/teagan/instructions/en.md
@@ -2,8 +2,8 @@
 
 ![Close the shoulder seams](step01.svg)
 
--   Place the front and back on top of each other with [good sides together](/docs/sewing/good-sides-together). Align the shoulder seams.
--   Serge the shoulder seams, or stitch them with a narrow (~2 mm) zigzag stitch at the standard seam allowance.
+- Place the front and back on top of each other with [good sides together](/docs/sewing/good-sides-together). Align the shoulder seams.
+- Serge the shoulder seams, or stitch them with a narrow (~2 mm) zigzag stitch at the standard seam allowance.
 
 <Note>
 Optional: In a drapier knit, you may choose to reinforce the shoulder seams by stitching clear elastic along the seam on the inside. On a T-shirt, the shoulder seams support most of the weight of the garment. Reinforcing is not required, but it can keep the shoulder seams from stretching over time.
@@ -13,13 +13,13 @@ Optional: In a drapier knit, you may choose to reinforce the shoulder seams by s
 
 ![Set in sleeves](step02.svg)
 
--   Place your now attached front and back with the good side up.
--   Identify the front and back sides of each of your sleeves. (This is how you separate the left sleeve from the right.) On your paper pattern piece, the front side of the sleeve is to the left.
--   Place a sleeve on top of the front and back, with the good side down.
--   Align the top of the sleevecap with the shoulder seam. Make sure that the front and back of the sleeve are aligned with the front and back pieces of your shirt.
--   Pin sleeve in place along the entire armhole. There’s a bit of sleevecap ease, which means that the sleevehead is slightly longer than the armhole. Ease in the top part of the sleeve head while pinning.
--   Sew/serge your pinned sleeve in place.
--   Repeat for the other sleeve.
+- Place your now attached front and back with the good side up.
+- Identify the front and back sides of each of your sleeves. (This is how you separate the left sleeve from the right.) On your paper pattern piece, the front side of the sleeve is to the left.
+- Place a sleeve on top of the front and back, with the good side down.
+- Align the top of the sleevecap with the shoulder seam. Make sure that the front and back of the sleeve are aligned with the front and back pieces of your shirt.
+- Pin sleeve in place along the entire armhole. There’s a bit of sleevecap ease, which means that the sleevehead is slightly longer than the armhole. Ease in the top part of the sleeve head while pinning.
+- Sew/serge your pinned sleeve in place.
+- Repeat for the other sleeve.
 
 ## Step 3: Sew knit binding to the neck opening.
 
@@ -31,7 +31,7 @@ A more extensive how-to on knit binding can be found in the [Aaron Instuctions](
 
 </Tip>
 
--   We are going to finish the arm and neck hole with [knit binding](/docs/sewing/knit-binding) (note: not a knit band. There’s a difference, and it’s explained [here](/docs/sewing/knit-binding)).
+- We are going to finish the arm and neck hole with [knit binding](/docs/sewing/knit-binding) (note: not a knit band. There’s a difference, and it’s explained [here](/docs/sewing/knit-binding)).
 
 <Note>
 This is the most complex step in making the Teagan T-shirt, but it just requires a bit of practice. Don’t worry, all you need to do is make a couple of these and you’ll be a pro in no time.
@@ -41,24 +41,24 @@ This is the most complex step in making the Teagan T-shirt, but it just requires
 
 ![Place your binding](step03a.svg)
 
--   Put your T-shirt down with the back good side up, and place your binding strip on top of it with the good side down (as in, good sides together). Your binding should start at the center back of the neck opening.
--   Align the long edge of your strip with the edge of your fabric so the strip lies on top of the fabric (not in the opening). Place the corner on your starting point.
--   Now shift your binding strip 1cm beyond your starting point. This little extra will guarantee we can join the two ends later.
+- Put your T-shirt down with the back good side up, and place your binding strip on top of it with the good side down (as in, good sides together). Your binding should start at the center back of the neck opening.
+- Align the long edge of your strip with the edge of your fabric so the strip lies on top of the fabric (not in the opening). Place the corner on your starting point.
+- Now shift your binding strip 1cm beyond your starting point. This little extra will guarantee we can join the two ends later.
 
 ### Sew binding in place
 
 ![Sew binding in place](step03b.svg)
 
--   Place your presser foot 3 cm along the knit binding, so a 3 cm tail will be left unstitched. This will help us join the ends of the binding later. Then, sew 1.5 cm from the edge around the neck opening, stretching the binding gently as you sew.  (Note: this is not the standard seam allowance.)
--   Stop sewing 3 cm before the end, leaving a tail like we did at the beginning.
+- Place your presser foot 3 cm along the knit binding, so a 3 cm tail will be left unstitched. This will help us join the ends of the binding later. Then, sew 1.5 cm from the edge around the neck opening, stretching the binding gently as you sew.  (Note: this is not the standard seam allowance.)
+- Stop sewing 3 cm before the end, leaving a tail like we did at the beginning.
 
 ### Mark and sew binding ends
 
 ![Sew binding ends](step03c.svg)
 
--   With about 6cm left to go before we complete our circle, it’s time to sew the ends of the binding together.
--   Take one of the edges, and stretch it along the 3cm separating it from the start point as you would while sewing. On the binding, mark where the binding reached the start point. Do the same for the other end.
--   Fold your T-shirt in whatever way makes it more easy for you to place both binding ends with good sides together, aligning the marks. Sew them together at the marks.
+- With about 6cm left to go before we complete our circle, it’s time to sew the ends of the binding together.
+- Take one of the edges, and stretch it along the 3cm separating it from the start point as you would while sewing. On the binding, mark where the binding reached the start point. Do the same for the other end.
+- Fold your T-shirt in whatever way makes it more easy for you to place both binding ends with good sides together, aligning the marks. Sew them together at the marks.
 
 <Note>
 
@@ -68,21 +68,21 @@ This is the most complex step in making the Teagan T-shirt, but it just requires
 
 ![Finish binding](step03d.svg)
 
--   Now that your binding ends are joined together, it’s time to finish the last 6cm of binding. Sew it down, staying 1.5cm from the edge as you did before.
+- Now that your binding ends are joined together, it’s time to finish the last 6cm of binding. Sew it down, staying 1.5cm from the edge as you did before.
 
 ### Fold knit binding to the back and sew down
 
 ![Sew down binding](step03e.svg)
 
--   Fold your binding fabric around the fabric of your T-shirt to the back. This is how we’ll sew it down.
--   While the fabric is folded double at the front (hiding the fabric edge in the process), there’s no need for that at the back. We will merely trim back the edge later, given that knit doesn’t ravel. If we were to fold back the fabric at the back too, it would only add bulk.
--   Now you’ll sew the binding down. From the right side of your fabric, sew along the inner edge of your binding (furthest from the edge), making sure to catch the binding at the back in the process.
+- Fold your binding fabric around the fabric of your T-shirt to the back. This is how we’ll sew it down.
+- While the fabric is folded double at the front (hiding the fabric edge in the process), there’s no need for that at the back. We will merely trim back the edge later, given that knit doesn’t ravel. If we were to fold back the fabric at the back too, it would only add bulk.
+- Now you’ll sew the binding down. From the right side of your fabric, sew along the inner edge of your binding (furthest from the edge), making sure to catch the binding at the back in the process.
 
 <Note>
 If you have a coverlock machine, that would be perfect for this seam.
 </Note>
 
--   You’ll have to, once again, stretch your binding a bit while doing this. But this time, there’s an extra caveat to look out for.
+- You’ll have to, once again, stretch your binding a bit while doing this. But this time, there’s an extra caveat to look out for.
 
 <Note>
 
@@ -101,17 +101,17 @@ On the inside of your T-shirt, trim back the knit binding just outside of your s
 
 ![Close the side seams and sleeves](step04.svg)
 
--   Fold your Teagan T-shirt double at the shoulder seams with good sides together.
--   Align the side seams and sleeves and pin them together.
--   Serge/sew the side seam and continue sewing to close the arms all the way to the sleeve hem.
--   Repeat on the other side.
+- Fold your Teagan T-shirt double at the shoulder seams with good sides together.
+- Align the side seams and sleeves and pin them together.
+- Serge/sew the side seam and continue sewing to close the arms all the way to the sleeve hem.
+- Repeat on the other side.
 
 ## Step 5: Finish hem and sleeves
 
 ![Finish hem and sleeves](step05.svg)
 
--   Fold the hem upwards, to the inside, and sew it down. If you have a coverlock, use it. If not, use a twin needle or zig-zag stitch to keep the seam stretchable.
--   Repeat for the hem on each sleeve.
+- Fold the hem upwards, to the inside, and sew it down. If you have a coverlock, use it. If not, use a twin needle or zig-zag stitch to keep the seam stretchable.
+- Repeat for the hem on each sleeve.
 
 <Note>
 

--- a/markdown/org/docs/patterns/teagan/needs/en.md
+++ b/markdown/org/docs/patterns/teagan/needs/en.md
@@ -1,7 +1,7 @@
 To make Teagan, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 1 meter (1.1 yards) of a suitable fabric ([see Fabric options](/docs/patterns/teagan/fabric))
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 1 meter (1.1 yards) of a suitable fabric ([see Fabric options](/docs/patterns/teagan/fabric))
 
 <!--- This link isn't a thing yet, but it follows the site nomenclature, so it should work when everything's up? --->
 

--- a/markdown/org/docs/patterns/theo/cutting/en.md
+++ b/markdown/org/docs/patterns/theo/cutting/en.md
@@ -1,34 +1,34 @@
--   **Main fabric**
-    -   Cut **2 back(s)** with good sides together
-    -   Cut **2 front(s)** with good sides together
-    -   Cut **1 waistband left**
-    -   Cut **1 waistband right**
-    -   Cut **2 fly piece(s)** with good sides together
-    -   Cut **2 side piece(s)** with good sides together
-    -   Cut **4 back pocket facing(s)**
-    -   Cut **8 belt loop(s)**
--   **Lining**
-    -   Cut **2 front lining(s)** with good sides together
-    -   Cut **1 waistband lining left**
-    -   Cut **1 waistband lining right**
-    -   Cut **1 fly shield**
-    -   Cut **4 front pocket bag(s)** 2x2 with good sides together (**see caveats below**)
-    -   Cut **2 back inner pocket bag(s)**
-    -   Cut **2 back outer pocket bag(s)**
--   **Interfacing**
-    -   Cut **1 waistband interfacing left**
-    -   Cut **1 waistband interfacing right**
-    -   Cut **4 back pocket interfacing(s)**
+- **Main fabric**
+  - Cut **2 back(s)** with good sides together
+  - Cut **2 front(s)** with good sides together
+  - Cut **1 waistband left**
+  - Cut **1 waistband right**
+  - Cut **2 fly piece(s)** with good sides together
+  - Cut **2 side piece(s)** with good sides together
+  - Cut **4 back pocket facing(s)**
+  - Cut **8 belt loop(s)**
+- **Lining**
+  - Cut **2 front lining(s)** with good sides together
+  - Cut **1 waistband lining left**
+  - Cut **1 waistband lining right**
+  - Cut **1 fly shield**
+  - Cut **4 front pocket bag(s)** 2x2 with good sides together (**see caveats below**)
+  - Cut **2 back inner pocket bag(s)**
+  - Cut **2 back outer pocket bag(s)**
+- **Interfacing**
+  - Cut **1 waistband interfacing left**
+  - Cut **1 waistband interfacing right**
+  - Cut **4 back pocket interfacing(s)**
 
 <Warning>
 
 ###### Caveats
 
--   The **front lining** is cut from the **front** part on your draft, down to the line just below the knee
--   Pay attention to the grainline on the **fly piece**, **fly shield**, and **side piece**
--   There are two variations of the front pocket bag. You need to cut out two of each:
-    -   Cut two of the complete piece
-    -   Cut two with only extending up to the dashed line at the left
--   The **back inner pocket bag** and **back outer pocket bag** are very similar. Make sure to mark them correctly so you don't confuse them.
+- The **front lining** is cut from the **front** part on your draft, down to the line just below the knee
+- Pay attention to the grainline on the **fly piece**, **fly shield**, and **side piece**
+- There are two variations of the front pocket bag. You need to cut out two of each:
+  - Cut two of the complete piece
+  - Cut two with only extending up to the dashed line at the left
+- The **back inner pocket bag** and **back outer pocket bag** are very similar. Make sure to mark them correctly so you don't confuse them.
 
 </Warning>

--- a/markdown/org/docs/patterns/theo/instructions/en.md
+++ b/markdown/org/docs/patterns/theo/instructions/en.md
@@ -139,9 +139,9 @@ When everything is pinned together, fold away the front piece and lining, and cl
 
 > You can finish the pocket bag in a number of ways, including:
 >
-> -   Serge the sides together
-> -   Finish the edge with bias tape
-> -   Sew the sides together and finish the edge with a zig-zag stitch
+> - Serge the sides together
+> - Finish the edge with bias tape
+> - Sew the sides together and finish the edge with a zig-zag stitch
 
 ### Step 11: Press the front pocket
 
@@ -218,8 +218,8 @@ Take your zip and open it (unzip it). Now turn it over so that it sits with the 
 
 Align your zip with the crotch seam as shown in the illustration. Take the following into account:
 
--   The end of your zip should sit at the top of your trousers where your waistband will start. However, make sure to remember that there is seam allowance there, so don't align it with the top of the front piece, but subtract 1cm seam allowance.
--   Align the zip with the crotch seam. Do not mind the edge of the zip, as they come in different widths. Instead, make sure that you can sew next to the teeth of the zip within the seam allowance of the front piece.
+- The end of your zip should sit at the top of your trousers where your waistband will start. However, make sure to remember that there is seam allowance there, so don't align it with the top of the front piece, but subtract 1cm seam allowance.
+- Align the zip with the crotch seam. Do not mind the edge of the zip, as they come in different widths. Instead, make sure that you can sew next to the teeth of the zip within the seam allowance of the front piece.
 
 Pin the zip in place with a few pins perpendicular to your zip (as shown). In other words, don't pin along the zip, but across the zip.
 
@@ -322,9 +322,9 @@ Last but not least, sew along the zip with your zipper foot to attach it to the 
 
 > When aligning the zip, make sure to take the following into account:
 >
-> -   The zip should be placed with the good side down
-> -   The zip should sit a bit back from the edge of your fly piece
-> -   Make sure to align the top of the zip with the other zip half on the right leg
+> - The zip should be placed with the good side down
+> - The zip should sit a bit back from the edge of your fly piece
+> - Make sure to align the top of the zip with the other zip half on the right leg
 
 ### Step 28: Zig-zag the zip edge to the fly piece
 
@@ -507,11 +507,11 @@ That being said, here's what to do to make a standard belt loop:
 
 Find the belt loop pattern part, a small rectangular piece of fabric. There should be 8 of them, and these will become your belt loops. For each of them, take these steps:
 
--   Zig-zag (or serge) along the longest edges of the rectangle
--   Fold one side back along the length, and press
--   Fold the other side back, along the length, and press
--   Hand sew along the back of the belt loop so that the folded sides stay in place, but the stitches do not show at the front
--   Give it a final good press when you're done
+- Zig-zag (or serge) along the longest edges of the rectangle
+- Fold one side back along the length, and press
+- Fold the other side back, along the length, and press
+- Hand sew along the back of the belt loop so that the folded sides stay in place, but the stitches do not show at the front
+- Give it a final good press when you're done
 
 > While the width of your belt loops is not all that important, it does matter to make sure they are all the same width.
 >

--- a/markdown/org/docs/patterns/theo/instructions/en.md
+++ b/markdown/org/docs/patterns/theo/instructions/en.md
@@ -12,7 +12,7 @@ In this particular case, there's a lot of video material available, but it was o
 
 Many of the steps below are to be repeated for both trouser legs.
 
-That is not always mentioned because life is short and continuously writing *Do not forget to do this for both trouser legs* gets tired really soon.
+That is not always mentioned because life is short and continuously writing _Do not forget to do this for both trouser legs_ gets tired really soon.
 
 </Note>
 
@@ -562,7 +562,7 @@ Before we finalize the waistband, we're going to trim back some of its seam allo
 
 ![Press and baste the waistband lining](step49.png)
 
-The waistband lining will be sewn from the front of the trousers on top of the seam that joins the waistband to the trousers (so called *stitch in the ditch*).
+The waistband lining will be sewn from the front of the trousers on top of the seam that joins the waistband to the trousers (so called _stitch in the ditch_).
 
 Doing so will catch the lining and secure it in place. However, since we'll be sewing this from the good side, the lining will lie beneath all other layers, and we won't see what we're doing.
 

--- a/markdown/org/docs/patterns/theo/needs/en.md
+++ b/markdown/org/docs/patterns/theo/needs/en.md
@@ -1,7 +1,7 @@
 To make Theodore, you will need the following:
 
--   Basic sewing supplies
--   About 2 meters (2.2 yards) of a suitable fabric ([see Fabric options](/docs/patterns/theo/fabric))
--   About 1 meter (1.1 yards) of lining fabric
--   Fusible interfacing for back pockets and waistband
--   A zipper, button and hook for the fly
+- Basic sewing supplies
+- About 2 meters (2.2 yards) of a suitable fabric ([see Fabric options](/docs/patterns/theo/fabric))
+- About 1 meter (1.1 yards) of lining fabric
+- Fusible interfacing for back pockets and waistband
+- A zipper, button and hook for the fly

--- a/markdown/org/docs/patterns/tiberius/cutting/en.md
+++ b/markdown/org/docs/patterns/tiberius/cutting/en.md
@@ -1,14 +1,14 @@
 <Tip>
 
-##### Use the power of the *paperless* option - do *not* print this pattern
+##### Use the power of the _paperless_ option - do _not_ print this pattern
 
 Tiberius is just a big rectangle, so printing the pattern out is a bit of a waste. Save a tree, toggle the [paperless](/docs/guide/options/paperless) option, and copy the dimensions to your fabric, while respecting the grainline.
 
 </Tip>
 
-Tiberius consists of only one part, the *tunica*, that will act as a pattern for both front and back pieces.
+Tiberius consists of only one part, the _tunica_, that will act as a pattern for both front and back pieces.
 
--   cut *2 tunicae*, *on the fold*
+-   cut _2 tunicae_, _on the fold_
 
 <Note>
 

--- a/markdown/org/docs/patterns/tiberius/cutting/en.md
+++ b/markdown/org/docs/patterns/tiberius/cutting/en.md
@@ -8,7 +8,7 @@ Tiberius is just a big rectangle, so printing the pattern out is a bit of a wast
 
 Tiberius consists of only one part, the _tunica_, that will act as a pattern for both front and back pieces.
 
--   cut _2 tunicae_, _on the fold_
+- cut _2 tunicae_, _on the fold_
 
 <Note>
 

--- a/markdown/org/docs/patterns/tiberius/instructions/en.md
+++ b/markdown/org/docs/patterns/tiberius/instructions/en.md
@@ -7,7 +7,7 @@ Tiberius is a historically inspired pattern, and if you want more authenticity, 
 ### Step 1: Sew shoulder seams
 
 -   Put both parts with good sides together. Sew the shoulder seams, taking care to stop at the notches for the head opening.
--   Finish the seams, with a method of your choice. (If you used the fabrics recommended in the [fabric options](/docs/patterns/tiberius/fabric), they *will* fray. Folding the seam allowance twice, enclosing the raw edge and topstitching is an option. You can also use decorative topstitching.)
+-   Finish the seams, with a method of your choice. (If you used the fabrics recommended in the [fabric options](/docs/patterns/tiberius/fabric), they _will_ fray. Folding the seam allowance twice, enclosing the raw edge and topstitching is an option. You can also use decorative topstitching.)
 
 <Note>
 

--- a/markdown/org/docs/patterns/tiberius/instructions/en.md
+++ b/markdown/org/docs/patterns/tiberius/instructions/en.md
@@ -6,8 +6,8 @@ Tiberius is a historically inspired pattern, and if you want more authenticity, 
 
 ### Step 1: Sew shoulder seams
 
--   Put both parts with good sides together. Sew the shoulder seams, taking care to stop at the notches for the head opening.
--   Finish the seams, with a method of your choice. (If you used the fabrics recommended in the [fabric options](/docs/patterns/tiberius/fabric), they _will_ fray. Folding the seam allowance twice, enclosing the raw edge and topstitching is an option. You can also use decorative topstitching.)
+- Put both parts with good sides together. Sew the shoulder seams, taking care to stop at the notches for the head opening.
+- Finish the seams, with a method of your choice. (If you used the fabrics recommended in the [fabric options](/docs/patterns/tiberius/fabric), they _will_ fray. Folding the seam allowance twice, enclosing the raw edge and topstitching is an option. You can also use decorative topstitching.)
 
 <Note>
 
@@ -17,8 +17,8 @@ If you opted for cutting the whole tunica out of one piece, carefully cut out th
 
 ### Step 2: Sew side seams
 
--   Still with good sides together, sew the side seams. Start at the notch for the armhole and work your way down. Take care to align your layers properly.
--   Finish seams.
+- Still with good sides together, sew the side seams. Start at the notch for the armhole and work your way down. Take care to align your layers properly.
+- Finish seams.
 
 ### Step 3: Hem the bottom edge
 

--- a/markdown/org/docs/patterns/tiberius/needs/en.md
+++ b/markdown/org/docs/patterns/tiberius/needs/en.md
@@ -1,5 +1,5 @@
 To make Tiberius, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 2 meters (2.2 yards) of a suitable fabric (see [Fabric options](/docs/patterns/tiberius/fabric))
--   (a belt, for wearing it)
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 2 meters (2.2 yards) of a suitable fabric (see [Fabric options](/docs/patterns/tiberius/fabric))
+- (a belt, for wearing it)

--- a/markdown/org/docs/patterns/titan/cutting/en.md
+++ b/markdown/org/docs/patterns/titan/cutting/en.md
@@ -1,7 +1,7 @@
 **Main fabric**
 
--   Cut **2 front** parts with *good sides together*
--   Cut **2 back** parts with *good sides together*
+-   Cut **2 front** parts with _good sides together_
+-   Cut **2 back** parts with _good sides together_
 
 These cutting instructions are just for the default Titan block. Adjust your cutting accordingly if you have/are making changes to the block.
 

--- a/markdown/org/docs/patterns/titan/cutting/en.md
+++ b/markdown/org/docs/patterns/titan/cutting/en.md
@@ -1,7 +1,7 @@
 **Main fabric**
 
--   Cut **2 front** parts with _good sides together_
--   Cut **2 back** parts with _good sides together_
+- Cut **2 front** parts with _good sides together_
+- Cut **2 back** parts with _good sides together_
 
 These cutting instructions are just for the default Titan block. Adjust your cutting accordingly if you have/are making changes to the block.
 

--- a/markdown/org/docs/patterns/titan/instructions/en.md
+++ b/markdown/org/docs/patterns/titan/instructions/en.md
@@ -15,7 +15,7 @@ Blocks are typically not made as-is but rather serve as a basis for other patter
 -   Join the inseam (the seam the runs along the inside of your legs) of the front and back.
 -   You now have a leg. Repeat for the other leg, **making certain they are mirror images of each other**.
 -   Turn one leg with the good side in, and the other with the good side out.
--   Now tuck the *good side out* into the *good side in* leg, so that they have their *good sides together*.
+-   Now tuck the _good side out_ into the _good side in_ leg, so that they have their _good sides together_.
 -   Align and sew the cross seam.
 
 <Note>

--- a/markdown/org/docs/patterns/titan/instructions/en.md
+++ b/markdown/org/docs/patterns/titan/instructions/en.md
@@ -11,12 +11,12 @@ Blocks are typically not made as-is but rather serve as a basis for other patter
 
 ### Step 1: Mock-up Construction
 
--   Join the outseam (the seam that runs along the side of your leg) of the front and back.
--   Join the inseam (the seam the runs along the inside of your legs) of the front and back.
--   You now have a leg. Repeat for the other leg, **making certain they are mirror images of each other**.
--   Turn one leg with the good side in, and the other with the good side out.
--   Now tuck the _good side out_ into the _good side in_ leg, so that they have their _good sides together_.
--   Align and sew the cross seam.
+- Join the outseam (the seam that runs along the side of your leg) of the front and back.
+- Join the inseam (the seam the runs along the inside of your legs) of the front and back.
+- You now have a leg. Repeat for the other leg, **making certain they are mirror images of each other**.
+- Turn one leg with the good side in, and the other with the good side out.
+- Now tuck the _good side out_ into the _good side in_ leg, so that they have their _good sides together_.
+- Align and sew the cross seam.
 
 <Note>
 
@@ -32,9 +32,9 @@ If you are making adjustments you may wish to sew the seams wrong sides together
 
 ### Step 2: Try it on
 
--   Try it on and check the fit by pinning the front closed whilst wearing it.
--   Make any alterations and try it on again.
--   Repeat until you are happy.
+- Try it on and check the fit by pinning the front closed whilst wearing it.
+- Make any alterations and try it on again.
+- Repeat until you are happy.
 
 <Tip>
 
@@ -49,11 +49,11 @@ Sometimes you may need to wear the mock-up for an extended amount of time to get
 Remember to treat Titan as a basis rather than a final product, so adjust what you need to get the desired look.\
 For instance:
 
--   Add a front closure
--   Add pockets
--   Change the pant length
--   Change the pant width
--   Add a waistband
+- Add a front closure
+- Add pockets
+- Change the pant length
+- Change the pant width
+- Add a waistband
 
 It is all up to you! Experiment and go forth!
 
@@ -61,8 +61,8 @@ It is all up to you! Experiment and go forth!
 
 ### Step 3: Make a paper pattern
 
--   Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
--   Now you have a pattern you can use to produce a garment.
+- Once happy with all your changes unpick your mockup and make a paper pattern based off of it.
+- Now you have a pattern you can use to produce a garment.
 
 <Note>
 

--- a/markdown/org/docs/patterns/titan/needs/en.md
+++ b/markdown/org/docs/patterns/titan/needs/en.md
@@ -1,7 +1,7 @@
 To make Titan, you will need the following:
 
--   Basic sewing supplies
--   About 1.5 meters (1.7 yards) of suitable fabric ([see Titan Fabric options](/docs/patterns/titan/fabric))
+- Basic sewing supplies
+- About 1.5 meters (1.7 yards) of suitable fabric ([see Titan Fabric options](/docs/patterns/titan/fabric))
 
 <Note>
 

--- a/markdown/org/docs/patterns/titan/options/waistheight/en.md
+++ b/markdown/org/docs/patterns/titan/options/waistheight/en.md
@@ -1,7 +1,7 @@
 Controls the height of the waist, where:
 
--   100% : The waist of the trousers sits at the waist line
--   0% : The waist of the trousers sits at the hip line
+- 100% : The waist of the trousers sits at the waist line
+- 0% : The waist of the trousers sits at the hip line
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/trayvon/cutting/en.md
+++ b/markdown/org/docs/patterns/trayvon/cutting/en.md
@@ -1,21 +1,21 @@
--   **Main fabric**
-    -   Cut **1 tip**
-    -   Cut **1 tail**
--   **Lining fabric**
-    -   Cut **1 lining tip**
-    -   Cut **1 lining tail**
-    -   Cut **1 loop**
--   **Interfacing**
-    -   Cut **1 interfacing tip**
-    -   Cut **1 interfacing tail**
+- **Main fabric**
+  - Cut **1 tip**
+  - Cut **1 tail**
+- **Lining fabric**
+  - Cut **1 lining tip**
+  - Cut **1 lining tail**
+  - Cut **1 loop**
+- **Interfacing**
+  - Cut **1 interfacing tip**
+  - Cut **1 interfacing tail**
 
 <Warning>
 
 ###### Caveat
 
--   There is no seam allowance on the **interfacing** parts and the **loop**
--   The **lining** **tip** and **tail** have only seam allowance at the tip
--   The **fabric** **tip** and **tail** have only seam allowance at the tip and center
+- There is no seam allowance on the **interfacing** parts and the **loop**
+- The **lining** **tip** and **tail** have only seam allowance at the tip
+- The **fabric** **tip** and **tail** have only seam allowance at the tip and center
 
 </Warning>
 

--- a/markdown/org/docs/patterns/trayvon/needs/en.md
+++ b/markdown/org/docs/patterns/trayvon/needs/en.md
@@ -1,4 +1,4 @@
 To make Trayvon, you will need the following:
 
--   Basic sewing supplies
--   Between 0.5 meters - 1.5 meters (0.6 - 1.7 yards) of a suitable fabric ([see Fabric options](/docs/patterns/trayvon/fabric)), depending on whether you're cutting on the bias, the grain, or the cross-grain.
+- Basic sewing supplies
+- Between 0.5 meters - 1.5 meters (0.6 - 1.7 yards) of a suitable fabric ([see Fabric options](/docs/patterns/trayvon/fabric)), depending on whether you're cutting on the bias, the grain, or the cross-grain.

--- a/markdown/org/docs/patterns/ursula/cutting/en.md
+++ b/markdown/org/docs/patterns/ursula/cutting/en.md
@@ -1,15 +1,15 @@
 Ursula consists of a front, a back, and a lined gusset.
 
--   **Main fabric**
-    -   Cut **1 front**
-    -   Cut **1 back**
-    -   Cut **2 gusset**
+- **Main fabric**
+  - Cut **1 front**
+  - Cut **1 back**
+  - Cut **2 gusset**
 
 <Note>
 
 ##### Notes
 
--   Ursula is a great scrap buster. If you have fabric scraps from making a [Teagan t-shirt](/designs/teagan/) or anything from a jersey fabric that has good stretch, this is a good way to use those up.
--   You can use the same fabric for the whole garment, including the gusset lining. Some people prefer to use a cotton jersey instead to line the gusset. If you want to do that, cut **1 gusset** from your main fabric and **1 gusset** from your lining fabric.
+- Ursula is a great scrap buster. If you have fabric scraps from making a [Teagan t-shirt](/designs/teagan/) or anything from a jersey fabric that has good stretch, this is a good way to use those up.
+- You can use the same fabric for the whole garment, including the gusset lining. Some people prefer to use a cotton jersey instead to line the gusset. If you want to do that, cut **1 gusset** from your main fabric and **1 gusset** from your lining fabric.
 
 </Note>

--- a/markdown/org/docs/patterns/ursula/instructions/en.md
+++ b/markdown/org/docs/patterns/ursula/instructions/en.md
@@ -1,6 +1,6 @@
 ### Step 1: Sew the front to the first gusset piece
 
-Place one of the gusset pieces on the front piece, *good sides together*, so that the crotch seams are aligned. Pin or baste at the seam allowance.
+Place one of the gusset pieces on the front piece, _good sides together_, so that the crotch seams are aligned. Pin or baste at the seam allowance.
 
 ![Sew the front to the first gusset piece](step01.png)
 

--- a/markdown/org/docs/patterns/ursula/needs/en.md
+++ b/markdown/org/docs/patterns/ursula/needs/en.md
@@ -1,8 +1,8 @@
 To make Ursula, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 0.7 meters (0.8 yards) of a suitable fabric (see [Fabric options](/docs/patterns/ursula/fabric))
--   About 3 meters (3.3 yards) of underwear elastic, such as picot elastic or fold over elastic
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 0.7 meters (0.8 yards) of a suitable fabric (see [Fabric options](/docs/patterns/ursula/fabric))
+- About 3 meters (3.3 yards) of underwear elastic, such as picot elastic or fold over elastic
 
 <Tip>
 

--- a/markdown/org/docs/patterns/wahid/cutting/en.md
+++ b/markdown/org/docs/patterns/wahid/cutting/en.md
@@ -1,15 +1,15 @@
 -   **Main fabric**
-    -   Cut **2 front(s)** with *good sides together*
-    -   Cut **2 back(s)** with *good sides together*
-    -   Cut **2 front facing(s)** with *good sides together*
-    -   Cut **2 pocket welt(s)** with *good sides together*
-    -   Cut **2 pocket facing(s)** with *good sides together*
+    -   Cut **2 front(s)** with _good sides together_
+    -   Cut **2 back(s)** with _good sides together_
+    -   Cut **2 front facing(s)** with _good sides together_
+    -   Cut **2 pocket welt(s)** with _good sides together_
+    -   Cut **2 pocket facing(s)** with _good sides together_
 -   **Lining fabric**
-    -   Cut **2 front lining(s)** with *good sides together*
-    -   Cut **2 back(s)** with *good sides together*
-    -   Cut **2 pocket bag(s)** with *good sides together*
+    -   Cut **2 front lining(s)** with _good sides together_
+    -   Cut **2 back(s)** with _good sides together_
+    -   Cut **2 pocket bag(s)** with _good sides together_
 -   **Interfacing**
-    -   Cut **2 front(s)** with *good sides together*
+    -   Cut **2 front(s)** with _good sides together_
     -   Cut **2 pocket interfacing(s)**
 
 <Warning>

--- a/markdown/org/docs/patterns/wahid/cutting/en.md
+++ b/markdown/org/docs/patterns/wahid/cutting/en.md
@@ -1,23 +1,23 @@
--   **Main fabric**
-    -   Cut **2 front(s)** with _good sides together_
-    -   Cut **2 back(s)** with _good sides together_
-    -   Cut **2 front facing(s)** with _good sides together_
-    -   Cut **2 pocket welt(s)** with _good sides together_
-    -   Cut **2 pocket facing(s)** with _good sides together_
--   **Lining fabric**
-    -   Cut **2 front lining(s)** with _good sides together_
-    -   Cut **2 back(s)** with _good sides together_
-    -   Cut **2 pocket bag(s)** with _good sides together_
--   **Interfacing**
-    -   Cut **2 front(s)** with _good sides together_
-    -   Cut **2 pocket interfacing(s)**
+- **Main fabric**
+  - Cut **2 front(s)** with _good sides together_
+  - Cut **2 back(s)** with _good sides together_
+  - Cut **2 front facing(s)** with _good sides together_
+  - Cut **2 pocket welt(s)** with _good sides together_
+  - Cut **2 pocket facing(s)** with _good sides together_
+- **Lining fabric**
+  - Cut **2 front lining(s)** with _good sides together_
+  - Cut **2 back(s)** with _good sides together_
+  - Cut **2 pocket bag(s)** with _good sides together_
+- **Interfacing**
+  - Cut **2 front(s)** with _good sides together_
+  - Cut **2 pocket interfacing(s)**
 
 <Warning>
 
 ###### Caveats
 
--   Do not cut out the **front** dart
--   Do not cut out the **back** dart
--   Watch out for the grainline on the **pocket welt** and **pocket facing**
+- Do not cut out the **front** dart
+- Do not cut out the **back** dart
+- Watch out for the grainline on the **pocket welt** and **pocket facing**
 
 </Warning>

--- a/markdown/org/docs/patterns/wahid/needs/en.md
+++ b/markdown/org/docs/patterns/wahid/needs/en.md
@@ -1,7 +1,7 @@
 To make Wahid, you will need the following:
 
--   Basic sewing supplies
--   About 1 meter (1.1 yards) of a suitable fabric ([see Fabric options](/docs/patterns/wahid/fabric))
--   About 1 meter (1.1 yards) of lining fabric
--   Fusible interfacing
--   Buttons
+- Basic sewing supplies
+- About 1 meter (1.1 yards) of a suitable fabric ([see Fabric options](/docs/patterns/wahid/fabric))
+- About 1 meter (1.1 yards) of lining fabric
+- Fusible interfacing
+- Buttons

--- a/markdown/org/docs/patterns/walburga/cutting/en.md
+++ b/markdown/org/docs/patterns/walburga/cutting/en.md
@@ -1,4 +1,4 @@
-Walburga consists of two parts, a *front* and a *back* piece.
+Walburga consists of two parts, a _front_ and a _back_ piece.
 
 <Tip>
 
@@ -6,8 +6,8 @@ Apart from the cutout for the neck opening, front and back are identical. It is 
 
 </Tip>
 
--   cut *1 front*, *on the fold*
--   cut *1 back*, *on the fold*
+-   cut _1 front_, _on the fold_
+-   cut _1 back_, _on the fold_
 
 ### On Historical Accuracy
 

--- a/markdown/org/docs/patterns/walburga/cutting/en.md
+++ b/markdown/org/docs/patterns/walburga/cutting/en.md
@@ -6,8 +6,8 @@ Apart from the cutout for the neck opening, front and back are identical. It is 
 
 </Tip>
 
--   cut _1 front_, _on the fold_
--   cut _1 back_, _on the fold_
+- cut _1 front_, _on the fold_
+- cut _1 back_, _on the fold_
 
 ### On Historical Accuracy
 

--- a/markdown/org/docs/patterns/walburga/instructions/en.md
+++ b/markdown/org/docs/patterns/walburga/instructions/en.md
@@ -10,11 +10,11 @@ Walburga is a historically inspired pattern, and if you want more authenticity, 
 
 ### Step 2: Finish seams and head opening
 
--   Finish the seams and the raw edges at the head opening, with a method of your choice. (If you used the fabrics recommended in the [fabric options](/docs/patterns/walburga/fabric), they *will* fray. Folding the seam allowance twice, enclosing the raw edge and topstitching is an option. You can also use decorative topstitching.)
+-   Finish the seams and the raw edges at the head opening, with a method of your choice. (If you used the fabrics recommended in the [fabric options](/docs/patterns/walburga/fabric), they _will_ fray. Folding the seam allowance twice, enclosing the raw edge and topstitching is an option. You can also use decorative topstitching.)
 
 ### (Optional) Step 3: Cut slits
 
-*This step is optional, you can also opt not to cut slits. If so, continue with step 4.*
+_This step is optional, you can also opt not to cut slits. If so, continue with step 4._
 
 <Warning>
 

--- a/markdown/org/docs/patterns/walburga/instructions/en.md
+++ b/markdown/org/docs/patterns/walburga/instructions/en.md
@@ -6,11 +6,11 @@ Walburga is a historically inspired pattern, and if you want more authenticity, 
 
 ### Step 1: Sew shoulder seams
 
--   Put front and back pieces with good sides together. Sew the shoulder seams, taking care to stop at the notches for the head opening.
+- Put front and back pieces with good sides together. Sew the shoulder seams, taking care to stop at the notches for the head opening.
 
 ### Step 2: Finish seams and head opening
 
--   Finish the seams and the raw edges at the head opening, with a method of your choice. (If you used the fabrics recommended in the [fabric options](/docs/patterns/walburga/fabric), they _will_ fray. Folding the seam allowance twice, enclosing the raw edge and topstitching is an option. You can also use decorative topstitching.)
+- Finish the seams and the raw edges at the head opening, with a method of your choice. (If you used the fabrics recommended in the [fabric options](/docs/patterns/walburga/fabric), they _will_ fray. Folding the seam allowance twice, enclosing the raw edge and topstitching is an option. You can also use decorative topstitching.)
 
 ### (Optional) Step 3: Cut slits
 
@@ -22,11 +22,11 @@ If you cut slits, there will be no seam (or hem) allowance to finish the edge th
 
 </Warning>
 
--   Cut into your fabric until the notch, both on the front and back piece.
+- Cut into your fabric until the notch, both on the front and back piece.
 
 ### Step 4: Finish edges
 
--   Finish the edges of the garment. This is a good time to use bias tape or similar to enclose the raw edge (especially if you cut slits in step 3). This step can take some time, so be patient.
+- Finish the edges of the garment. This is a good time to use bias tape or similar to enclose the raw edge (especially if you cut slits in step 3). This step can take some time, so be patient.
 
 ### Step 5: That's it!
 

--- a/markdown/org/docs/patterns/walburga/needs/en.md
+++ b/markdown/org/docs/patterns/walburga/needs/en.md
@@ -1,5 +1,5 @@
 To make Walburga, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 1 meter (1.1 yards) of a suitable fabric (see [Fabric options](/docs/patterns/walburga/fabric))
--   (optional) about 3 metres (3.3 yards) of bias tape or trimmings to finsh the raw edges
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 1 meter (1.1 yards) of a suitable fabric (see [Fabric options](/docs/patterns/walburga/fabric))
+- (optional) about 3 metres (3.3 yards) of bias tape or trimmings to finsh the raw edges

--- a/markdown/org/docs/patterns/waralee/cutting/en.md
+++ b/markdown/org/docs/patterns/waralee/cutting/en.md
@@ -13,12 +13,12 @@ You will need to print out the pockets and pocket facings in the traditional way
 
 ### Materials
 
--   **Main fabric**
-    -   Cut **2 pants** parts.
-    -   (Optional) Cut **2 Pocket** parts on the fold.
-    -   Cut **4 backPocket** parts
-    -   Cut **4 frontFacing** parts
-    -   Cut **4 backFacing** parts
+- **Main fabric**
+  - Cut **2 pants** parts.
+  - (Optional) Cut **2 Pocket** parts on the fold.
+  - Cut **4 backPocket** parts
+  - Cut **4 frontFacing** parts
+  - Cut **4 backFacing** parts
 
 <Note>
 

--- a/markdown/org/docs/patterns/waralee/instructions/en.md
+++ b/markdown/org/docs/patterns/waralee/instructions/en.md
@@ -55,8 +55,8 @@ You can use whatever method works best for you. In the version I first made I ju
 
 Now you get to sew the two pants parts together.
 
--   Lay the two pants parts on top of one another with *good sides together* and sew the seam along the cutout.
--   *Finish* this seam and press it.
+-   Lay the two pants parts on top of one another with _good sides together_ and sew the seam along the cutout.
+-   _Finish_ this seam and press it.
 
 ### Step 4: Prepare the four strings
 
@@ -85,7 +85,7 @@ If your material is delicate or flimsy, you can add some interfacing to this to 
 
 </Note>
 
--   Fold them in half along the long side, *good sides together*.
+-   Fold them in half along the long side, _good sides together_.
 -   Stitch the long side and one of the short sides,
 -   Turn the tie right side out.
 

--- a/markdown/org/docs/patterns/waralee/instructions/en.md
+++ b/markdown/org/docs/patterns/waralee/instructions/en.md
@@ -22,7 +22,7 @@ If you're going to make the pockets, make them before putting one piece of fabri
 
 </Note>
 
--   If desired, sew the pockets.
+- If desired, sew the pockets.
 
 <Note>
 
@@ -40,8 +40,8 @@ Explain how to sew the pockets more.
 
 ![Hem the sides and bottom](waralee-hem-sides-and-bottom.png)
 
--   Hem the sides
--   Hem the bottom.
+- Hem the sides
+- Hem the bottom.
 
 <Note>
 
@@ -55,15 +55,15 @@ You can use whatever method works best for you. In the version I first made I ju
 
 Now you get to sew the two pants parts together.
 
--   Lay the two pants parts on top of one another with _good sides together_ and sew the seam along the cutout.
--   _Finish_ this seam and press it.
+- Lay the two pants parts on top of one another with _good sides together_ and sew the seam along the cutout.
+- _Finish_ this seam and press it.
 
 ### Step 4: Prepare the four strings
 
 The strings are just long tubes of fabric.
 
--   Take a quarter of your waist measurement. Add that number to 40cm (17”). Add your seam allowance. This is the length of each string.
--   Cut out four strips of fabric that are that long and 5cm (2”) wide.
+- Take a quarter of your waist measurement. Add that number to 40cm (17”). Add your seam allowance. This is the length of each string.
+- Cut out four strips of fabric that are that long and 5cm (2”) wide.
 
 <Tip>
 
@@ -85,9 +85,9 @@ If your material is delicate or flimsy, you can add some interfacing to this to 
 
 </Note>
 
--   Fold them in half along the long side, _good sides together_.
--   Stitch the long side and one of the short sides,
--   Turn the tie right side out.
+- Fold them in half along the long side, _good sides together_.
+- Stitch the long side and one of the short sides,
+- Turn the tie right side out.
 
 <Tip>
 
@@ -103,10 +103,10 @@ This can be made easier by taking a piece of twine longer than the strips. Lay t
 
 Now it is time to sew the waist band.
 
--   If your fabric is delicate, add interfacing to the wrong side of the pants above the waist band line. (red)
--   Fold the seam allowance in, and then fold along the waist band line. (red)
--   Insert one of the strings you made in the previous step on each side.
--   Sew along the waist band line, and add some additional stitching to make sure those strings are attached well. (blue)
+- If your fabric is delicate, add interfacing to the wrong side of the pants above the waist band line. (red)
+- Fold the seam allowance in, and then fold along the waist band line. (red)
+- Insert one of the strings you made in the previous step on each side.
+- Sew along the waist band line, and add some additional stitching to make sure those strings are attached well. (blue)
 
 <Warning>
 

--- a/markdown/org/docs/patterns/waralee/needs/en.md
+++ b/markdown/org/docs/patterns/waralee/needs/en.md
@@ -1,5 +1,5 @@
 To make Waralee, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 2 meters (2.2 yards) of a suitable fabric ([see Waralee Fabric options](/docs/patterns/waralee/fabric/))
--   Some interfacing for the waistband and pockets (if making pockets).
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 2 meters (2.2 yards) of a suitable fabric ([see Waralee Fabric options](/docs/patterns/waralee/fabric/))
+- Some interfacing for the waistband and pockets (if making pockets).

--- a/markdown/org/docs/patterns/yuri/cutting/en.md
+++ b/markdown/org/docs/patterns/yuri/cutting/en.md
@@ -1,6 +1,6 @@
--   Cut **2 fronts** with *good sides together*
--   Cut **1 back** *on the fold*
--   Cut **2 sleeves** with *good sides together*
--   Cut **2 gussets** *on the fold* with *good sides together*
--   Cut **4 hood sides** 2 x 2 with *good sides together* for the outer hood and inner hood
--   Cut **2 hood centers** with *good sides together*
+-   Cut **2 fronts** with _good sides together_
+-   Cut **1 back** _on the fold_
+-   Cut **2 sleeves** with _good sides together_
+-   Cut **2 gussets** _on the fold_ with _good sides together_
+-   Cut **4 hood sides** 2 x 2 with _good sides together_ for the outer hood and inner hood
+-   Cut **2 hood centers** with _good sides together_

--- a/markdown/org/docs/patterns/yuri/cutting/en.md
+++ b/markdown/org/docs/patterns/yuri/cutting/en.md
@@ -1,6 +1,6 @@
--   Cut **2 fronts** with _good sides together_
--   Cut **1 back** _on the fold_
--   Cut **2 sleeves** with _good sides together_
--   Cut **2 gussets** _on the fold_ with _good sides together_
--   Cut **4 hood sides** 2 x 2 with _good sides together_ for the outer hood and inner hood
--   Cut **2 hood centers** with _good sides together_
+- Cut **2 fronts** with _good sides together_
+- Cut **1 back** _on the fold_
+- Cut **2 sleeves** with _good sides together_
+- Cut **2 gussets** _on the fold_ with _good sides together_
+- Cut **4 hood sides** 2 x 2 with _good sides together_ for the outer hood and inner hood
+- Cut **2 hood centers** with _good sides together_

--- a/markdown/org/docs/patterns/yuri/instructions/en.md
+++ b/markdown/org/docs/patterns/yuri/instructions/en.md
@@ -4,14 +4,14 @@ This pattern can be sewn with or with out a overlocker/serger. To _**Finish**_ s
 
 ##### Finishing Method 1
 
--   Press open the seam allowances.
--   Then on the good side, _**Edgestitch**_ 3mm (1/8 inch) away or closer to both sides of the seam catching the seam allowances underneath.
--   On the wrong side trim the seam allowances close to the edgestitching.
+- Press open the seam allowances.
+- Then on the good side, _**Edgestitch**_ 3mm (1/8 inch) away or closer to both sides of the seam catching the seam allowances underneath.
+- On the wrong side trim the seam allowances close to the edgestitching.
 
 ##### Finishing Method 2
 
--   Sew the seam allowances together with either a ziz-zag, overcast or straight stitch and press to one side.
--   Trim to 1cm (3/8 inch) seam allowance if needed.
+- Sew the seam allowances together with either a ziz-zag, overcast or straight stitch and press to one side.
+- Trim to 1cm (3/8 inch) seam allowance if needed.
 
 </Note>
 
@@ -23,18 +23,18 @@ If using a overlocker/serger you can sew seams which need fininshing in one go r
 
 ## Step 1: Attaching the Gussets
 
--   With the good sides together, sew the gussets to the front panels along the side seams.
--   _**Finish**_ seams.
+- With the good sides together, sew the gussets to the front panels along the side seams.
+- _**Finish**_ seams.
 
 ## Step 2:  Sew the Shoulder Seams
 
--   With good sides together, sew the front pieces to the back along the shoulder seams.
--   _**Finish**_ seams.
+- With good sides together, sew the front pieces to the back along the shoulder seams.
+- _**Finish**_ seams.
 
 ## Step 3: Attach the Sleeves
 
--   With good sides together, matching back notch to back notch and front notch to front notch, sew the sleeves to the body.
--   _**Finish**_ seams.
+- With good sides together, matching back notch to back notch and front notch to front notch, sew the sleeves to the body.
+- _**Finish**_ seams.
 
 <Note>
 
@@ -44,11 +44,11 @@ On the pattern the back notch is marked as a cross-notch (see [our pattern notat
 
 ## Step 4: Hem the Sleeves
 
--   (Optional) Overcast the raw edge of the sleeve.
--   Press the hem allowance to the wrong side of the fabric and baste in place close to the raw edge.
--   On the outside, stitch away from the folded edge, catching the hem allowance underneath using the basting as guide to where the raw edge is.
--   (Optional) On the outside, stitch 6mm (1/4 inch) parallel to original stich along the hem allowance.
--   Remove basting.
+- (Optional) Overcast the raw edge of the sleeve.
+- Press the hem allowance to the wrong side of the fabric and baste in place close to the raw edge.
+- On the outside, stitch away from the folded edge, catching the hem allowance underneath using the basting as guide to where the raw edge is.
+- (Optional) On the outside, stitch 6mm (1/4 inch) parallel to original stich along the hem allowance.
+- Remove basting.
 
 <Note>
 
@@ -60,23 +60,23 @@ This is just one hemming method, if you prefer another way go for it.
 
 ## Step 5: Close the Sides
 
--   With good sides together, matching shoulder seams, start at the sleeve edge and sew the sleeve together than sew the gusset and back together.
--   _**Finish**_ seams.
--   Repeat for remaining sleeve and side opening.
+- With good sides together, matching shoulder seams, start at the sleeve edge and sew the sleeve together than sew the gusset and back together.
+- _**Finish**_ seams.
+- Repeat for remaining sleeve and side opening.
 
 ## Step 6: Hem the Raw Edges
 
--   Fold under and sew the hem on all the raw edges except around the neck edge.
--   Sew the hem from the top of one front, to the bottom of the front, then along the bottom of the gusset, then along the bottom of the back, then along bottom of the other gusset, and then up to the neck of the other front.
+- Fold under and sew the hem on all the raw edges except around the neck edge.
+- Sew the hem from the top of one front, to the bottom of the front, then along the bottom of the gusset, then along the bottom of the back, then along bottom of the other gusset, and then up to the neck of the other front.
 
 ## Step 7: Prepare Lining and Outside Hood
 
 Follow this step twice, once for the outer hood and once for the lining hood.
 
--   With good sides together, sew the long edge of the Hood Centre to the outer edge of one of the Hood Sides.
--   With good sides together, sew the remaining long edge of the Hood Centre to the outer edge of the other Hood Side.
--   Press the seam allowances open.
--   _**Finish**_ seams.
+- With good sides together, sew the long edge of the Hood Centre to the outer edge of one of the Hood Sides.
+- With good sides together, sew the remaining long edge of the Hood Centre to the outer edge of the other Hood Side.
+- Press the seam allowances open.
+- _**Finish**_ seams.
 
 <Note>
 
@@ -86,12 +86,12 @@ It is recommended to use **Finishing Method 1** for this step regardless of whet
 
 ## Step 8: Join Inside and Outside Hood
 
--   With _good sides together_, pin the Outside and Lining Hoods together matching the seams.
--   Sew the pinned edge together.
--   Trim the seam allowance to 1cm (3/8 inch) if your chosen seam allowance is bigger and you have not used and overlocker/serger. Otherwise _do not_ trim the seam.
--   Turn the hood good sides out and press the outer edge flat.
--   On the outside Topstitch along the edge of the hood, about 1.5 - 2cm (5/8 - 3/4 inch) from the edge. Ensure that your topstiching encloses but does not go through the seam allowance of the outer hood edge. This will create a decorative rim, with the enclosed seam allowance making the rim a bit poofy.
--   With raw edges together, overcast the bottom of the hood. You can either do this with an overlocker/serger or a ziz-zag or overcast stitch on a regular machine.
+- With _good sides together_, pin the Outside and Lining Hoods together matching the seams.
+- Sew the pinned edge together.
+- Trim the seam allowance to 1cm (3/8 inch) if your chosen seam allowance is bigger and you have not used and overlocker/serger. Otherwise _do not_ trim the seam.
+- Turn the hood good sides out and press the outer edge flat.
+- On the outside Topstitch along the edge of the hood, about 1.5 - 2cm (5/8 - 3/4 inch) from the edge. Ensure that your topstiching encloses but does not go through the seam allowance of the outer hood edge. This will create a decorative rim, with the enclosed seam allowance making the rim a bit poofy.
+- With raw edges together, overcast the bottom of the hood. You can either do this with an overlocker/serger or a ziz-zag or overcast stitch on a regular machine.
 
 <Note>
 
@@ -102,8 +102,8 @@ If you do not wish to have the decorative rim, you may still want to understitch
 
 ## Step 9: Prepping a Neckband for the Hood (Optional)
 
--   Cut a cross-wise strip of fabric out of your main fabric, your neck opening + 2cm (3/4 inch) long and triple your neck seam allowance wide.
--   Press under 1cm (3/8 inch) allowance on the short sides.
+- Cut a cross-wise strip of fabric out of your main fabric, your neck opening + 2cm (3/4 inch) long and triple your neck seam allowance wide.
+- Press under 1cm (3/8 inch) allowance on the short sides.
 
 <Note>
 
@@ -114,14 +114,14 @@ You can also make a folded band so the neckband does not have a raw edge but thi
 
 ## Step 10: Attach the Hood
 
--   With good sides together, starting from the centre back pin the hood to the neck, matching the centre backs and overlapping the hood ends at the centre front.
--   With good side of neckband to lining side of hood, pin the neckband to the hood matching middle of the neckband to the centre back.
--   If using an overlocker/serger, serge the neck and hood together through all layers.
--   If using a sewing machine, use a zig-zag stich to sew all the neck and hood layers together.
--   On the outside check around the neckline to make sure all the layers are caught.
--   Press seam allowances towards the body.
--   On the good side, topstitch with a straight sitch approximately 1cm (3/8 inch) away from the neck edge towards the body to catch and secure the neckband underneath.
--   Trim the excess binding from the inside.
+- With good sides together, starting from the centre back pin the hood to the neck, matching the centre backs and overlapping the hood ends at the centre front.
+- With good side of neckband to lining side of hood, pin the neckband to the hood matching middle of the neckband to the centre back.
+- If using an overlocker/serger, serge the neck and hood together through all layers.
+- If using a sewing machine, use a zig-zag stich to sew all the neck and hood layers together.
+- On the outside check around the neckline to make sure all the layers are caught.
+- Press seam allowances towards the body.
+- On the good side, topstitch with a straight sitch approximately 1cm (3/8 inch) away from the neck edge towards the body to catch and secure the neckband underneath.
+- Trim the excess binding from the inside.
 
 <Warning>
 
@@ -138,10 +138,10 @@ If you are not using a neckband you will want to finish the seam with **Finishin
 
 ## Step 11: Buttons and buttonholes
 
--   At the buttonhole marks on the front panels, sew button holes for 2.5cm (1 inch) buttons or button size of your choosing.
--   For button placement you may want to try your Yuri on and see where the buttons fit the best for you.
--   Alternatively you can use the button markings on the pattern for placement.
--   Attach the buttons.
+- At the buttonhole marks on the front panels, sew button holes for 2.5cm (1 inch) buttons or button size of your choosing.
+- For button placement you may want to try your Yuri on and see where the buttons fit the best for you.
+- Alternatively you can use the button markings on the pattern for placement.
+- Attach the buttons.
 
 ## Step 12 : Ta-daaa
 

--- a/markdown/org/docs/patterns/yuri/instructions/en.md
+++ b/markdown/org/docs/patterns/yuri/instructions/en.md
@@ -1,11 +1,11 @@
 <Note>
 
-This pattern can be sewn with or with out a overlocker/serger. To ***Finish*** seams without a overlocker/serger you can either use your prefered method or one of the methods below:
+This pattern can be sewn with or with out a overlocker/serger. To _**Finish**_ seams without a overlocker/serger you can either use your prefered method or one of the methods below:
 
 ##### Finishing Method 1
 
 -   Press open the seam allowances.
--   Then on the good side, ***Edgestitch*** 3mm (1/8 inch) away or closer to both sides of the seam catching the seam allowances underneath.
+-   Then on the good side, _**Edgestitch**_ 3mm (1/8 inch) away or closer to both sides of the seam catching the seam allowances underneath.
 -   On the wrong side trim the seam allowances close to the edgestitching.
 
 ##### Finishing Method 2
@@ -24,17 +24,17 @@ If using a overlocker/serger you can sew seams which need fininshing in one go r
 ## Step 1: Attaching the Gussets
 
 -   With the good sides together, sew the gussets to the front panels along the side seams.
--   ***Finish*** seams.
+-   _**Finish**_ seams.
 
 ## Step 2:  Sew the Shoulder Seams
 
 -   With good sides together, sew the front pieces to the back along the shoulder seams.
--   ***Finish*** seams.
+-   _**Finish**_ seams.
 
 ## Step 3: Attach the Sleeves
 
 -   With good sides together, matching back notch to back notch and front notch to front notch, sew the sleeves to the body.
--   ***Finish*** seams.
+-   _**Finish**_ seams.
 
 <Note>
 
@@ -61,7 +61,7 @@ This is just one hemming method, if you prefer another way go for it.
 ## Step 5: Close the Sides
 
 -   With good sides together, matching shoulder seams, start at the sleeve edge and sew the sleeve together than sew the gusset and back together.
--   ***Finish*** seams.
+-   _**Finish**_ seams.
 -   Repeat for remaining sleeve and side opening.
 
 ## Step 6: Hem the Raw Edges
@@ -76,7 +76,7 @@ Follow this step twice, once for the outer hood and once for the lining hood.
 -   With good sides together, sew the long edge of the Hood Centre to the outer edge of one of the Hood Sides.
 -   With good sides together, sew the remaining long edge of the Hood Centre to the outer edge of the other Hood Side.
 -   Press the seam allowances open.
--   ***Finish*** seams.
+-   _**Finish**_ seams.
 
 <Note>
 
@@ -86,9 +86,9 @@ It is recommended to use **Finishing Method 1** for this step regardless of whet
 
 ## Step 8: Join Inside and Outside Hood
 
--   With *good sides together*, pin the Outside and Lining Hoods together matching the seams.
+-   With _good sides together_, pin the Outside and Lining Hoods together matching the seams.
 -   Sew the pinned edge together.
--   Trim the seam allowance to 1cm (3/8 inch) if your chosen seam allowance is bigger and you have not used and overlocker/serger. Otherwise *do not* trim the seam.
+-   Trim the seam allowance to 1cm (3/8 inch) if your chosen seam allowance is bigger and you have not used and overlocker/serger. Otherwise _do not_ trim the seam.
 -   Turn the hood good sides out and press the outer edge flat.
 -   On the outside Topstitch along the edge of the hood, about 1.5 - 2cm (5/8 - 3/4 inch) from the edge. Ensure that your topstiching encloses but does not go through the seam allowance of the outer hood edge. This will create a decorative rim, with the enclosed seam allowance making the rim a bit poofy.
 -   With raw edges together, overcast the bottom of the hood. You can either do this with an overlocker/serger or a ziz-zag or overcast stitch on a regular machine.

--- a/markdown/org/docs/patterns/yuri/needs/en.md
+++ b/markdown/org/docs/patterns/yuri/needs/en.md
@@ -1,8 +1,8 @@
 To make Yuri, you will need the following:
 
--   [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
--   About 2.5 meters (2.8 yards) of a suitable fabric ([see Fabric options](/docs/patterns/yuri/fabric))
--   2 large buttons
+- [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
+- About 2.5 meters (2.8 yards) of a suitable fabric ([see Fabric options](/docs/patterns/yuri/fabric))
+- 2 large buttons
 
 <Note>
 

--- a/markdown/org/docs/patterns/yuri/options/s3armhole/en.md
+++ b/markdown/org/docs/patterns/yuri/options/s3armhole/en.md
@@ -1,7 +1,7 @@
 Controls the shoulder seam location on the armhole side.
 
--   Increase this option to shift the shoulder seam forward on the armhole side
--   Decrease this option to shift the shoulder seam backward on the armhole side
+- Increase this option to shift the shoulder seam forward on the armhole side
+- Decrease this option to shift the shoulder seam backward on the armhole side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/yuri/options/s3collar/en.md
+++ b/markdown/org/docs/patterns/yuri/options/s3collar/en.md
@@ -1,7 +1,7 @@
 Controls the shoulder seam location on the collar side.
 
--   Increase this option to shift the shoulder seam forward on the collar side
--   Decrease this option to shift the shoulder seam backward on the collar side
+- Increase this option to shift the shoulder seam forward on the collar side
+- Decrease this option to shift the shoulder seam backward on the collar side
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/sewing/basic-sewing-supplies/en.md
+++ b/markdown/org/docs/sewing/basic-sewing-supplies/en.md
@@ -7,13 +7,13 @@ title: Basic sewing supplies
 
 For the sake of clarity, when I refer to basic sewing supplies on this website, I mean the following:
 
--   Tape measure
--   Sewing machine
-    -   Sewing machine needles
-    -   Bobbins
--   Sewing thread
--   Fabric scissors
--   Seam ripper
--   Pins and hand sewing needles
--   Fabric marker/Pencils
--   An iron
+- Tape measure
+- Sewing machine
+  - Sewing machine needles
+  - Bobbins
+- Sewing thread
+- Fabric scissors
+- Seam ripper
+- Pins and hand sewing needles
+- Fabric marker/Pencils
+- An iron

--- a/markdown/org/docs/sewing/basting/en.md
+++ b/markdown/org/docs/sewing/basting/en.md
@@ -11,9 +11,9 @@ It is typically done by hand, but you can also machine baste.
 
 Examples of where basting is commonly used are:
 
--   Basting a seam in place before sewing it
--   Basting an ornament, pocket, or other part in place before attaching it
--   Basting darts or other pattern changes while fitting the garment on a model
+- Basting a seam in place before sewing it
+- Basting an ornament, pocket, or other part in place before attaching it
+- Basting darts or other pattern changes while fitting the garment on a model
 
 Basting is never permanent, but merely a temporary measure to hold things in place.
 

--- a/markdown/org/docs/sewing/double-welt-pockets/en.md
+++ b/markdown/org/docs/sewing/double-welt-pockets/en.md
@@ -24,19 +24,19 @@ David is a friend of the site, and by all measures much better at explaining thi
 
 To make double welt pockets, you will need:
 
--   Basic sewing supplies
--   The fabric or pattern piece you want to make the pocket in
--   Two fabric strips for the welts
--   A strip of interfacing
--   Lining or other suitable fabric for the pocket bag (See fabric and colour options)
--   Facing for the pocket bag, depending on your fabric and colour options
+- Basic sewing supplies
+- The fabric or pattern piece you want to make the pocket in
+- Two fabric strips for the welts
+- A strip of interfacing
+- Lining or other suitable fabric for the pocket bag (See fabric and colour options)
+- Facing for the pocket bag, depending on your fabric and colour options
 
 ### Parameters
 
 Two values determine the size of your double welt pocket. They are:
 
--   The pocket width: This is the width of the opening of the finalized double welt pocket
--   The welt height: This is the height of a single welt, and this half of the height of our double welt pocket
+- The pocket width: This is the width of the opening of the finalized double welt pocket
+- The welt height: This is the height of a single welt, and this half of the height of our double welt pocket
 
 > In the example below, I use a pocket width of 13cm and a welt height of 0.5cm
 
@@ -46,13 +46,13 @@ Two values determine the size of your double welt pocket. They are:
 
 The welts are two rectangular strips of fabric with the following measurements:
 
--   Length: Pocket width + 4cm
--   Width: Welt height x2 + 5cm
+- Length: Pocket width + 4cm
+- Width: Welt height x2 + 5cm
 
 For our example:
 
--   Length: 13cm + 4cm = 17cm
--   Width: (0.5cm x 2) + 5cm = 6cm
+- Length: 13cm + 4cm = 17cm
+- Width: (0.5cm x 2) + 5cm = 6cm
 
 They will form the two narrow strips of fabric that form your double welt pocket.
 
@@ -62,13 +62,13 @@ They will form the two narrow strips of fabric that form your double welt pocket
 
 The pocket interfacing is a single rectangular strip of fusible interfacing with the following measurements:
 
--   Length: Pocket width + 4cm
--   Width: Welt height x2 + 5cm
+- Length: Pocket width + 4cm
+- Width: Welt height x2 + 5cm
 
 For our example:
 
--   Length: 13cm + 4cm = 17cm
--   Width: (0.5cm x 2) + 5cm = 6cm
+- Length: 13cm + 4cm = 17cm
+- Width: (0.5cm x 2) + 5cm = 6cm
 
 > You may have noticed that the interfacing is the same size as a welt
 
@@ -78,13 +78,13 @@ The interfacing is used to stabilize the pocket, and will be fused to the fabric
 
 The (optional) pocket facing is a single rectangular strip of fabric with the following measurements:
 
--   Length: Pocket width + 4cm
--   Width: Welt height x2 + 5cm
+- Length: Pocket width + 4cm
+- Width: Welt height x2 + 5cm
 
 For our example:
 
--   Length: 13cm + 4cm = 17cm
--   Width: (0.5cm x 2) + 5cm = 6cm
+- Length: 13cm + 4cm = 17cm
+- Width: (0.5cm x 2) + 5cm = 6cm
 
 > You may have noticed that the facing is the same size as a welt
 
@@ -115,9 +115,9 @@ Fuse the pocket interfacing to the bad side of your garment, so that it covers t
 
 Mark the welt pocket as follows:
 
--   Mark the pocket width with the vertical lines. Let these lines extend to help you align the welts later
--   Align the center opening of the pocket with a horizontal line. Let it extend to help you align the welts later
--   Mark two horizontal lines parallel to the center line, at an offset equal to the welt height (0.5cm in our example)
+- Mark the pocket width with the vertical lines. Let these lines extend to help you align the welts later
+- Align the center opening of the pocket with a horizontal line. Let it extend to help you align the welts later
+- Mark two horizontal lines parallel to the center line, at an offset equal to the welt height (0.5cm in our example)
 
 The part of the horizontal lines parallel to the center line that fall in between the verticle lines is where we'll sew our welts in place. This is illustrated by the red lines.
 

--- a/markdown/org/docs/sewing/edgestitching/en.md
+++ b/markdown/org/docs/sewing/edgestitching/en.md
@@ -2,7 +2,7 @@
 title: Edgestitching
 ---
 
-Edgestitching is a speficic type of *topstitching*.
+Edgestitching is a speficic type of _topstitching_.
 It is specific because of its location.
 To edgestitch means to topstitch right next to a seam,
 typically about 3mm or 1/8 inch next to it.

--- a/markdown/org/docs/sewing/good-sides-together/en.md
+++ b/markdown/org/docs/sewing/good-sides-together/en.md
@@ -20,7 +20,7 @@ This gives you two pieces that are mirror images of each other.
 
 ##### What if there is not obvious good side?
 
-When cutting out something without an obvious *good* side (like interfacing),
+When cutting out something without an obvious _good_ side (like interfacing),
 what matters is that you cut two mirrored pieces, rather than two identical ones.
 
 </Note>

--- a/markdown/org/docs/sewing/knit-binding/en.md
+++ b/markdown/org/docs/sewing/knit-binding/en.md
@@ -107,12 +107,12 @@ Obviously, that means your shoulder seam will cut through your binding which is 
 
 ### Instead, do this
 
--   Cut your binding as long as the seam it needs to be sewn into. Not 90%, but 100%. This way, you know it's going to be too long, and that's what we want.
--   Mark the place you want your binding to be joined (say center back of the neckline) and place your binding 1cm beyond this point.
--   Start sewing your binding about 3cm or so from this point, and go all the way around. While you do so, make sure to adjust the stretch to whatever the curve requires. There's no tricks for this, you'll have to practice until it comes naturally to you.
--   When you make your way around and get close to the point you marked, stop about 3cm before that.
--   Now your entire binding is attached, apart from a 6cm or so stretch at the back. Pin both edges of your binding good sides together, making is exactly as long as needed and sew them together.
--   Sew the remaining 6cm of your binding.
+- Cut your binding as long as the seam it needs to be sewn into. Not 90%, but 100%. This way, you know it's going to be too long, and that's what we want.
+- Mark the place you want your binding to be joined (say center back of the neckline) and place your binding 1cm beyond this point.
+- Start sewing your binding about 3cm or so from this point, and go all the way around. While you do so, make sure to adjust the stretch to whatever the curve requires. There's no tricks for this, you'll have to practice until it comes naturally to you.
+- When you make your way around and get close to the point you marked, stop about 3cm before that.
+- Now your entire binding is attached, apart from a 6cm or so stretch at the back. Pin both edges of your binding good sides together, making is exactly as long as needed and sew them together.
+- Sew the remaining 6cm of your binding.
 
 This way, there is no guessing how long your binding should be, and the binding seam sits where you want it to sit.
 

--- a/markdown/org/docs/sewing/knit-binding/en.md
+++ b/markdown/org/docs/sewing/knit-binding/en.md
@@ -96,7 +96,7 @@ The length of your knit binding depends on the amount it needs to be stretched. 
 ### Do not do this
 
 There are a bunch of tutorials out on the internet that show you how to sew on knit binding.
-Many of those suggest something like *make the neck binding 90% of the length of the seam you are attaching it to* (the percentage varies).
+Many of those suggest something like _make the neck binding 90% of the length of the seam you are attaching it to_ (the percentage varies).
 
 This idea is that you cut your binding, join its edges, and then sew it in the opening. That is (in my opinion) no good.
 

--- a/markdown/org/docs/sewing/on-the-fold/en.md
+++ b/markdown/org/docs/sewing/on-the-fold/en.md
@@ -2,10 +2,10 @@
 title: On the fold
 ---
 
-When you have a pattern piece that is symmetric, the instructions might tell you that it is to be cut *on the fold*.
+When you have a pattern piece that is symmetric, the instructions might tell you that it is to be cut _on the fold_.
 
 This means that only half the pattern piece is printed, and you should cut it out by folding your fabric, and
-aligning the line that is *on the fold* with the fold line indicated on the pattern.
+aligning the line that is _on the fold_ with the fold line indicated on the pattern.
 
 The fold line is indicated with a double arrow like in this example:
 

--- a/markdown/org/docs/sewing/pinning/en.md
+++ b/markdown/org/docs/sewing/pinning/en.md
@@ -10,9 +10,9 @@ Pinning is used whenever you use sewing pins to hold things in place.
 
 Examples of where pinning is commonly used are:
 
--   Pinning a seam in place before sewing it
--   Pinning an ornament, pocket, or other part in place before attaching it
--   Pinning darts or other pattern changes while fitting the garment on a model
+- Pinning a seam in place before sewing it
+- Pinning an ornament, pocket, or other part in place before attaching it
+- Pinning darts or other pattern changes while fitting the garment on a model
 
 Pinning is never permanent, but merely a temporary measure to hold things in place.
 

--- a/markdown/org/docs/sewing/slipstitch/en.md
+++ b/markdown/org/docs/sewing/slipstitch/en.md
@@ -4,7 +4,7 @@ title: Slipstitch
 
 A slipstitch is a hand-sewing technique that allows you to join layers
 of fabric with a stitch that is invisible from the outside.
-A slipstitch is *slipped* in between the layers of fabric
+A slipstitch is _slipped_ in between the layers of fabric
 where it sews together the seam allowance.
 
 ![A closeup of a slipstitch being made on a seam](slipstitch.jpg)

--- a/markdown/org/docs/various/notation/buttons/en.md
+++ b/markdown/org/docs/various/notation/buttons/en.md
@@ -11,7 +11,7 @@ A button is shown on the left, and a buttonhole on the right
 
 </Legend>
 
-Snaps have a *stud* and *socket* part, and also look like the real thing:
+Snaps have a _stud_ and _socket_ part, and also look like the real thing:
 
 <Legend part="snaps">
 

--- a/markdown/org/docs/various/notation/dimensions/en.md
+++ b/markdown/org/docs/various/notation/dimensions/en.md
@@ -2,7 +2,7 @@
 title: Dimensions
 ---
 
-When you opt for a *paperless* pattern, your pattern will come with dimensions:
+When you opt for a _paperless_ pattern, your pattern will come with dimensions:
 
 <Legend part="dimension">
 

--- a/markdown/org/docs/various/notation/grainline/en.md
+++ b/markdown/org/docs/various/notation/grainline/en.md
@@ -2,7 +2,7 @@
 title: Grainline and cut-on-fold indicator
 ---
 
-Grainlines — a line that indicates the *fabric grain* — look like this:
+Grainlines — a line that indicates the _fabric grain_ — look like this:
 
 <Legend part="grainline">
 

--- a/markdown/org/docs/various/notation/lines/en.md
+++ b/markdown/org/docs/various/notation/lines/en.md
@@ -4,10 +4,10 @@ title: Other lines
 
 Some patterns may have other lines on them, there are 4 additional styles:
 
--   Note
--   Mark
--   Contrast
--   Help
+- Note
+- Mark
+- Contrast
+- Help
 
 They might be used by patterns designers to add additional info, depending on the context.
 

--- a/markdown/org/docs/various/pledge/motivation/en.md
+++ b/markdown/org/docs/various/pledge/motivation/en.md
@@ -32,7 +32,7 @@ And that message is: **Hey, you're doing a worthwhile thing. Keep up the good wo
 
 ##### The value of your money
 
-It is not *just* about the money. But that doesn't mean the money is not important.
+It is not _just_ about the money. But that doesn't mean the money is not important.
 Much to the contrary.
 
 Raising money by doing something I love and then passing it on to charity allows me to sleep at night.
@@ -69,7 +69,7 @@ Sometimes precariously, among the rubble of their bombed hospitals, but always t
 
 I can't think of a single symbol that reminds us that not everything is lost, and there's still good people out there.
 
-It is also one of the few organisations that has the global reach to go and help there where it's needed most. We're used to them working in poverty-stricken regions, but when the COVID-19 pandemic ripped our healthcare systems to shreds, *MSF* stepped up to the plate, deploying their teams in Western Europe, in the US, and anywhere where the need was most acute.
+It is also one of the few organisations that has the global reach to go and help there where it's needed most. We're used to them working in poverty-stricken regions, but when the COVID-19 pandemic ripped our healthcare systems to shreds, _MSF_ stepped up to the plate, deploying their teams in Western Europe, in the US, and anywhere where the need was most acute.
 
 I hope that this explains the choice of Médecins Sans Frontières/Doctors Without Borders as FreeSewing's charity of choice. And I hope you will join us in making the world a little bit better.
 

--- a/markdown/org/docs/various/privacy/account/en.md
+++ b/markdown/org/docs/various/privacy/account/en.md
@@ -5,23 +5,23 @@ order: 30
 
 ##### What personal data do we store?
 
--   Your E-mail address
--   Your username and password
--   Optional: A profile picture, bio, and your social media accounts
+- Your E-mail address
+- Your username and password
+- Optional: A profile picture, bio, and your social media accounts
 
 ##### Why do we need it?
 
--   To authenticate you
--   To be able to contact you when required
--   Optional: We don't need a picture or your social media accounts, but they help to build an on-line community
+- To authenticate you
+- To be able to contact you when required
+- Optional: We don't need a picture or your social media accounts, but they help to build an on-line community
 
 ##### How long do we keep it?
 
--   We keep profile data up to 12 months after your last login, or until you remove it.
+- We keep profile data up to 12 months after your last login, or until you remove it.
 
 ##### Do we share it?
 
--   No, never.
+- No, never.
 
 <Note>
 This data is stored for anybody with an account on our website.

--- a/markdown/org/docs/various/privacy/en.md
+++ b/markdown/org/docs/various/privacy/en.md
@@ -11,10 +11,10 @@ We are confident it will demonstrate our commitment to privacy.
 
 For clarity, we've broken this up in four different types of roles:
 
--   For **visitors of our website**, we store **[visitor data][v]**
--   For **subscribers to our newsletter**, we store **[subscriber data][s]**
--   For **users with an account** on our website, we store **[account data][a]**
--   For **users with an account that contains people**, we store **[people data][p]**
+- For **visitors of our website**, we store **[visitor data][v]**
+- For **subscribers to our newsletter**, we store **[subscriber data][s]**
+- For **users with an account** on our website, we store **[account data][a]**
+- For **users with an account that contains people**, we store **[people data][p]**
 
 Here are the relevant sections:
 
@@ -41,8 +41,8 @@ A more comprehensive overview of this document's history is [available on GitHub
 
 ##### See also
 
--   [Your rights][2]
--   [Your consent][3]
+- [Your rights][2]
+- [Your consent][3]
 
 [1]: https://github.com/freesewing/markdown/commits/develop/org/docs/various/privacy
 

--- a/markdown/org/docs/various/privacy/people/en.md
+++ b/markdown/org/docs/various/privacy/people/en.md
@@ -5,24 +5,24 @@ order: 40
 
 ##### What personal data do we store?
 
--   Body measurements
--   Whether the model has breasts or not
--   Optional: An avatar for the model
+- Body measurements
+- Whether the model has breasts or not
+- Optional: An avatar for the model
 
 ##### Why do we need it?
 
--   We need the body measurements to draft made-to-measure sewing patterns
--   We use the information about whether a model has breasts to only show relevant measurements when configuring the model
--   The model avatar only serves to help you differentiate between your different models
+- We need the body measurements to draft made-to-measure sewing patterns
+- We use the information about whether a model has breasts to only show relevant measurements when configuring the model
+- The model avatar only serves to help you differentiate between your different models
 
 ##### How long do we keep it?
 
--   We keep model data up to 12 months after your last login, or until you remove it.
+- We keep model data up to 12 months after your last login, or until you remove it.
 
 ##### Do we share it?
 
--   We never share personal model data
--   We publish an open data set of measurements, containing fully anonymized data.
+- We never share personal model data
+- We publish an open data set of measurements, containing fully anonymized data.
 
 <Note>
 This data is stored for anybody with an account on our website which contains one or more people.

--- a/markdown/org/docs/various/privacy/subscriber/en.md
+++ b/markdown/org/docs/various/privacy/subscriber/en.md
@@ -5,19 +5,19 @@ order: 20
 
 ##### What personal data do we store?
 
--   Your E-mail address
+- Your E-mail address
 
 ##### Why do we need it?
 
--   To send you our newsletter
+- To send you our newsletter
 
 ##### How long do we keep it?
 
--   As long as you remain subscribed
+- As long as you remain subscribed
 
 ##### Do we share it?
 
--   No, never
+- No, never
 
 <Note> 
 

--- a/markdown/org/docs/various/privacy/visitor/en.md
+++ b/markdown/org/docs/various/privacy/visitor/en.md
@@ -5,19 +5,19 @@ order: 10
 
 ##### What personal data do we store?
 
--   Your IP address
+- Your IP address
 
 ##### Why do we need it?
 
--   Your IP address is logged on our backend systems. We use these logs and the information in them only to diagnose problems.
+- Your IP address is logged on our backend systems. We use these logs and the information in them only to diagnose problems.
 
 ##### How long do we keep it?
 
--   We keep these logs no longer than 6 months.
+- We keep these logs no longer than 6 months.
 
 ##### Do we share it?
 
--   No, never.
+- No, never.
 
 <Note>
 This data is stored for anybody who visits our website or connects to our backend APIs.

--- a/markdown/org/docs/various/sizes/en.md
+++ b/markdown/org/docs/various/sizes/en.md
@@ -4,7 +4,7 @@ title: Sizing tables
 
 FreeSewing does not use sizes. All our patterns are drafted to a set of measurements.
 
-Since version 2.2 however, we do provide *standard sizes*.
+Since version 2.2 however, we do provide _standard sizes_.
 Each size is a set of measurements that is an estimation of what a person with a given
 neck circumference could have as measurements.
 

--- a/markdown/org/ui/errors/broken-draft/en.md
+++ b/markdown/org/ui/errors/broken-draft/en.md
@@ -10,10 +10,10 @@ investigate what exactly went wrong.
 
 The diagnostics data we collect includes:
 
--   Your userid
--   Your Github username (only if you configured it in your profile)
--   The pattern name and version
--   The full set of measurements and options used to create this pattern
+- Your userid
+- Your Github username (only if you configured it in your profile)
+- The pattern name and version
+- The full set of measurements and options used to create this pattern
 
 If you consent to publish this data in the crash report, click the button below.
 

--- a/markdown/org/ui/homepage/designers/en.md
+++ b/markdown/org/ui/homepage/designers/en.md
@@ -6,19 +6,19 @@
 Parametric design refers to the use of parameters or variables to manipulate the outcome
 of a given design within its rules.
 
-In sewing patterns, the *parameters* are what is provided by the user: Their measurements
+In sewing patterns, the _parameters_ are what is provided by the user: Their measurements
 and options that they have selected.\
-The *rules* of the design are what you, the designer, make them.
+The _rules_ of the design are what you, the designer, make them.
 
 #### What does that mean for designers?
 
-When drafting or designing patterns or garments, it is common practice to start with a *fit model*
-(or *dress form*). The measurements of the fit model are used as input in the initial design.
+When drafting or designing patterns or garments, it is common practice to start with a _fit model_
+(or _dress form_). The measurements of the fit model are used as input in the initial design.
 
 Adapting the pattern for a different model is a tedious task, which is why patterns are graded
 up and down to cover different sizes.
 
-But in a parametric sewing pattern, adapting to different sizes or models *just works*.
+But in a parametric sewing pattern, adapting to different sizes or models _just works_.
 
 #### What can FreeSewing do for me?
 

--- a/markdown/org/ui/homepage/makers/en.md
+++ b/markdown/org/ui/homepage/makers/en.md
@@ -3,7 +3,7 @@
 
 #### Sewing patterns made to your measurements
 
-All our patterns are *made-to-measure*.
+All our patterns are _made-to-measure_.
 Not just graded up or down, but actually drafted to your exact specifications, just as you would on paper.
 
 #### Packed with options plus live preview

--- a/markdown/org/ui/homepage/row-1/en.md
+++ b/markdown/org/ui/homepage/row-1/en.md
@@ -3,7 +3,7 @@
 
 #### Sewing patterns made to your measurements
 
-All our patterns are *made-to-measure*.
+All our patterns are _made-to-measure_.
 Not just graded up or down, but actually drafted to your exact specifications, just as you would on paper.
 
 #### Packed with options plus live preview

--- a/markdown/org/ui/homepage/updates/en.md
+++ b/markdown/org/ui/homepage/updates/en.md
@@ -7,7 +7,7 @@
 
 If you're looking for our facemask pattern, follow this link:
 
--   [Face mask pattern and instructions](/blog/facemask-frenzy)
+- [Face mask pattern and instructions](/blog/facemask-frenzy)
 
 ##### Contributor calls
 

--- a/markdown/org/ui/share/en.md
+++ b/markdown/org/ui/share/en.md
@@ -16,7 +16,7 @@ For Instagram, you can use this square image:
 
 The images above are also available in other langauges:
 
--   German: [wide](/share/de.wide.jpg) or [square](/share/de.square.jpg)
--   Spanish: [wide](/share/es.wide.jpg) or [square](/share/es.square.jpg)
--   French: [wide](/share/fr.wide.jpg) or [square](/share/fr.square.jpg)
--   Dutch: [wide](/share/nl.wide.jpg) or [square](/share/nl.square.jpg)
+- German: [wide](/share/de.wide.jpg) or [square](/share/de.square.jpg)
+- Spanish: [wide](/share/es.wide.jpg) or [square](/share/es.square.jpg)
+- French: [wide](/share/fr.wide.jpg) or [square](/share/fr.square.jpg)
+- Dutch: [wide](/share/nl.wide.jpg) or [square](/share/nl.square.jpg)

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "contributors:generate": "all-contributors generate",
     "famadd": "all-contributors add",
     "famgen": "all-contributors generate",
-    "checkdocs": "remark markdown --quiet --frail",
-    "fixdocs": "remark markdown --quiet --frail --output"
+    "checkdocs": "remark ./markdown --quiet --frail",
+    "fixdocs": "remark ./markdown --quiet --frail --output"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This holds two commits:

- b6dab9f8fa9d50307dc15fd70607c4f61be416c4 makes some tweaks to the remark config, specifically:
  - Using `./markdown` rather than `markdown` seems to work better for some reason
  - Ignoring non-English files as they are auto-generated from the English content, so updating them should happen via Crowdin (this should also speed things up)
- e6f1189017651803b2023742834952b0b2f1393d holds the result of the actual linting

This works, but for one thing: 
```
warning  Incorrect list-item indent: remove 2 spaces  list-item-indent  remark-lint
```
There are **2144** warnings, but the **all** seem to be this warning.
So it seems to me that there's an issue with [remark-lint-list-item-indent](https://www.npmjs.com/package/remark-lint-list-item-indent) where it's not fixing the files.

I will open an issue upstream. In the meanwhile, I think we can merge this?
