### PR TITLE
Correcting Yuri's Gusset Seam allowance.

### DIFF
--- a/packages/yuri/src/gusset.js
+++ b/packages/yuri/src/gusset.js
@@ -38,11 +38,11 @@ export default function (part) {
     points.logo = points.title.shift(-75, 100)
     snippets.logo = new Snippet('logo', points.logo)
     if (sa) {
-      paths.sa = paths.hat
-        .offset(sa)
-        .join(paths.curve.offset(3 * sa))
-        .close()
-        .attr('class', 'fabric sa')
+	paths.saBase = new Path()
+	.move(points.right)
+	.line(points.top)
+  .setRender(false)
+	paths.sa = paths.curve.offset(3 * sa).join(paths.saBase.offset(sa)).line(points.top).close().attr('class','fabric sa')
     }
   }
 


### PR DESCRIPTION
As pointed out by sean#4312 in discord https://discord.com/channels/698854858052075530/757632180980547686/959311669841002566 . Yuri's grainline was indicating cut on fold whereas the seam allowance was indicating a seam. After discussing with @hellgy it was determined to be cut on fold and I was giving permission to quickly patch it. 
From:
![image](https://user-images.githubusercontent.com/16866285/161273865-4360a43c-6519-4348-9fb8-3b9ce0063149.png)

To:
![image](https://user-images.githubusercontent.com/16866285/161273702-71f99b1b-3aa7-464f-a955-2b17f9c6f9d0.png)

Note: The difference in letter sizing is due to my components workaround and is not part of this pr.

Changes
- paths.sa has been changed to show cut on fold.

Additions
- Added path.saBase to alter seam allowance correctly.