### PR TITLE
Fixing Titan's Waist

### DIFF
--- a/packages/titan/src/front.js
+++ b/packages/titan/src/front.js
@@ -216,7 +216,7 @@ export default (part) => {
   points.kneeOutCp1 = points.kneeOut.shift(90, points.fork.dy(points.knee) / 3)
   points.seatOutCp1 = points.seatOut.shift(
     90,
-    measurements.waistToHips + absoluteOptions.waistbandWidth
+    measurements.waistToHips * options.waistHeight + absoluteOptions.waistbandWidth
   )
   points.seatOutCp2 = points.seatOut.shift(-90, points.seatOut.dy(points.knee) / 3)
 


### PR DESCRIPTION
Had noticed this a couple times that with certain configurations of options the sideSeam on Titan's Front would extend beyond the waist seam. Originally I didn't think too much off it as I thought it would simply be something compensated for when extending the block but since I was dabbling in that atm and since I prefer lower rise trousers it was bothering me. after a bit of sloothing I found that once again it was an accidental oversight when the waistband was changed to pct snap option with options.waistHeight on points,seatOutCp1 being removed. This commit simply re-adds it. Have tested it too :)

Changes
Re-added options.waistHeight on point,seatOutCp1

Edit: Hit Enter too soon gg me.