### PR TITLE
WIP: Conversion to the new `waistToArmhole` measurement

### DIFF
--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -1,5 +1,20 @@
 Unreleased:
 
+  Added:
+    utils:
+      - The `waistToArmhole` measurement is new in the neckstimate method
+    models:
+      - The `waistToArmhole` measurement is new
+
+  Changed:
+    brian:
+      - Brian now uses the `waistToArmhole` measurement to calculate the armhole depth
+      - Brian has a new `armholeHeight` option that controls the height of the armhole
+
+  Deprecated:
+    brian:
+      - The `armholeDepthFactor` option is no longer used, but keps in config for backwards compatibility
+
   Fixed:
     brian:
       - Adde both front and back armhole pitch points

--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -1,6 +1,8 @@
 Unreleased:
 
   Added:
+    brian:
+      - Added the sleeveBulge option
     utils:
       - The `waistToArmhole` measurement is new in the neckstimate method
     models:

--- a/markdown/org/docs/patterns/brian/options/armholeheight/brian_armholeheight_sample.svg
+++ b/markdown/org/docs/patterns/brian/options/armholeheight/brian_armholeheight_sample.svg
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg
+ xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xmlns:freesewing="http://freesewing.org/namespaces/freesewing" class="freesewing" width="0mm" height="0mm" viewBox="0 0 0 0"
+>
+<style type="text/css"> <![CDATA[ 
+text.title-nr{font-size:24pt;font-weight:700;text-anchor:middle;dominant-baseline:reset-size}text.title-name{font-size:7pt;font-weight:500;text-anchor:middle;dominant-baseline:reset-size}text.title-pattern{font-size:4pt;font-weight:500;dominant-baseline:reset-size;text-anchor:middle;font-style:italic}
+  /* Sample classes */
+  svg.freesewing path.sample {
+    stroke-width: 0.75
+  }
+  svg.freesewing path.sample-focus {
+    stroke-width: 1.5; fill: rgba(0,0,0,0.1)
+  }
+
+  /* Paperless grid */
+  svg.freesewing path.grid {
+    fill: none;
+    stroke: #555;
+    stroke-width: 0.3;
+  }
+  svg.freesewing path.gridline {
+    stroke: #555;
+    stroke-width: 0.2;
+  }
+  svg.freesewing path.gridline-lg {
+    stroke: #777;
+    stroke-width: 0.2;
+    stroke-dasharray: 1.5,1.5;
+  }
+  svg.freesewing path.gridline-sm {
+    stroke: #999;
+    stroke-width: 0.1;
+  }
+  svg.freesewing path.gridline-xs {
+    stroke: #999;
+    stroke-width: 0.1;
+    stroke-dasharray: 0.5,0.5;
+  }
+  svg.freesewing path.gridbox {
+    fill: url(#grid);
+  }
+
+  /* Reset */
+  svg.freesewing path,
+  svg.freesewing circle,
+  svg.freesewing rect {
+    fill: none;
+    stroke: none;
+  }
+
+  /* Defaults */
+  svg.freesewing path,
+  svg.freesewing circle {
+    stroke: #000;
+    stroke-opacity: 1;
+    stroke-width: 0.3;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  /* Stroke classes */
+  svg.freesewing .fabric {
+    stroke-width: 0.6;
+    stroke: #212121;
+  }
+  svg.freesewing .lining {
+    stroke-width: 0.6;
+    stroke: #ff5b77;
+  }
+  svg.freesewing .interfacing {
+    stroke-width: 0.6;
+    stroke: #64b5f6;
+  }
+  svg.freesewing .canvas {
+    stroke-width: 0.6;
+    stroke: #ff9000;
+  }
+  svg.freesewing .various {
+    stroke-width: 0.6;
+    stroke: #4caf50;
+  }
+  svg.freesewing .note {
+    stroke-width: 0.4;
+    stroke: #dd60dd;
+  }
+  svg.freesewing .mark {
+    stroke-width: 0.4;
+    stroke: blue;
+  }
+  svg.freesewing .contrast {
+    stroke-width: 0.8;
+    stroke: red;
+  }
+  svg.freesewing .stroke-xs {
+    stroke-width: 0.1;
+  }
+  svg.freesewing .stroke-sm {
+    stroke-width: 0.2;
+  }
+  svg.freesewing .stroke-lg {
+    stroke-width: 0.6;
+  }
+  svg.freesewing .stroke-xl {
+    stroke-width: 1;
+  }
+  svg.freesewing .stroke-xxl,
+  svg.freesewing .stroke-2xl {
+    stroke-width: 2;
+  }
+  svg.freesewing .stroke-3xl {
+    stroke-width: 3;
+  }
+  svg.freesewing .stroke-4xl {
+    stroke-width: 4;
+  }
+
+  svg.freesewing .sa {
+    stroke-dasharray: 0.4, 0.8;
+  }
+  svg.freesewing .help {
+    stroke-width: 0.2;
+    stroke-dasharray: 15, 1.5, 1, 1.5;
+  }
+  svg.freesewing .dotted {
+    stroke-dasharray: 0.4, 0.8;
+  }
+  svg.freesewing .dashed {
+    stroke-dasharray: 1, 1.5;
+  }
+  svg.freesewing .lashed {
+    stroke-dasharray: 6, 6;
+  }
+  svg.freesewing .hidden {
+    stroke: none;
+    fill: none;
+  }
+
+  /* Fill classes */
+  svg.freesewing .fill-fabric {
+    fill: #212121;
+  }
+  svg.freesewing .fill-lining {
+    fill: #ff5b77;
+  }
+  svg.freesewing .fill-interfacing {
+    fill: #64b5f6;
+  }
+  svg.freesewing .fill-canvas {
+    fill: #ff9000;
+  }
+  svg.freesewing .fill-various {
+    fill: #4caf50;
+  }
+  svg.freesewing .fill-note {
+    fill: #dd69dd;
+  }
+  svg.freesewing .fill-mark {
+    fill: blue;
+  }
+  svg.freesewing .fill-contrast {
+    fill: red;
+  }
+
+  /* Text */
+  svg.freesewing text {
+    font-size: 5px;
+    font-family: -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+      Arial, sans-serif;
+    fill: #000;
+    text-anchor: start;
+    font-weight: 200;
+    dominant-baseline: ideographic;
+  }
+  svg.freesewing .text-xs {
+    font-size: 3px;
+  }
+  svg.freesewing .text-sm {
+    font-size: 4px;
+  }
+  svg.freesewing .text-lg {
+    font-size: 7px;
+  }
+  svg.freesewing .text-xl {
+    font-size: 9px;
+  }
+  svg.freesewing .text-xxl {
+    font-size: 12px;
+  }
+
+  svg.freesewing .center {
+    text-anchor: middle;
+  }
+  svg.freesewing .right {
+    text-anchor: end;
+  }
+
+  /* Bartack */
+  svg.freesewing path.bartack {
+    stroke-width: 2;
+    stroke: #fd7e14;
+    stroke-linecap: butt;
+  }
+
+]]>
+</style>
+<script type="text/javascript"> <![CDATA[
+
+]]>
+</script>
+<defs>
+
+<g id="button">
+  <circle
+    cx="0" cy="0" r="3.4"
+    style="stroke:var(--pattern-mark);fill:none;stroke-width:var(--pattern-stroke);"
+  />
+  <circle cx="-1" cy="-1" r="0.5" style="stroke:none;fill:var(--pattern-mark)"/>
+  <circle cx="1"  cy="-1" r="0.5" style="stroke:none;fill:var(--pattern-mark)" />
+  <circle cx="1"  cy="1"  r="0.5" style="stroke:none;fill:var(--pattern-mark)" />
+  <circle cx="-1" cy="1"  r="0.5" style="stroke:none;fill:var(--pattern-mark)" />
+</g>
+<g id="buttonhole">
+  <path
+    style="fill:none;stroke:var(--pattern-mark);stroke-width:var(--pattern-stroke);"
+    d="M -1,-5 L 1,-5 L 1,5 L -1,5 z"
+  />
+</g>
+<g id="buttonhole-start">
+  <path
+    style="fill:none;stroke:var(--pattern-mark);stroke-width:var(--pattern-stroke);"
+    d="M -1,-10 L 1,-10 L 1,0 L -1,0 z"
+  />
+</g>
+<g id="buttonhole-end">
+  <path
+    style="fill:none;stroke:var(--pattern-mark);stroke-width:var(--pattern-stroke);"
+    d="M -1,0 L 1,0 L 1,10 L -1,10 z"
+  />
+</g>
+<radialGradient id="snap-stud-grad" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
+  <stop offset="30%" style="stop-color:rgb(235,235,235); stop-opacity:1"/>
+  <stop offset="80%" style="stop-color:rgb(100,100,100);stop-opacity:1" />
+</radialGradient>
+<g id="snap-stud">
+  <circle id="snap-stud-circle-edge" cx="0" cy="0" r="3.4"
+    style="stroke:#666;fill:#dddddd;stroke-width:0.3;"
+  />
+  <circle id="snap-stud-circle-middle" cx="0" cy="0" r="1.8"
+    style="stroke:none;fill:url(#snap-stud-grad);"
+  />
+  <path
+    id="snap-stud-lines" style="fill:none;stroke:#666; stroke-width:0.2;"
+    d="M -2,0 L -3,0 M 2,0 L 3,0 M 0,2 L 0,3 M 0,-2 L 0,-3 M 1.5,1.5 L 2.1,2.1 M -1.5,1.5 L -2.1,2.1 M -1.5,-1.5 L -2.1,-2.1 M 1.5,-1.5 L 2.1,-2.1"
+  />
+</g>
+<g id="snap-socket">
+  <circle id="snap-socket-circle-edge" cx="0" cy="0" r="3.4"
+    style="stroke:#666;fill:#bbbbbb;stroke-width:0.3;"
+  />
+  <circle id="snap-socket-circle-middle" cx="0" cy="0" r="2"
+    style="stroke:#666;fill:#dddddd; stroke-width:0.4;"
+  />
+  <path
+    style="fill:none;stroke:#666; stroke-width:0.5;"
+    d="M -1.7,-1 L -1.7,1 M 1.7,-1 L 1.7,1" id="snap-socket-lines"
+  />
+</g>
+<marker orient="auto" refY="0.0" refX="0.0" id="cutonfoldFrom" style="overflow:visible;" >
+	<path class="note fill-note" d="M 0,0 L 12,-4 C 10,-2 10,2  12, 4 z" />
+</marker>
+<marker orient="auto" refY="0.0" refX="0.0" id="cutonfoldTo" style="overflow:visible;" >
+	<path class="note fill-note" d="M 0,0 L -12,-4 C -10,-2 -10,2  -12, 4 z" />
+</marker>
+
+<marker orient="auto" refY="0.0" refX="0.0" id="dimensionFrom" style="overflow:visible;"><path class="mark fill-mark" d="M 0,0 L 12,-4 C 10,-2 10,2  12, 4 z" /></marker>
+<marker orient="auto" refY="0.0" refX="0.0" id="dimensionTo" style="overflow:visible;" ><path class="mark fill-mark" d="M 0,0 L -12,-4 C -10,-2 -10,2  -12, 4 z" /></marker>
+
+<marker orient="auto" refY="0.0" refX="0.0" id="grainlineFrom" style="overflow:visible;" >
+	<path class="note fill-note" d="M 0,0 L 12,-4 C 10,-2 10,2  12, 4 z" />
+</marker>
+<marker orient="auto" refY="0.0" refX="0.0" id="grainlineTo" style="overflow:visible;" >
+	<path class="note fill-note" d="M 0,0 L -12,-4 C -10,-2 -10,2  -12, 4 z" />
+</marker>
+<g id="logo" transform="translate(-23 -36)"><path class="logo" stroke="none" fill="currentColor" d="M 35.222,0 C 34.233,0.703 34.284,0.613 33.485,0.874 31.653,1.473 29.896,1.144 27.811,0.97 27.184,0.9 26.562,0.859 25.955,0.855 22.89,0.834 20.287,1.733 19.794,4.243 18.885,4.794 18.049,5.461 17.221,6.129 15.453,7.524 14.122,9.229 13.214,11.284 11.974,14.319 13.094,17.576 13.649,20.652 13.781,21.372 13.919,22.058 13.993,22.323 14.098,22.696 14.283,23.052 14.484,23.372 14.531,23.38 14.779,22.998 14.838,22.829 14.924,22.583 14.915,22.188 14.821,21.848 14.613,21.083 14.415,20.462 14.398,20.15 14.368,19.564 14.482,19.023 14.696,18.755 14.772,18.66 14.946,19.15 14.901,19.332 14.848,19.551 14.808,19.926 14.825,20.099 14.872,20.685 14.958,21.312 15.065,21.86 15.202,22.567 15.261,23.021 15.236,23.197 15.218,23.325 15.158,23.454 14.928,23.85 14.728,24.197 14.624,24.478 14.608,24.726 14.591,24.968 14.664,25.573 14.732,25.721 14.831,25.952 15.129,26.195 15.389,26.255 15.638,26.35 15.763,26.547 15.891,26.768 16.202,27.361 16.442,28.083 16.68,29.171 16.796,29.692 16.893,30.157 16.924,30.401 15.004,30.403 12.545,30.404 10.305,30.404 9.551,30.416 8.189,30.062 6.94,29.98 6.759,28.026 5.901,25.756 4.433,25.624 3.431,25.533 2.6,25.914 1.897,27.497 L 1.917,27.582 C 2.332,27.235 2.77,26.174 4.348,26.247 5.56,26.302 5.964,28.596 6.084,29.976 5.346,30.03 4.718,30.257 4.39,30.824 L 4.383,30.824 C 4.383,30.825 4.383,30.827 4.386,30.829 4.383,30.831 4.383,30.833 4.383,30.835 L 4.39,30.835 C 4.728,31.416 5.379,31.641 6.144,31.686 6.655,46.136 20.238,48 23.95,48 37.798,48 42.646,38.59 43.375,34.863 43.716,36.451 42.642,38.474 42.385,39.967 45.306,36.59 44.778,33.343 44.244,30.077 44.688,30.605 45.289,30.932 46.104,30.751 45.523,30.363 44.735,30.635 44.263,28.998 44.057,28.291 43.879,27.761 43.702,27.316 43.32,25.883 42.778,24.514 42.112,23.18 41.55,21.733 41.921,20.795 41.865,19.553 42.876,22.887 43.508,23.774 44.688,24.123 41.72,20.547 42.736,15.01 41.059,10.068 41.818,10.514 42.684,10.648 43.606,10.103 42.714,9.849 41.824,10.52 40.544,8.639 39.463,6.536 37.897,4.983 35.997,3.613 34.979,2.949 33.849,2.503 32.713,2.089 33.87,1.799 35.162,0.769 35.222,0 z M 33.281,11.107 C 34.805,11.663 36.485,13.775 36.466,15.847 L 36.466,15.933 36.466,15.963 C 36.425,18.777 35.146,20.29 35.2,22.164 35.269,24.371 36.219,25.141 36.408,25.509 36.084,24.148 35.894,22.436 36.322,21.08 36.872,19.336 37.427,17.892 37.387,16.526 37.367,16.206 37.231,15.009 37.14,14.479 38.774,16.837 36.786,20.266 37.358,22.51 38.352,26.419 42.807,26.913 41.481,34.789 40.314,41.713 32.318,46.968 24.122,46.968 18.046,46.968 7.517,43.605 6.997,31.676 8.232,31.588 9.56,31.244 10.305,31.256 12.557,31.256 15.129,31.257 17.067,31.258 17.431,32.9 17.704,33.296 19.085,34.39 20.621,35.598 20.979,35.745 23.251,35.767 25.524,35.79 26.198,35.303 28.403,33.217 28.879,32.659 29.085,31.928 29.316,31.241 31.584,31.22 33.238,31.18 34.865,31.104 36.522,31.029 36.756,31.104 39.426,30.829 36.756,30.554 36.522,30.629 34.865,30.553 33.281,30.481 31.677,30.44 29.508,30.42 29.69,29.603 29.95,28.805 30.227,28.016 30.398,27.551 30.599,27.098 30.805,26.647 L 31.03,26.577 C 31.464,26.423 31.848,26.093 32.001,25.647 32.198,25.056 32.058,24.392 31.677,23.909 31.546,23.728 31.383,23.497 31.316,23.395 31.115,23.077 31.11,22.9 31.28,21.718 31.423,20.728 31.439,20.21 31.34,19.708 31.32,19.421 31.318,18.831 31.309,18.672 31.385,18.714 31.55,19.09 31.717,19.599 31.883,20.11 31.91,20.216 31.948,20.651 31.99,21.145 31.805,21.511 31.653,22.248 31.577,22.628 31.51,22.981 31.51,23.029 31.51,23.08 31.546,23.188 31.584,23.272 31.673,23.46 31.84,23.724 31.871,23.724 32.416,23.123 32.736,22.381 33.021,21.628 33.321,20.776 33.409,19.872 33.619,18.995 33.789,18.231 33.985,17.466 34.046,16.682 34.169,15.152 34.097,14.072 33.759,12.478 33.678,12.118 33.444,11.431 33.281,11.107 z M 27.921,18.644 C 28.506,18.637 29.085,18.708 29.636,18.867 30.385,19.154 30.49,19.823 30.628,20.574 30.705,21.054 30.702,21.399 30.615,21.963 30.554,22.781 30.229,23.414 29.519,23.859 28.448,24.057 27.303,24.248 26.395,23.539 25.633,22.489 25.174,21.162 25.349,19.868 25.46,19.337 25.707,19.061 26.215,18.896 26.762,18.739 27.341,18.653 27.921,18.644 z M 19.038,18.739 C 19.585,18.734 20.138,18.792 20.442,18.986 21.747,19.869 21.328,21.306 20.812,22.567 20.061,24.218 18.437,24.157 16.863,24.144 15.992,23.889 15.912,23.175 15.786,22.412 15.678,21.675 15.448,20.885 15.64,20.144 16.133,18.952 17.935,18.815 19.038,18.739 z M 38.941,18.945 C 38.948,22.118 39.49,23.677 40.578,25.924 39.937,24.701 39.021,24.005 38.68,22.543 38.028,19.72 38.731,19.878 38.941,18.945 z M 23.128,21.243 C 23.3,21.417 23.383,21.657 23.532,21.848 23.647,21.651 23.765,21.455 23.913,21.28 23.99,21.282 24.084,21.434 24.169,21.706 24.533,22.712 24.604,23.819 25.076,24.786 25.517,25.486 24.915,25.894 24.254,25.926 23.772,25.925 23.568,25.596 23.285,25.27 23.212,25.483 23.073,25.62 22.907,25.764 22.485,26.118 21.658,25.987 21.53,25.429 21.7,24.363 22.243,23.384 22.599,22.362 22.776,21.989 22.778,21.703 23.128,21.243 z M 16.936,26.628 C 17.149,26.628 17.734,27.025 17.853,27.249 17.935,27.398 18.122,27.978 18.135,28.119 18.156,28.287 18.105,28.685 18.053,28.793 18.015,28.87 17.986,28.881 17.942,28.831 17.905,28.789 17.415,27.849 17.102,27.227 16.856,26.729 16.83,26.628 16.936,26.628 z M 29.158,26.939 C 29.166,26.94 29.178,26.943 29.189,26.946 29.255,26.973 29.209,27.207 28.961,28.057 28.914,28.313 28.8,28.515 28.633,28.683 28.578,28.683 28.553,28.619 28.467,28.264 28.394,27.961 28.386,27.691 28.437,27.449 28.525,27.146 28.881,27.053 29.158,26.939 z M 27.675,28.792 C 27.696,28.788 27.716,28.799 27.742,28.82 27.832,28.883 27.845,29.049 27.785,29.374 27.712,29.792 27.696,29.838 27.588,29.881 27.541,29.902 27.457,29.917 27.401,29.917 27.3,29.899 27.274,29.817 27.298,29.693 27.298,29.433 27.374,29.207 27.546,28.94 27.611,28.84 27.644,28.797 27.675,28.792 z M 19.042,28.811 C 19.111,28.811 19.319,28.961 19.396,29.065 19.482,29.175 19.58,29.83 19.525,29.943 19.462,30.085 19.154,30.014 19.069,29.837 19.017,29.731 18.894,29.159 18.894,29.023 18.894,28.897 18.955,28.811 19.042,28.811 z M 26.933,28.984 C 27.017,29.104 27.039,29.258 27.021,29.596 L 27.004,29.904 26.916,29.992 C 26.863,30.041 26.773,30.101 26.719,30.126 26.6,30.182 26.509,30.187 26.492,30.142 26.472,30.082 26.506,29.7 26.543,29.571 26.586,29.438 26.779,29.041 26.843,28.957 26.872,28.88 26.906,28.976 26.933,28.984 z M 21.912,28.966 C 22.093,29.012 22.173,29.175 22.272,29.323 L 22.339,29.455 22.245,29.782 C 22.195,29.962 22.142,30.124 22.126,30.142 22.108,30.162 22.041,30.172 21.942,30.171 21.678,30.164 21.648,30.153 21.577,30.045 L 21.511,29.947 21.567,29.672 C 21.648,29.276 21.687,29.157 21.777,29.055 21.824,29 21.871,28.97 21.912,28.966 z M 20.241,29.249 20.39,29.398 20.415,29.735 C 20.428,29.919 20.434,30.09 20.424,30.111 20.415,30.14 20.361,30.148 20.194,30.148 L 19.977,30.148 C 19.861,30.021 19.825,29.866 19.776,29.706 19.662,29.225 19.662,29.006 19.78,28.977 19.973,28.989 20.1,29.129 20.241,29.249 z M 26.041,29.018 C 26.277,29.081 26.23,29.456 26.229,29.724 26.211,30.158 26.194,30.248 26.138,30.304 26.041,30.401 25.771,30.347 25.64,30.203 25.597,30.151 25.593,30.135 25.627,29.924 25.666,29.667 25.716,29.507 25.827,29.287 25.908,29.129 25.984,29.03 26.041,29.018 z M 20.715,29.038 C 20.728,29.037 20.749,29.038 20.769,29.04 20.919,29.052 21.059,29.15 21.183,29.33 L 21.283,29.477 C 21.292,29.718 21.283,29.972 21.24,30.196 21.214,30.209 21.106,30.229 21,30.239 20.816,30.256 20.799,30.252 20.735,30.196 20.646,30.12 20.621,29.979 20.599,29.511 20.586,29.129 20.595,29.044 20.715,29.038 z M 22.984,29.118 C 23.145,29.152 23.247,29.238 23.292,29.379 23.328,29.5 23.35,30.177 23.315,30.224 23.303,30.244 23.227,30.269 23.14,30.28 22.816,30.321 22.53,30.29 22.502,30.213 22.466,30.125 22.707,29.253 22.796,29.145 22.834,29.061 22.926,29.126 22.984,29.118 z M 25.082,29.124 C 25.153,29.117 25.229,29.185 25.303,29.33 25.363,29.451 25.372,29.493 25.372,29.764 25.372,29.98 25.359,30.073 25.336,30.093 25.316,30.109 25.235,30.138 25.149,30.16 24.999,30.199 24.966,30.203 24.919,30.187 L 24.694,30.146 24.711,30.012 C 24.727,29.837 24.842,29.449 24.923,29.281 24.971,29.181 25.026,29.131 25.082,29.124 z M 24.104,29.127 C 24.151,29.125 24.173,29.136 24.203,29.169 24.274,29.253 24.364,29.501 24.421,29.766 24.497,30.139 24.497,30.138 24.334,30.187 24.263,30.209 24.113,30.232 24.006,30.238 23.653,30.256 23.626,30.235 23.669,29.923 23.703,29.645 23.84,29.207 23.899,29.175 23.963,29.141 24.037,29.142 24.104,29.127 z M 6.111,30.536 C 6.114,30.535 6.118,30.536 6.118,30.536 6.127,30.731 6.127,30.928 6.131,31.124 5.636,31.086 5.272,30.968 5.272,30.829 5.272,30.692 5.623,30.575 6.111,30.536 z M 6.976,30.553 C 7.377,30.603 7.654,30.708 7.649,30.829 7.649,30.951 7.381,31.055 6.983,31.104 6.979,30.921 6.979,30.737 6.976,30.553 z M 25.702,31.086 C 25.736,31.083 25.751,31.08 25.803,31.085 26.011,31.106 26.041,31.119 26.041,31.189 26.041,31.281 25.883,31.558 25.776,31.654 25.726,31.702 25.657,31.742 25.633,31.742 25.513,31.742 25.443,31.489 25.499,31.256 25.533,31.13 25.595,31.091 25.702,31.086 z M 24.947,31.169 C 25.04,31.161 25.13,31.186 25.22,31.198 25.194,31.461 25.076,31.676 24.857,31.819 24.803,31.819 24.776,31.716 24.776,31.491 24.776,31.223 24.79,31.172 24.947,31.169 z M 24.119,31.266 C 24.312,31.266 24.482,31.275 24.49,31.286 24.526,31.32 24.422,31.578 24.269,31.84 24.138,32.073 24.119,32.09 24.038,32.096 23.72,32.06 23.729,31.687 23.68,31.431 23.68,31.279 23.714,31.266 24.119,31.266 z M 21.11,31.295 C 21.331,31.299 21.417,31.332 21.417,31.417 21.417,31.525 21.335,31.74 21.288,31.767 21.217,31.806 21.211,31.804 21.071,31.658 20.85,31.41 20.825,31.364 21.11,31.295 z M 22.174,31.306 C 22.178,31.312 22.221,31.39 22.264,31.478 22.358,31.661 22.365,31.741 22.298,31.802 22.14,31.892 22.107,31.841 21.964,31.75 21.798,31.593 21.667,31.382 21.71,31.338 21.858,31.285 22.021,31.305 22.174,31.306 z M 22.596,31.311 22.991,31.318 C 23.145,31.318 23.278,31.326 23.285,31.338 23.312,31.362 23.225,31.876 23.178,31.992 23.124,32.122 22.935,32.123 22.837,31.969 22.697,31.748 22.605,31.562 22.602,31.434 L 22.596,31.311 z" /></g><g id="notch"><circle cy="0" cx="0" r="1.4" class="fill-note" /><circle cy="0" cx="0" r="2.8" class="note" /></g><g id="bnotch"><path d="M -1.1 -1.1 L 1.1 1.1 M 1.1 -1.1 L -1.1 1.1" class="note" /><circle cy="0" cx="0" r="2.8" class="note" /></g>
+</defs>
+
+
+<!-- Start of group #fs-container -->
+<g id="fs-container">
+
+<!-- Start of group #fs-part-back -->
+<g id="fs-part-back" >
+<path  class="fabric" style="stroke: hsl(0, 100%, 35%);" data-sample-run="1" data-sample-runs="10" id="fs-1" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(33, 100%, 35%);" data-sample-run="2" data-sample-runs="10" id="fs-2" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(66, 100%, 35%);" data-sample-run="3" data-sample-runs="10" id="fs-3" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(99, 100%, 35%);" data-sample-run="4" data-sample-runs="10" id="fs-4" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(132, 100%, 35%);" data-sample-run="5" data-sample-runs="10" id="fs-5" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(165, 100%, 35%);" data-sample-run="6" data-sample-runs="10" id="fs-6" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(198, 100%, 35%);" data-sample-run="7" data-sample-runs="10" id="fs-7" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(231, 100%, 35%);" data-sample-run="8" data-sample-runs="10" id="fs-8" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(264, 100%, 35%);" data-sample-run="9" data-sample-runs="10" id="fs-9" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(297, 100%, 35%);" data-sample-run="10" data-sample-runs="10" id="fs-10" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+</g>
+<!-- end of group #fs-part-back -->
+
+<!-- Start of group #fs-part-front -->
+<g id="fs-part-front" >
+<path  class="fabric" style="stroke: hsl(0, 100%, 35%);" data-sample-run="1" data-sample-runs="10" id="fs-11" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(33, 100%, 35%);" data-sample-run="2" data-sample-runs="10" id="fs-12" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(66, 100%, 35%);" data-sample-run="3" data-sample-runs="10" id="fs-13" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(99, 100%, 35%);" data-sample-run="4" data-sample-runs="10" id="fs-14" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(132, 100%, 35%);" data-sample-run="5" data-sample-runs="10" id="fs-15" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(165, 100%, 35%);" data-sample-run="6" data-sample-runs="10" id="fs-16" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(198, 100%, 35%);" data-sample-run="7" data-sample-runs="10" id="fs-17" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(231, 100%, 35%);" data-sample-run="8" data-sample-runs="10" id="fs-18" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(264, 100%, 35%);" data-sample-run="9" data-sample-runs="10" id="fs-19" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(297, 100%, 35%);" data-sample-run="10" data-sample-runs="10" id="fs-20" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+</g>
+<!-- end of group #fs-part-front -->
+
+<!-- Start of group #fs-part-sleeve -->
+<g id="fs-part-sleeve" >
+<path  style="stroke: hsl(0, 100%, 35%);" data-sample-run="1" data-sample-runs="10" id="fs-21" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(0, 100%, 35%);" data-sample-run="1" data-sample-runs="10" id="fs-22" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(33, 100%, 35%);" data-sample-run="2" data-sample-runs="10" id="fs-23" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(33, 100%, 35%);" data-sample-run="2" data-sample-runs="10" id="fs-24" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(66, 100%, 35%);" data-sample-run="3" data-sample-runs="10" id="fs-25" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(66, 100%, 35%);" data-sample-run="3" data-sample-runs="10" id="fs-26" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(99, 100%, 35%);" data-sample-run="4" data-sample-runs="10" id="fs-27" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(99, 100%, 35%);" data-sample-run="4" data-sample-runs="10" id="fs-28" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(132, 100%, 35%);" data-sample-run="5" data-sample-runs="10" id="fs-29" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(132, 100%, 35%);" data-sample-run="5" data-sample-runs="10" id="fs-30" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(165, 100%, 35%);" data-sample-run="6" data-sample-runs="10" id="fs-31" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(165, 100%, 35%);" data-sample-run="6" data-sample-runs="10" id="fs-32" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(198, 100%, 35%);" data-sample-run="7" data-sample-runs="10" id="fs-33" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(198, 100%, 35%);" data-sample-run="7" data-sample-runs="10" id="fs-34" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(231, 100%, 35%);" data-sample-run="8" data-sample-runs="10" id="fs-35" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(231, 100%, 35%);" data-sample-run="8" data-sample-runs="10" id="fs-36" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(264, 100%, 35%);" data-sample-run="9" data-sample-runs="10" id="fs-37" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(264, 100%, 35%);" data-sample-run="9" data-sample-runs="10" id="fs-38" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(297, 100%, 35%);" data-sample-run="10" data-sample-runs="10" id="fs-39" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(297, 100%, 35%);" data-sample-run="10" data-sample-runs="10" id="fs-40" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+</g>
+<!-- end of group #fs-part-sleeve -->
+</g>
+<!-- end of group #fs-container -->
+</svg>

--- a/markdown/org/docs/patterns/brian/options/armholeheight/en.md
+++ b/markdown/org/docs/patterns/brian/options/armholeheight/en.md
@@ -1,0 +1,6 @@
+---
+title: "Armhole height"
+---
+
+This option, together with the waist to armhole measurement, will control the height/depth of the armhole.
+

--- a/markdown/org/docs/patterns/brian/options/sleevebulge/en.md
+++ b/markdown/org/docs/patterns/brian/options/sleevebulge/en.md
@@ -1,0 +1,8 @@
+---
+title: "Sleeve bulge"
+---
+
+Increase this option to make the sleeve bulge out along the biceps.
+
+This can be a mere style choice, or you can use this to accomodate for large upper arms.
+

--- a/markdown/org/docs/patterns/brian/options/sleevecapheight/brian_sleevecapheight_sample.svg
+++ b/markdown/org/docs/patterns/brian/options/sleevecapheight/brian_sleevecapheight_sample.svg
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg
+ xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xmlns:freesewing="http://freesewing.org/namespaces/freesewing" class="freesewing" width="0mm" height="0mm" viewBox="0 0 0 0"
+>
+<style type="text/css"> <![CDATA[ 
+text.title-nr{font-size:24pt;font-weight:700;text-anchor:middle;dominant-baseline:reset-size}text.title-name{font-size:7pt;font-weight:500;text-anchor:middle;dominant-baseline:reset-size}text.title-pattern{font-size:4pt;font-weight:500;dominant-baseline:reset-size;text-anchor:middle;font-style:italic}
+  /* Sample classes */
+  svg.freesewing path.sample {
+    stroke-width: 0.75
+  }
+  svg.freesewing path.sample-focus {
+    stroke-width: 1.5; fill: rgba(0,0,0,0.1)
+  }
+
+  /* Paperless grid */
+  svg.freesewing path.grid {
+    fill: none;
+    stroke: #555;
+    stroke-width: 0.3;
+  }
+  svg.freesewing path.gridline {
+    stroke: #555;
+    stroke-width: 0.2;
+  }
+  svg.freesewing path.gridline-lg {
+    stroke: #777;
+    stroke-width: 0.2;
+    stroke-dasharray: 1.5,1.5;
+  }
+  svg.freesewing path.gridline-sm {
+    stroke: #999;
+    stroke-width: 0.1;
+  }
+  svg.freesewing path.gridline-xs {
+    stroke: #999;
+    stroke-width: 0.1;
+    stroke-dasharray: 0.5,0.5;
+  }
+  svg.freesewing path.gridbox {
+    fill: url(#grid);
+  }
+
+  /* Reset */
+  svg.freesewing path,
+  svg.freesewing circle,
+  svg.freesewing rect {
+    fill: none;
+    stroke: none;
+  }
+
+  /* Defaults */
+  svg.freesewing path,
+  svg.freesewing circle {
+    stroke: #000;
+    stroke-opacity: 1;
+    stroke-width: 0.3;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  /* Stroke classes */
+  svg.freesewing .fabric {
+    stroke-width: 0.6;
+    stroke: #212121;
+  }
+  svg.freesewing .lining {
+    stroke-width: 0.6;
+    stroke: #ff5b77;
+  }
+  svg.freesewing .interfacing {
+    stroke-width: 0.6;
+    stroke: #64b5f6;
+  }
+  svg.freesewing .canvas {
+    stroke-width: 0.6;
+    stroke: #ff9000;
+  }
+  svg.freesewing .various {
+    stroke-width: 0.6;
+    stroke: #4caf50;
+  }
+  svg.freesewing .note {
+    stroke-width: 0.4;
+    stroke: #dd60dd;
+  }
+  svg.freesewing .mark {
+    stroke-width: 0.4;
+    stroke: blue;
+  }
+  svg.freesewing .contrast {
+    stroke-width: 0.8;
+    stroke: red;
+  }
+  svg.freesewing .stroke-xs {
+    stroke-width: 0.1;
+  }
+  svg.freesewing .stroke-sm {
+    stroke-width: 0.2;
+  }
+  svg.freesewing .stroke-lg {
+    stroke-width: 0.6;
+  }
+  svg.freesewing .stroke-xl {
+    stroke-width: 1;
+  }
+  svg.freesewing .stroke-xxl,
+  svg.freesewing .stroke-2xl {
+    stroke-width: 2;
+  }
+  svg.freesewing .stroke-3xl {
+    stroke-width: 3;
+  }
+  svg.freesewing .stroke-4xl {
+    stroke-width: 4;
+  }
+
+  svg.freesewing .sa {
+    stroke-dasharray: 0.4, 0.8;
+  }
+  svg.freesewing .help {
+    stroke-width: 0.2;
+    stroke-dasharray: 15, 1.5, 1, 1.5;
+  }
+  svg.freesewing .dotted {
+    stroke-dasharray: 0.4, 0.8;
+  }
+  svg.freesewing .dashed {
+    stroke-dasharray: 1, 1.5;
+  }
+  svg.freesewing .lashed {
+    stroke-dasharray: 6, 6;
+  }
+  svg.freesewing .hidden {
+    stroke: none;
+    fill: none;
+  }
+
+  /* Fill classes */
+  svg.freesewing .fill-fabric {
+    fill: #212121;
+  }
+  svg.freesewing .fill-lining {
+    fill: #ff5b77;
+  }
+  svg.freesewing .fill-interfacing {
+    fill: #64b5f6;
+  }
+  svg.freesewing .fill-canvas {
+    fill: #ff9000;
+  }
+  svg.freesewing .fill-various {
+    fill: #4caf50;
+  }
+  svg.freesewing .fill-note {
+    fill: #dd69dd;
+  }
+  svg.freesewing .fill-mark {
+    fill: blue;
+  }
+  svg.freesewing .fill-contrast {
+    fill: red;
+  }
+
+  /* Text */
+  svg.freesewing text {
+    font-size: 5px;
+    font-family: -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+      Arial, sans-serif;
+    fill: #000;
+    text-anchor: start;
+    font-weight: 200;
+    dominant-baseline: ideographic;
+  }
+  svg.freesewing .text-xs {
+    font-size: 3px;
+  }
+  svg.freesewing .text-sm {
+    font-size: 4px;
+  }
+  svg.freesewing .text-lg {
+    font-size: 7px;
+  }
+  svg.freesewing .text-xl {
+    font-size: 9px;
+  }
+  svg.freesewing .text-xxl {
+    font-size: 12px;
+  }
+
+  svg.freesewing .center {
+    text-anchor: middle;
+  }
+  svg.freesewing .right {
+    text-anchor: end;
+  }
+
+  /* Bartack */
+  svg.freesewing path.bartack {
+    stroke-width: 2;
+    stroke: #fd7e14;
+    stroke-linecap: butt;
+  }
+
+]]>
+</style>
+<script type="text/javascript"> <![CDATA[
+
+]]>
+</script>
+<defs>
+
+<g id="button">
+  <circle
+    cx="0" cy="0" r="3.4"
+    style="stroke:var(--pattern-mark);fill:none;stroke-width:var(--pattern-stroke);"
+  />
+  <circle cx="-1" cy="-1" r="0.5" style="stroke:none;fill:var(--pattern-mark)"/>
+  <circle cx="1"  cy="-1" r="0.5" style="stroke:none;fill:var(--pattern-mark)" />
+  <circle cx="1"  cy="1"  r="0.5" style="stroke:none;fill:var(--pattern-mark)" />
+  <circle cx="-1" cy="1"  r="0.5" style="stroke:none;fill:var(--pattern-mark)" />
+</g>
+<g id="buttonhole">
+  <path
+    style="fill:none;stroke:var(--pattern-mark);stroke-width:var(--pattern-stroke);"
+    d="M -1,-5 L 1,-5 L 1,5 L -1,5 z"
+  />
+</g>
+<g id="buttonhole-start">
+  <path
+    style="fill:none;stroke:var(--pattern-mark);stroke-width:var(--pattern-stroke);"
+    d="M -1,-10 L 1,-10 L 1,0 L -1,0 z"
+  />
+</g>
+<g id="buttonhole-end">
+  <path
+    style="fill:none;stroke:var(--pattern-mark);stroke-width:var(--pattern-stroke);"
+    d="M -1,0 L 1,0 L 1,10 L -1,10 z"
+  />
+</g>
+<radialGradient id="snap-stud-grad" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
+  <stop offset="30%" style="stop-color:rgb(235,235,235); stop-opacity:1"/>
+  <stop offset="80%" style="stop-color:rgb(100,100,100);stop-opacity:1" />
+</radialGradient>
+<g id="snap-stud">
+  <circle id="snap-stud-circle-edge" cx="0" cy="0" r="3.4"
+    style="stroke:#666;fill:#dddddd;stroke-width:0.3;"
+  />
+  <circle id="snap-stud-circle-middle" cx="0" cy="0" r="1.8"
+    style="stroke:none;fill:url(#snap-stud-grad);"
+  />
+  <path
+    id="snap-stud-lines" style="fill:none;stroke:#666; stroke-width:0.2;"
+    d="M -2,0 L -3,0 M 2,0 L 3,0 M 0,2 L 0,3 M 0,-2 L 0,-3 M 1.5,1.5 L 2.1,2.1 M -1.5,1.5 L -2.1,2.1 M -1.5,-1.5 L -2.1,-2.1 M 1.5,-1.5 L 2.1,-2.1"
+  />
+</g>
+<g id="snap-socket">
+  <circle id="snap-socket-circle-edge" cx="0" cy="0" r="3.4"
+    style="stroke:#666;fill:#bbbbbb;stroke-width:0.3;"
+  />
+  <circle id="snap-socket-circle-middle" cx="0" cy="0" r="2"
+    style="stroke:#666;fill:#dddddd; stroke-width:0.4;"
+  />
+  <path
+    style="fill:none;stroke:#666; stroke-width:0.5;"
+    d="M -1.7,-1 L -1.7,1 M 1.7,-1 L 1.7,1" id="snap-socket-lines"
+  />
+</g>
+<marker orient="auto" refY="0.0" refX="0.0" id="cutonfoldFrom" style="overflow:visible;" >
+	<path class="note fill-note" d="M 0,0 L 12,-4 C 10,-2 10,2  12, 4 z" />
+</marker>
+<marker orient="auto" refY="0.0" refX="0.0" id="cutonfoldTo" style="overflow:visible;" >
+	<path class="note fill-note" d="M 0,0 L -12,-4 C -10,-2 -10,2  -12, 4 z" />
+</marker>
+
+<marker orient="auto" refY="0.0" refX="0.0" id="dimensionFrom" style="overflow:visible;"><path class="mark fill-mark" d="M 0,0 L 12,-4 C 10,-2 10,2  12, 4 z" /></marker>
+<marker orient="auto" refY="0.0" refX="0.0" id="dimensionTo" style="overflow:visible;" ><path class="mark fill-mark" d="M 0,0 L -12,-4 C -10,-2 -10,2  -12, 4 z" /></marker>
+
+<marker orient="auto" refY="0.0" refX="0.0" id="grainlineFrom" style="overflow:visible;" >
+	<path class="note fill-note" d="M 0,0 L 12,-4 C 10,-2 10,2  12, 4 z" />
+</marker>
+<marker orient="auto" refY="0.0" refX="0.0" id="grainlineTo" style="overflow:visible;" >
+	<path class="note fill-note" d="M 0,0 L -12,-4 C -10,-2 -10,2  -12, 4 z" />
+</marker>
+<g id="logo" transform="translate(-23 -36)"><path class="logo" stroke="none" fill="currentColor" d="M 35.222,0 C 34.233,0.703 34.284,0.613 33.485,0.874 31.653,1.473 29.896,1.144 27.811,0.97 27.184,0.9 26.562,0.859 25.955,0.855 22.89,0.834 20.287,1.733 19.794,4.243 18.885,4.794 18.049,5.461 17.221,6.129 15.453,7.524 14.122,9.229 13.214,11.284 11.974,14.319 13.094,17.576 13.649,20.652 13.781,21.372 13.919,22.058 13.993,22.323 14.098,22.696 14.283,23.052 14.484,23.372 14.531,23.38 14.779,22.998 14.838,22.829 14.924,22.583 14.915,22.188 14.821,21.848 14.613,21.083 14.415,20.462 14.398,20.15 14.368,19.564 14.482,19.023 14.696,18.755 14.772,18.66 14.946,19.15 14.901,19.332 14.848,19.551 14.808,19.926 14.825,20.099 14.872,20.685 14.958,21.312 15.065,21.86 15.202,22.567 15.261,23.021 15.236,23.197 15.218,23.325 15.158,23.454 14.928,23.85 14.728,24.197 14.624,24.478 14.608,24.726 14.591,24.968 14.664,25.573 14.732,25.721 14.831,25.952 15.129,26.195 15.389,26.255 15.638,26.35 15.763,26.547 15.891,26.768 16.202,27.361 16.442,28.083 16.68,29.171 16.796,29.692 16.893,30.157 16.924,30.401 15.004,30.403 12.545,30.404 10.305,30.404 9.551,30.416 8.189,30.062 6.94,29.98 6.759,28.026 5.901,25.756 4.433,25.624 3.431,25.533 2.6,25.914 1.897,27.497 L 1.917,27.582 C 2.332,27.235 2.77,26.174 4.348,26.247 5.56,26.302 5.964,28.596 6.084,29.976 5.346,30.03 4.718,30.257 4.39,30.824 L 4.383,30.824 C 4.383,30.825 4.383,30.827 4.386,30.829 4.383,30.831 4.383,30.833 4.383,30.835 L 4.39,30.835 C 4.728,31.416 5.379,31.641 6.144,31.686 6.655,46.136 20.238,48 23.95,48 37.798,48 42.646,38.59 43.375,34.863 43.716,36.451 42.642,38.474 42.385,39.967 45.306,36.59 44.778,33.343 44.244,30.077 44.688,30.605 45.289,30.932 46.104,30.751 45.523,30.363 44.735,30.635 44.263,28.998 44.057,28.291 43.879,27.761 43.702,27.316 43.32,25.883 42.778,24.514 42.112,23.18 41.55,21.733 41.921,20.795 41.865,19.553 42.876,22.887 43.508,23.774 44.688,24.123 41.72,20.547 42.736,15.01 41.059,10.068 41.818,10.514 42.684,10.648 43.606,10.103 42.714,9.849 41.824,10.52 40.544,8.639 39.463,6.536 37.897,4.983 35.997,3.613 34.979,2.949 33.849,2.503 32.713,2.089 33.87,1.799 35.162,0.769 35.222,0 z M 33.281,11.107 C 34.805,11.663 36.485,13.775 36.466,15.847 L 36.466,15.933 36.466,15.963 C 36.425,18.777 35.146,20.29 35.2,22.164 35.269,24.371 36.219,25.141 36.408,25.509 36.084,24.148 35.894,22.436 36.322,21.08 36.872,19.336 37.427,17.892 37.387,16.526 37.367,16.206 37.231,15.009 37.14,14.479 38.774,16.837 36.786,20.266 37.358,22.51 38.352,26.419 42.807,26.913 41.481,34.789 40.314,41.713 32.318,46.968 24.122,46.968 18.046,46.968 7.517,43.605 6.997,31.676 8.232,31.588 9.56,31.244 10.305,31.256 12.557,31.256 15.129,31.257 17.067,31.258 17.431,32.9 17.704,33.296 19.085,34.39 20.621,35.598 20.979,35.745 23.251,35.767 25.524,35.79 26.198,35.303 28.403,33.217 28.879,32.659 29.085,31.928 29.316,31.241 31.584,31.22 33.238,31.18 34.865,31.104 36.522,31.029 36.756,31.104 39.426,30.829 36.756,30.554 36.522,30.629 34.865,30.553 33.281,30.481 31.677,30.44 29.508,30.42 29.69,29.603 29.95,28.805 30.227,28.016 30.398,27.551 30.599,27.098 30.805,26.647 L 31.03,26.577 C 31.464,26.423 31.848,26.093 32.001,25.647 32.198,25.056 32.058,24.392 31.677,23.909 31.546,23.728 31.383,23.497 31.316,23.395 31.115,23.077 31.11,22.9 31.28,21.718 31.423,20.728 31.439,20.21 31.34,19.708 31.32,19.421 31.318,18.831 31.309,18.672 31.385,18.714 31.55,19.09 31.717,19.599 31.883,20.11 31.91,20.216 31.948,20.651 31.99,21.145 31.805,21.511 31.653,22.248 31.577,22.628 31.51,22.981 31.51,23.029 31.51,23.08 31.546,23.188 31.584,23.272 31.673,23.46 31.84,23.724 31.871,23.724 32.416,23.123 32.736,22.381 33.021,21.628 33.321,20.776 33.409,19.872 33.619,18.995 33.789,18.231 33.985,17.466 34.046,16.682 34.169,15.152 34.097,14.072 33.759,12.478 33.678,12.118 33.444,11.431 33.281,11.107 z M 27.921,18.644 C 28.506,18.637 29.085,18.708 29.636,18.867 30.385,19.154 30.49,19.823 30.628,20.574 30.705,21.054 30.702,21.399 30.615,21.963 30.554,22.781 30.229,23.414 29.519,23.859 28.448,24.057 27.303,24.248 26.395,23.539 25.633,22.489 25.174,21.162 25.349,19.868 25.46,19.337 25.707,19.061 26.215,18.896 26.762,18.739 27.341,18.653 27.921,18.644 z M 19.038,18.739 C 19.585,18.734 20.138,18.792 20.442,18.986 21.747,19.869 21.328,21.306 20.812,22.567 20.061,24.218 18.437,24.157 16.863,24.144 15.992,23.889 15.912,23.175 15.786,22.412 15.678,21.675 15.448,20.885 15.64,20.144 16.133,18.952 17.935,18.815 19.038,18.739 z M 38.941,18.945 C 38.948,22.118 39.49,23.677 40.578,25.924 39.937,24.701 39.021,24.005 38.68,22.543 38.028,19.72 38.731,19.878 38.941,18.945 z M 23.128,21.243 C 23.3,21.417 23.383,21.657 23.532,21.848 23.647,21.651 23.765,21.455 23.913,21.28 23.99,21.282 24.084,21.434 24.169,21.706 24.533,22.712 24.604,23.819 25.076,24.786 25.517,25.486 24.915,25.894 24.254,25.926 23.772,25.925 23.568,25.596 23.285,25.27 23.212,25.483 23.073,25.62 22.907,25.764 22.485,26.118 21.658,25.987 21.53,25.429 21.7,24.363 22.243,23.384 22.599,22.362 22.776,21.989 22.778,21.703 23.128,21.243 z M 16.936,26.628 C 17.149,26.628 17.734,27.025 17.853,27.249 17.935,27.398 18.122,27.978 18.135,28.119 18.156,28.287 18.105,28.685 18.053,28.793 18.015,28.87 17.986,28.881 17.942,28.831 17.905,28.789 17.415,27.849 17.102,27.227 16.856,26.729 16.83,26.628 16.936,26.628 z M 29.158,26.939 C 29.166,26.94 29.178,26.943 29.189,26.946 29.255,26.973 29.209,27.207 28.961,28.057 28.914,28.313 28.8,28.515 28.633,28.683 28.578,28.683 28.553,28.619 28.467,28.264 28.394,27.961 28.386,27.691 28.437,27.449 28.525,27.146 28.881,27.053 29.158,26.939 z M 27.675,28.792 C 27.696,28.788 27.716,28.799 27.742,28.82 27.832,28.883 27.845,29.049 27.785,29.374 27.712,29.792 27.696,29.838 27.588,29.881 27.541,29.902 27.457,29.917 27.401,29.917 27.3,29.899 27.274,29.817 27.298,29.693 27.298,29.433 27.374,29.207 27.546,28.94 27.611,28.84 27.644,28.797 27.675,28.792 z M 19.042,28.811 C 19.111,28.811 19.319,28.961 19.396,29.065 19.482,29.175 19.58,29.83 19.525,29.943 19.462,30.085 19.154,30.014 19.069,29.837 19.017,29.731 18.894,29.159 18.894,29.023 18.894,28.897 18.955,28.811 19.042,28.811 z M 26.933,28.984 C 27.017,29.104 27.039,29.258 27.021,29.596 L 27.004,29.904 26.916,29.992 C 26.863,30.041 26.773,30.101 26.719,30.126 26.6,30.182 26.509,30.187 26.492,30.142 26.472,30.082 26.506,29.7 26.543,29.571 26.586,29.438 26.779,29.041 26.843,28.957 26.872,28.88 26.906,28.976 26.933,28.984 z M 21.912,28.966 C 22.093,29.012 22.173,29.175 22.272,29.323 L 22.339,29.455 22.245,29.782 C 22.195,29.962 22.142,30.124 22.126,30.142 22.108,30.162 22.041,30.172 21.942,30.171 21.678,30.164 21.648,30.153 21.577,30.045 L 21.511,29.947 21.567,29.672 C 21.648,29.276 21.687,29.157 21.777,29.055 21.824,29 21.871,28.97 21.912,28.966 z M 20.241,29.249 20.39,29.398 20.415,29.735 C 20.428,29.919 20.434,30.09 20.424,30.111 20.415,30.14 20.361,30.148 20.194,30.148 L 19.977,30.148 C 19.861,30.021 19.825,29.866 19.776,29.706 19.662,29.225 19.662,29.006 19.78,28.977 19.973,28.989 20.1,29.129 20.241,29.249 z M 26.041,29.018 C 26.277,29.081 26.23,29.456 26.229,29.724 26.211,30.158 26.194,30.248 26.138,30.304 26.041,30.401 25.771,30.347 25.64,30.203 25.597,30.151 25.593,30.135 25.627,29.924 25.666,29.667 25.716,29.507 25.827,29.287 25.908,29.129 25.984,29.03 26.041,29.018 z M 20.715,29.038 C 20.728,29.037 20.749,29.038 20.769,29.04 20.919,29.052 21.059,29.15 21.183,29.33 L 21.283,29.477 C 21.292,29.718 21.283,29.972 21.24,30.196 21.214,30.209 21.106,30.229 21,30.239 20.816,30.256 20.799,30.252 20.735,30.196 20.646,30.12 20.621,29.979 20.599,29.511 20.586,29.129 20.595,29.044 20.715,29.038 z M 22.984,29.118 C 23.145,29.152 23.247,29.238 23.292,29.379 23.328,29.5 23.35,30.177 23.315,30.224 23.303,30.244 23.227,30.269 23.14,30.28 22.816,30.321 22.53,30.29 22.502,30.213 22.466,30.125 22.707,29.253 22.796,29.145 22.834,29.061 22.926,29.126 22.984,29.118 z M 25.082,29.124 C 25.153,29.117 25.229,29.185 25.303,29.33 25.363,29.451 25.372,29.493 25.372,29.764 25.372,29.98 25.359,30.073 25.336,30.093 25.316,30.109 25.235,30.138 25.149,30.16 24.999,30.199 24.966,30.203 24.919,30.187 L 24.694,30.146 24.711,30.012 C 24.727,29.837 24.842,29.449 24.923,29.281 24.971,29.181 25.026,29.131 25.082,29.124 z M 24.104,29.127 C 24.151,29.125 24.173,29.136 24.203,29.169 24.274,29.253 24.364,29.501 24.421,29.766 24.497,30.139 24.497,30.138 24.334,30.187 24.263,30.209 24.113,30.232 24.006,30.238 23.653,30.256 23.626,30.235 23.669,29.923 23.703,29.645 23.84,29.207 23.899,29.175 23.963,29.141 24.037,29.142 24.104,29.127 z M 6.111,30.536 C 6.114,30.535 6.118,30.536 6.118,30.536 6.127,30.731 6.127,30.928 6.131,31.124 5.636,31.086 5.272,30.968 5.272,30.829 5.272,30.692 5.623,30.575 6.111,30.536 z M 6.976,30.553 C 7.377,30.603 7.654,30.708 7.649,30.829 7.649,30.951 7.381,31.055 6.983,31.104 6.979,30.921 6.979,30.737 6.976,30.553 z M 25.702,31.086 C 25.736,31.083 25.751,31.08 25.803,31.085 26.011,31.106 26.041,31.119 26.041,31.189 26.041,31.281 25.883,31.558 25.776,31.654 25.726,31.702 25.657,31.742 25.633,31.742 25.513,31.742 25.443,31.489 25.499,31.256 25.533,31.13 25.595,31.091 25.702,31.086 z M 24.947,31.169 C 25.04,31.161 25.13,31.186 25.22,31.198 25.194,31.461 25.076,31.676 24.857,31.819 24.803,31.819 24.776,31.716 24.776,31.491 24.776,31.223 24.79,31.172 24.947,31.169 z M 24.119,31.266 C 24.312,31.266 24.482,31.275 24.49,31.286 24.526,31.32 24.422,31.578 24.269,31.84 24.138,32.073 24.119,32.09 24.038,32.096 23.72,32.06 23.729,31.687 23.68,31.431 23.68,31.279 23.714,31.266 24.119,31.266 z M 21.11,31.295 C 21.331,31.299 21.417,31.332 21.417,31.417 21.417,31.525 21.335,31.74 21.288,31.767 21.217,31.806 21.211,31.804 21.071,31.658 20.85,31.41 20.825,31.364 21.11,31.295 z M 22.174,31.306 C 22.178,31.312 22.221,31.39 22.264,31.478 22.358,31.661 22.365,31.741 22.298,31.802 22.14,31.892 22.107,31.841 21.964,31.75 21.798,31.593 21.667,31.382 21.71,31.338 21.858,31.285 22.021,31.305 22.174,31.306 z M 22.596,31.311 22.991,31.318 C 23.145,31.318 23.278,31.326 23.285,31.338 23.312,31.362 23.225,31.876 23.178,31.992 23.124,32.122 22.935,32.123 22.837,31.969 22.697,31.748 22.605,31.562 22.602,31.434 L 22.596,31.311 z" /></g><g id="notch"><circle cy="0" cx="0" r="1.4" class="fill-note" /><circle cy="0" cx="0" r="2.8" class="note" /></g><g id="bnotch"><path d="M -1.1 -1.1 L 1.1 1.1 M 1.1 -1.1 L -1.1 1.1" class="note" /><circle cy="0" cx="0" r="2.8" class="note" /></g>
+</defs>
+
+
+<!-- Start of group #fs-container -->
+<g id="fs-container">
+
+<!-- Start of group #fs-part-back -->
+<g id="fs-part-back" >
+<path  class="fabric" style="stroke: hsl(0, 100%, 35%);" data-sample-run="1" data-sample-runs="10" id="fs-1" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(33, 100%, 35%);" data-sample-run="2" data-sample-runs="10" id="fs-2" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(66, 100%, 35%);" data-sample-run="3" data-sample-runs="10" id="fs-3" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(99, 100%, 35%);" data-sample-run="4" data-sample-runs="10" id="fs-4" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(132, 100%, 35%);" data-sample-run="5" data-sample-runs="10" id="fs-5" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(165, 100%, 35%);" data-sample-run="6" data-sample-runs="10" id="fs-6" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(198, 100%, 35%);" data-sample-run="7" data-sample-runs="10" id="fs-7" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(231, 100%, 35%);" data-sample-run="8" data-sample-runs="10" id="fs-8" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(264, 100%, 35%);" data-sample-run="9" data-sample-runs="10" id="fs-9" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+<path  class="fabric" style="stroke: hsl(297, 100%, 35%);" data-sample-run="10" data-sample-runs="10" id="fs-10" d="M 0,16 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN 193.52,NaN L 193.52,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 65.31,16 0,16 0,16" />
+</g>
+<!-- end of group #fs-part-back -->
+
+<!-- Start of group #fs-part-front -->
+<g id="fs-part-front" >
+<path  class="fabric" style="stroke: hsl(0, 100%, 35%);" data-sample-run="1" data-sample-runs="10" id="fs-11" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(33, 100%, 35%);" data-sample-run="2" data-sample-runs="10" id="fs-12" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(66, 100%, 35%);" data-sample-run="3" data-sample-runs="10" id="fs-13" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(99, 100%, 35%);" data-sample-run="4" data-sample-runs="10" id="fs-14" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(132, 100%, 35%);" data-sample-run="5" data-sample-runs="10" id="fs-15" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(165, 100%, 35%);" data-sample-run="6" data-sample-runs="10" id="fs-16" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(198, 100%, 35%);" data-sample-run="7" data-sample-runs="10" id="fs-17" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(231, 100%, 35%);" data-sample-run="8" data-sample-runs="10" id="fs-18" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(264, 100%, 35%);" data-sample-run="9" data-sample-runs="10" id="fs-19" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+<path  class="fabric" style="stroke: hsl(297, 100%, 35%);" data-sample-run="10" data-sample-runs="10" id="fs-20" d="M 0,50.7 L 0,500 L 235.17,500 L 235.17,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN L NaN,NaN C NaN,NaN NaN,NaN 199.5,30.13 L 69,0 C 61.39,32.95 31.51,50.7 0,50.7" />
+</g>
+<!-- end of group #fs-part-front -->
+
+<!-- Start of group #fs-part-sleeve -->
+<g id="fs-part-sleeve" >
+<path  style="stroke: hsl(0, 100%, 35%);" data-sample-run="1" data-sample-runs="10" id="fs-21" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(0, 100%, 35%);" data-sample-run="1" data-sample-runs="10" id="fs-22" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(33, 100%, 35%);" data-sample-run="2" data-sample-runs="10" id="fs-23" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(33, 100%, 35%);" data-sample-run="2" data-sample-runs="10" id="fs-24" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(66, 100%, 35%);" data-sample-run="3" data-sample-runs="10" id="fs-25" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(66, 100%, 35%);" data-sample-run="3" data-sample-runs="10" id="fs-26" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(99, 100%, 35%);" data-sample-run="4" data-sample-runs="10" id="fs-27" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(99, 100%, 35%);" data-sample-run="4" data-sample-runs="10" id="fs-28" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(132, 100%, 35%);" data-sample-run="5" data-sample-runs="10" id="fs-29" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(132, 100%, 35%);" data-sample-run="5" data-sample-runs="10" id="fs-30" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(165, 100%, 35%);" data-sample-run="6" data-sample-runs="10" id="fs-31" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(165, 100%, 35%);" data-sample-run="6" data-sample-runs="10" id="fs-32" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(198, 100%, 35%);" data-sample-run="7" data-sample-runs="10" id="fs-33" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(198, 100%, 35%);" data-sample-run="7" data-sample-runs="10" id="fs-34" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(231, 100%, 35%);" data-sample-run="8" data-sample-runs="10" id="fs-35" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(231, 100%, 35%);" data-sample-run="8" data-sample-runs="10" id="fs-36" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(264, 100%, 35%);" data-sample-run="9" data-sample-runs="10" id="fs-37" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(264, 100%, 35%);" data-sample-run="9" data-sample-runs="10" id="fs-38" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+<path  style="stroke: hsl(297, 100%, 35%);" data-sample-run="10" data-sample-runs="10" id="fs-39" d="M 0,0 L NaN,NaN" />
+<path  class="fabric" style="stroke: hsl(297, 100%, 35%);" data-sample-run="10" data-sample-runs="10" id="fs-40" d="M 146.05,0 C 146.05,0 NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN NaN,NaN NaN,NaN C NaN,NaN -146.05,0 -146.05,0" />
+</g>
+<!-- end of group #fs-part-sleeve -->
+</g>
+<!-- end of group #fs-container -->
+</svg>

--- a/markdown/org/docs/patterns/brian/options/sleevecapheight/en.md
+++ b/markdown/org/docs/patterns/brian/options/sleevecapheight/en.md
@@ -1,0 +1,11 @@
+---
+title: "Sleevecap height"
+---
+
+This option controls the height of the sleevelcap.
+
+The sleevecap height controls how formal a sleeve looks. A sleeve with a higher sleevecap will
+be more dowward pointing (like a jacket) and give a more formal look, but allow for less movement.
+A sleeve with a lower sleevecap will be more outward pointing (like a t-shirt) and give a more informal
+look, with more movement.
+

--- a/markdown/org/docs/patterns/holmes/fabric/en.md
+++ b/markdown/org/docs/patterns/holmes/fabric/en.md
@@ -4,7 +4,9 @@ title: "Holmes deerstalker hat: Fabric Options"
 
 ### Main Fabric
 
-For the main fabric of your hat, a thick fabric will work best to hold the shape but if you wanna go for a lighter fabric you can interface it to give it more body. Generally you want to use **Wools** of coating weight but you can experiment with different weights and fabrics with the relevant interfacing. <Note>
+For the main fabric of your hat, a thick fabric will work best to hold the shape but if you wanna go for a lighter fabric you can interface it to give it more body. Generally you want to use **Wools** of coating weight but you can experiment with different weights and fabrics with the relevant interfacing. 
+
+<Note>
 
 A fun thing to try is printed cotton. Just double up the main fabric so each piece is double thickness. Then interface it with a **Medium Firm Interfacing**.
 

--- a/markdown/org/docs/patterns/paco/fabric/en.md
+++ b/markdown/org/docs/patterns/paco/fabric/en.md
@@ -18,4 +18,6 @@ While linen is the go-to for hot summer days, I would not recommend it for these
 as they come with an elasticated waist/cuffs, which means wrinkle hell.
 Use one of out other designs with a fitted waist if you want linen pants.
 
-Also avoid picking a fabric with a lot of stretch, for it will complicate matters when you're installing the elastic. </Tip>
+Also avoid picking a fabric with a lot of stretch, for it will complicate matters when you're installing the elastic. 
+
+</Tip>

--- a/markdown/org/docs/patterns/paco/instructions/en.md
+++ b/markdown/org/docs/patterns/paco/instructions/en.md
@@ -14,7 +14,9 @@ the raw edges.
 For these instructions, we'll assume that you are using a serger for seam finishes, but we'll
 also provide alternatives. Other options for finishing seams include trimming them with pinking
 shears, stitching a zig-zag along the edge of the seam to keep it from fraying, or binding with
-bias tape. </Tip>
+bias tape. 
+
+</Tip>
 
 ## Step 1: Construct the back pockets
 

--- a/packages/brian/config/index.js
+++ b/packages/brian/config/index.js
@@ -21,7 +21,7 @@ export default {
     style: ['s3Collar', 's3Armhole'],
     advanced: [
       'acrossBackFactor',
-      'armholeDepthFactor',
+      'armholeHeight',
       'backNeckCutout',
       'frontArmholeDeeper',
       'shoulderSlopeReduction',
@@ -29,6 +29,7 @@ export default {
       {
         sleevecap: [
           'sleevecapEase',
+          'sleevecapHeight',
           'sleevecapTopFactorX',
           'sleevecapTopFactorY',
           'sleevecapBackFactorX',
@@ -60,6 +61,7 @@ export default {
     'shoulderSlope',
     'shoulderToShoulder',
     'shoulderToWrist',
+    'waistToArmhole',
     'wrist',
   ],
   dependencies: {
@@ -82,7 +84,7 @@ export default {
 
     // Percentages
     acrossBackFactor: { pct: 97, min: 93, max: 100 },
-    armholeDepthFactor: { pct: 60, min: 50, max: 70 },
+    armholeHeight: { pct: 90, min: 70, max: 110 },
     backNeckCutout: { pct: 5, min: 2, max: 8 },
     bicepsEase: { pct: 15, min: 0, max: 50 },
     chestEase: { pct: 8, min: -4, max: 20 },
@@ -96,6 +98,7 @@ export default {
     s3Collar: { pct: 0, min: -100, max: 100 },
     s3Armhole: { pct: 0, min: -100, max: 100 },
     sleevecapEase: { pct: 0, min: 0, max: 10 },
+    sleevecapHeight: { pct: 80, min: 60, max: 100 },
     sleevecapTopFactorX: { pct: 50, min: 25, max: 75 },
     sleevecapTopFactorY: { pct: 100, min: 35, max: 165 },
     sleevecapBackFactorX: { pct: 60, min: 35, max: 65 },
@@ -116,5 +119,9 @@ export default {
     sleevecapQ4Spread2: { pct: 7, min: 4, max: 20 },
     sleeveWidthGuarantee: { pct: 90, min: 25, max: 100 },
     sleeveLengthBonus: { pct: 0, min: -40, max: 10 },
+
+    // Deprecated, but kept for backwards compatibility
+    armholeDepthFactor: { pct: 60, min: 50, max: 70 },
+
   },
 }

--- a/packages/brian/config/index.js
+++ b/packages/brian/config/index.js
@@ -25,6 +25,7 @@ export default {
       'backNeckCutout',
       'frontArmholeDeeper',
       'shoulderSlopeReduction',
+      'sleeveBulge',
       'sleeveWidthGuarantee',
       {
         sleevecap: [
@@ -97,6 +98,7 @@ export default {
     // s3 is short for Shoulder Seam Shift
     s3Collar: { pct: 0, min: -100, max: 100 },
     s3Armhole: { pct: 0, min: -100, max: 100 },
+    sleeveBulge: { pct: 0, min: 0, max: 75 },
     sleevecapEase: { pct: 0, min: 0, max: 10 },
     sleevecapHeight: { pct: 80, min: 60, max: 100 },
     sleevecapTopFactorX: { pct: 50, min: 25, max: 75 },

--- a/packages/brian/src/base.js
+++ b/packages/brian/src/base.js
@@ -32,11 +32,11 @@ export default (part) => {
     new Point(measurements.shoulderToShoulder / 2 + store.get('shoulderEase'), -100),
     new Point(measurements.shoulderToShoulder / 2 + store.get('shoulderEase'), 100)
   )
-  // Determine armhole depth and cbShoulder independent of shoulder slope reduction
   points.cbShoulder = new Point(0, points.shoulder.y)
+  // Armhole depth is controlled by measurments.waistToArmhole and options.armholeHeight
   points.cbArmhole = new Point(
     0,
-    points.shoulder.y + measurements.biceps * (1 + options.bicepsEase) * options.armholeDepthFactor
+    points.cbWaist.y - (measurements.waistToArmhole * options.armholeHeight)
   )
 
   // Now take shoulder slope reduction into account
@@ -96,6 +96,8 @@ export default (part) => {
   points.shoulderCp1 = points.shoulder
     .shiftTowards(points.neck, points.shoulder.dy(points.armholePitch) / 5)
     .rotate(90, points.shoulder)
+
+  store.set('armholeHeight', points.shoulder.dy(points.armhole))
 
   // Neck opening (back)
   points._tmp4 = points.neck.shiftTowards(points.shoulder, 10).rotate(-90, points.neck)

--- a/packages/brian/src/sleeve.js
+++ b/packages/brian/src/sleeve.js
@@ -25,13 +25,24 @@ export default (part) => {
   points.wristLeft = points.wristRight.rotate(180, points.centerWrist)
   points.sleeveTip = paths.sleevecap.shiftFractionAlong(0.5)
 
+  // Allow sleeve to bulge out
+  points.bicepsLeftWrist = new Point(points.bicepsLeft.x, points.wristLeft.y)
+  points.bicepsLeftCp = points.bicepsLeft.shiftFractionTowards(points.bicepsLeftWrist, options.sleeveBulge)
+  points.bicepsRightWrist = new Point(points.bicepsRight.x, points.wristRight.y)
+  points.bicepsRightCp = points.bicepsRight.shiftFractionTowards(points.bicepsRightWrist, options.sleeveBulge)
+
   // Paths
   paths.sleevecap.render = false
-  paths.seam = new Path()
-    .move(points.bicepsLeft)
-    .move(points.wristLeft)
-    .move(points.wristRight)
+  paths.seam = new Path().move(points.bicepsLeft)
+  if (options.sleeveBulge > 0) paths.seam = paths.seam
+    .curve_(points.bicepsLeftCp, points.wristLeft)
+    .line(points.wristRight)
+    ._curve(points.bicepsRightCp, points.bicepsRight)
+  else paths.seam = paths.seam
+    .line(points.wristLeft)
+    .line(points.wristRight)
     .line(points.bicepsRight)
+  paths.seam = paths.seam
     .join(paths.sleevecap)
     .close()
     .attr('class', 'fabric')

--- a/packages/brian/src/sleeve.js
+++ b/packages/brian/src/sleeve.js
@@ -44,7 +44,13 @@ export default (part) => {
     points.logo = points.centerBiceps.shiftFractionTowards(points.centerWrist, 0.3)
     snippets.logo = new Snippet('logo', points.logo)
     macro('title', { at: points.centerBiceps, nr: 3, title: 'sleeve' })
-    macro('grainline', { from: points.centerWrist, to: points.centerBiceps })
+    macro('grainline', {
+      from: points.centerWrist,
+      to: new Point(
+        points.centerBiceps.x,
+        points.capQ2.y
+      )
+    })
     points.scaleboxAnchor = points.scalebox = points.centerBiceps.shiftFractionTowards(
       points.centerWrist,
       0.5

--- a/packages/brian/src/sleevecap.js
+++ b/packages/brian/src/sleevecap.js
@@ -19,11 +19,7 @@ function draftSleevecap(part, run) {
   points.centerBiceps = new Point(0, 0)
   points.centerCap = points.centerBiceps.shift(
     90,
-    options.sleevecapTopFactorY *
-      (measurements.biceps *
-        (1 + options.bicepsEase) *
-        options.armholeDepthFactor *
-        store.get('sleeveFactor'))
+    store.get('armholeHeight') * options.sleevecapHeight
   )
 
   // Left and right biceps points, limit impact of sleeveFactor to 25%

--- a/packages/freesewing.shared/components/workbench/inputs/measurement.js
+++ b/packages/freesewing.shared/components/workbench/inputs/measurement.js
@@ -24,10 +24,7 @@ const MeasurementInput = ({ m, gist, app, updateMeasurements }) => {
   const update = evt => {
     setVal(evt.target.value)
     const ok = isValid(evt.target.value)
-    if (ok) {
-      setValid(true)
-      updateMeasurements(evt.target.value*10, m)
-    } else setValid(false)
+    if (ok) updateMeasurements(evt.target.value*10, m)
   }
 
   const [val, setVal] = useState(gist?.measurements?.[m] || '')

--- a/packages/i18n/src/locales/en/options/brian.yml
+++ b/packages/i18n/src/locales/en/options/brian.yml
@@ -54,6 +54,10 @@ shoulderSlopeReduction:
   title: Shoulder slope reduction
   description: The amount by which the shoulder slope is reduced to allow for shoulder padding.
 
+sleeveBulge:
+  title: Sleeve bulge
+  description: Constrols how much the sleeve bulges out along the biceps.
+
 sleeveLengthBonus:
   title: Sleeve length bonus
   description: The amount to lengthen the sleeve. A negative value will shorten it.

--- a/packages/i18n/src/locales/en/options/brian.yml
+++ b/packages/i18n/src/locales/en/options/brian.yml
@@ -6,6 +6,10 @@ armholeDepthFactor:
   title: Armhole depth factor
   description: Controls the depth of the armhole. Higher values make a deeper armhole.
 
+armholeHeight:
+  title: Armhole height
+  description: Controls the height of the armhole. Higher values result in a more tight armhole.
+
 backNeckCutout:
   title: Back neck cutout
   description: How deep the neck is cut out at the back
@@ -57,6 +61,10 @@ sleeveLengthBonus:
 sleevecapEase:
   title: Sleevecap ease
   description: The amount by which the sleevecap seam is longer than the armhole seam.
+
+sleevecapHeight:
+  title: Sleevecap height
+  description: Controls the overall height of the sleevecap. A higher sleevecap results in a more formal look.
 
 sleevecapTopFactorX:
   title: Sleevecap top X

--- a/packages/utils/src/neckstimate/with-breasts.js
+++ b/packages/utils/src/neckstimate/with-breasts.js
@@ -39,7 +39,7 @@ export default complete({
   upperLeg: 570,
   waist: 750,
   waistBack: 380,
-  waistToArmhole: 17,
+  waistToArmhole: 170,
   waistToFloor: 1050,
   waistToHips: 125,
   waistToKnee: 600,

--- a/packages/utils/src/neckstimate/without-breasts.js
+++ b/packages/utils/src/neckstimate/without-breasts.js
@@ -32,7 +32,7 @@ export default complete({
   upperLeg: 625,
   waist: 810,
   waistBack: 410,
-  waistToArmhole: 21,
+  waistToArmhole: 210,
   waistToFloor: 1160,
   waistToHips: 130,
   waistToKnee: 640,


### PR DESCRIPTION
This PR is a work in progress to add the new `waistToArmhole` measurement, and convert patterns to adopt its use.

High-level overview of changes:

- Added the `waistToArmhole` measurement to modes, utils (neckstimate) and i18n
 - Brian now uses/requires the `waistToArmhole` measuremnt
 - Brian uses this measurement to calculate the armhole depth/height
 - The `armholeDepthFactor` in brian is deprecated, I've kept it in the config but it's no longer used
 - Instead, armhole dept is controlled by the new `arhmoleHeight` factor
 - The sleevecap height is no longer depending on the biceps circumference, but now is based on the armhole height
 - The sleevecap height is further controlled by the new `sleevecapHeight` option which controls the sleevecap height independently of the armhole depth/height
 - There's a new `sleeveBulge` option in Brian (unrelated but while I was there I added it)


**Things not to forget**
- Update the sleevecap docs to mention the new `sleevecapHeight` option