### PR TITLE
Update back.js

### DIFF
--- a/packages/bella/src/back.js
+++ b/packages/bella/src/back.js
@@ -112,14 +112,6 @@ export default function (part) {
   }
 
   // Store the back width at bust level
-  points.bustSide = utils.curveIntersectsY(
-    points.waistSide,
-    points.waistSideCp2,
-    points.armhole,
-    points.armhole,
-    measurements.hpsToBust
-  )
-  if (!points.bustSide) raise.error('Could not find bust height in side seam of back part')
   points.bustCenter = utils.curveIntersectsY(
     points.cbNeck,
     points.cbNeckCp2,
@@ -128,21 +120,47 @@ export default function (part) {
     measurements.hpsToBust
   )
   if (!points.bustCenter) raise.error('Could not find bust height in center seam of back part')
-  points.bustDartLeft = utils.curveIntersectsY(
-    points.dartBottomLeft,
-    points.dartLeftCp,
-    points.dartTip,
-    points.dartTip,
-    measurements.hpsToBust
-  )
+  if (points.bustCenter.y < points.armhole.y) {
+    points.sideArmhole = points.armhole.clone()
+    let sideArmholeTemp = new Path()
+      .move(points.armhole)
+      .curve(points.armhole, points.waistSideCp2, points.waistSide)
+      .shiftAlong(10)
+    points.sideArmhole = sideArmholeTemp.shiftOutwards(points.armhole, 100)
+    points.bustSide = utils.beamIntersectsY(
+      points.armhole,
+      points.sideArmhole,
+      measurements.hpsToBust
+    )
+  } else {
+    points.bustSide = utils.curveIntersectsY(
+      points.waistSide,
+      points.waistSideCp2,
+      points.armhole,
+      points.armhole,
+      measurements.hpsToBust
+    )
+  }
+  if (!points.bustSide) raise.error('Could not find bust height in side seam of back part')
+  if (points.bustCenter.y < points.dartTip.y) {
+    points.bustDartLeft = points.bustCenter.clone()
+    points.bustDartLeft.x = points.dartTip.x
+  } else {
+    points.bustDartLeft = utils.curveIntersectsY(
+      points.dartBottomLeft,
+      points.dartLeftCp,
+      points.dartTip,
+      points.dartTip,
+      measurements.hpsToBust
+    )
+  }
   if (!points.bustDartLeft) raise.error('Could not find bust height in back dart')
   points.bustDartRight = points.bustDartLeft.flipX(points.dartTip)
+  // Store things we'll need in the front parts
   store.set(
     'bustWidthBack',
     points.bustCenter.dx(points.bustDartLeft) + points.bustDartRight.dx(points.bustSide)
   )
-
-  // Store things we'll need in the front parts
   store.set(
     'sideSeamLength',
     new Path().move(points.waistSide).curve_(points.waistSideCp2, points.armhole).length()
@@ -290,6 +308,8 @@ export default function (part) {
         to: points.armhole,
         y: points.hps.y - sa - 60,
       })
+
+      macro('ld', { from: points.hps, to: points.shoulder, d: 10 })
     }
   }
 


### PR DESCRIPTION
This addresses the issue #2051. When the HPS to Bust becomes too small, the calculation of 'bustWidthBack' would throw an error because the line along which this was measured would no longer intersect with the side seam. This solution solves this by creating an artificial extension on the side seam that is used to create this point at which the measurement is made.
There is still an issue where if the value keeps decreasing, the side dart itself will no longer be on the side seam. This is an issue in front.js.