### PR TITLE
Change hem allowance on Wahid to standard SA

### DIFF
--- a/designs/wahid/src/back.js
+++ b/designs/wahid/src/back.js
@@ -111,7 +111,7 @@ export default (part) => {
     if (sa) {
       paths.sa = paths.saBase
         .offset(sa)
-        .join(paths.hemBase.offset(sa * 1))
+        .join(paths.hemBase.offset(sa))
         .close()
         .attr('class', 'fabric sa')
     }

--- a/designs/wahid/src/back.js
+++ b/designs/wahid/src/back.js
@@ -111,7 +111,7 @@ export default (part) => {
     if (sa) {
       paths.sa = paths.saBase
         .offset(sa)
-        .join(paths.hemBase.offset(sa * 3))
+        .join(paths.hemBase.offset(sa * 1))
         .close()
         .attr('class', 'fabric sa')
     }

--- a/designs/wahid/src/front.js
+++ b/designs/wahid/src/front.js
@@ -285,7 +285,7 @@ export default (part) => {
     if (sa) {
       paths.sa = paths.saBase
         .offset(sa)
-        .join(paths.hemBase.offset(sa * 1))
+        .join(paths.hemBase.offset(sa))
         .close()
         .attr('class', 'fabric sa')
     }

--- a/designs/wahid/src/front.js
+++ b/designs/wahid/src/front.js
@@ -285,7 +285,7 @@ export default (part) => {
     if (sa) {
       paths.sa = paths.saBase
         .offset(sa)
-        .join(paths.hemBase.offset(sa * 3))
+        .join(paths.hemBase.offset(sa * 1))
         .close()
         .attr('class', 'fabric sa')
     }


### PR DESCRIPTION
Currently, when seam allowance is drawn on the patterns, a triple allowance is given on the bottom of the Wahid pieces, as they are labeled "hem allowance". However since Wahid has a lining rather than a rolled hem this is unnecessary and potentially confusing. 