### PR TITLE
fix(link) Broken Links, Counter and ButtonHoles

### DIFF
--- a/markdown/dev/reference/api/config/options/en.md
+++ b/markdown/dev/reference/api/config/options/en.md
@@ -129,7 +129,7 @@ to determine whether an option should be shown or not.
 
 [const]: /reference/api/config/options/const
 
-[count]: /reference/api/config/options/count
+[count]: /reference/api/config/options/counter
 
 [deg]: /reference/api/config/options/deg
 

--- a/markdown/dev/reference/api/config/options/en.md
+++ b/markdown/dev/reference/api/config/options/en.md
@@ -27,7 +27,7 @@ There are the five option types that an aspiring pattern designer should be
 familiar with:
 
 1. [**boolean** options][bool] are for yes/no choices
-2. [**counter** options][counter] are for integer values
+2. [**counter** options][count] are for integer values
 3. [**degree** options][deg] are for degrees
 4. [**list** options][list] are for a list of possible choices
 5. [**percentage** options][pct] are for percentages

--- a/markdown/dev/reference/api/config/options/en.md
+++ b/markdown/dev/reference/api/config/options/en.md
@@ -27,7 +27,7 @@ There are the five option types that an aspiring pattern designer should be
 familiar with:
 
 1. [**boolean** options][bool] are for yes/no choices
-2. [**counter** options][count] are for integer values
+2. [**counter** options][counter] are for integer values
 3. [**degree** options][deg] are for degrees
 4. [**list** options][list] are for a list of possible choices
 5. [**percentage** options][pct] are for percentages

--- a/markdown/dev/reference/api/snippets/buttonhole-end/en.md
+++ b/markdown/dev/reference/api/snippets/buttonhole-end/en.md
@@ -19,8 +19,8 @@ An example of the buttonhole-end snippet
 
 We provide three buttonhole snippets with a different alignment:
 
-- [buttonhole](/reference/snippets/buttonhole/): Anchor point is the middle of the buttonhole
-- [buttonhole-start](/reference/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
-- [buttonhole-end](/reference/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
+- [buttonhole](/reference/api/snippets/buttonhole/): Anchor point is the middle of the buttonhole
+- [buttonhole-start](/reference/api/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
+- [buttonhole-end](/reference/api/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
 
 </Note>

--- a/markdown/dev/reference/api/snippets/buttonhole-start/en.md
+++ b/markdown/dev/reference/api/snippets/buttonhole-start/en.md
@@ -19,8 +19,8 @@ An example of the buttonhole-start snippet
 
 We provide three buttonhole snippets with a different alignment:
 
-- [buttonhole](/reference/snippets/buttonhole/): Anchor point is the middle of the buttonhole
-- [buttonhole-start](/reference/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
-- [buttonhole-end](/reference/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
+- [buttonhole](/reference/api/snippets/buttonhole/): Anchor point is the middle of the buttonhole
+- [buttonhole-start](/reference/api/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
+- [buttonhole-end](/reference/api/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
 
 </Note>

--- a/markdown/dev/reference/api/snippets/buttonhole/en.md
+++ b/markdown/dev/reference/api/snippets/buttonhole/en.md
@@ -19,8 +19,8 @@ An example of the buttonhole snippet
 
 We provide three buttonhole snippets with a different alignment:
 
-- [buttonhole](/reference/snippets/buttonhole/): Anchor point is the middle of the buttonhole
-- [buttonhole-start](/reference/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
-- [buttonhole-end](/reference/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
+- [buttonhole](/reference/api/snippets/buttonhole/): Anchor point is the middle of the buttonhole
+- [buttonhole-start](/reference/api/snippets/buttonhole-start/): Anchor point is the start of the buttonhole
+- [buttonhole-end](/reference/api/snippets/buttonhole-end/): Anchor point is the end of the buttonhole
 
 </Note>


### PR DESCRIPTION
Noticed this when trying to look it up. The counter page exists it is just not registered as count so the link needed changing :)

Edit: Noticed the buttonhole pages had broken links as well

Changes
- Changed link from "count" to "counter"
- Added api to buttonhole links