### PR TITLE
Shin - Adding Grainlines

### DIFF
--- a/packages/shin/src/back.js
+++ b/packages/shin/src/back.js
@@ -117,7 +117,13 @@ export default function (part) {
       nr: 1,
       title: 'back',
     })
-    macro('scalebox', { at: new Point(points.legSide.x + 80, points.legSide.y - 40) })
+    macro('scalebox', { at: new Point(points.legSide.x + 100, points.legSide.y - 40) })
+	points.grainlineFrom = points.legSide.shift(0,15)
+	points.grainlineTo = points.hipSide.shift(0,15)
+	macro("grainline", {
+		from: points.grainlineFrom,
+		to: points.grainlineTo,
+		})
     if (sa) {
       paths.sa = paths.hemBase
         .offset(3 * sa)

--- a/packages/shin/src/front.js
+++ b/packages/shin/src/front.js
@@ -120,6 +120,12 @@ export default function (part) {
       nr: 2,
       title: 'front',
     })
+	points.grainlineFrom = points.seatCb.shift(180,30)
+	points.grainlineTo = points.hipCb.shift(180,30)
+	macro("grainline", {
+		from: points.grainlineFrom,
+		to: points.grainlineTo,
+		})
     if (sa) {
       paths.sa = paths.hemBase
         .offset(3 * sa)

--- a/packages/shin/src/waistband.js
+++ b/packages/shin/src/waistband.js
@@ -48,6 +48,12 @@ export default function (part) {
       nr: 3,
       title: 'waistband',
     })
+  points.grainlineFrom = points.bottomLeft.shiftFractionTowards(points.bottomRight,1/8)
+	points.grainlineTo = new Point(points.grainlineFrom.x, points.topLeft.y)
+	macro("grainline", {
+  from: points.grainlineFrom,
+  to: points.grainlineTo,
+})
     if (sa) {
       paths.sa = new Path()
         .move(points.topLeft)


### PR DESCRIPTION
For issue #2165 

Using the grainlines from https://freesewing.org/docs/patterns/shin/cutting/ as reference.

Additions
- Added grainline on back,js
- Added grainline on front.js
- Added grainline on waistband.js

Changes
- Tweaked the horizontal distance of the scalebox on back.js to reduce chance of overlap with the new grainline.

I was up and simple fix, understand though if you don't like the way I have done it.