### PR TITLE
chore: fix typo in using-hooks-more-than-once/en.md

### DIFF
--- a/markdown/dev/guides/plugins/using-hooks-more-than-once/en.md
+++ b/markdown/dev/guides/plugins/using-hooks-more-than-once/en.md
@@ -4,7 +4,7 @@ order: 80
 ---
 
 What if you want to attach more than one method to a hook?
-You could spread them over seperate plugins, but there's a better way.
+You could spread them over separate plugins, but there's a better way.
 
 Rather than assigning a method to your hook, assign an array of methods like this:
 


### PR DESCRIPTION
seperate -> separate