### PR TITLE
fix(lunetius-option-desc): to upper leg

### DIFF
--- a/packages/i18n/src/locales/en/options/lunetius.yml
+++ b/packages/i18n/src/locales/en/options/lunetius.yml
@@ -13,5 +13,5 @@ length:
     toKnee: On the knee
     toBelowKnee: Below the knee
     toHips: On the hips
-    toUpperLeg: Below the hips
+    toUpperLeg: To the upper leg
     toFloor: To the floor

--- a/packages/i18n/src/locales/en/options/lunetius.yml
+++ b/packages/i18n/src/locales/en/options/lunetius.yml
@@ -13,5 +13,5 @@ length:
     toKnee: On the knee
     toBelowKnee: Below the knee
     toHips: On the hips
-    toUpperLeg: To the upper leg
+    toUpperLeg: On the thigh
     toFloor: To the floor


### PR DESCRIPTION
changed the option description for `toUpperLeg` from "Below the hips" to "To the upper leg", as that is technically correct (it uses the `waist to upper leg` measurement). It sounds a bit more clunky, so opinions? (I'm also not sure if changing this here impacts anything else apart from the translation files, hence a PR and not a direct commit.)