### PR TITLE
Unice Broken Link

### DIFF
--- a/LATEST_NEWS.md
+++ b/LATEST_NEWS.md
@@ -7,7 +7,7 @@ Check the meetings voice/video channel.
 
 ##### New designs: Hi, Noble, and Unice
 
-Check the new designs, [Hi](/designs/hi), [Noble](/designs/noble), and [Unice](/unice).
+Check the new designs, [Hi](/designs/hi), [Noble](/designs/noble), and [Unice](/designs/unice).
 
 ##### Check out where FreeSewing is heading
 


### PR DESCRIPTION
Pointed out by Duck in discord https://discord.com/channels/698854858052075530/757632953097388043/994224234962362399 Unice's link is broken on the front page. Upon inspection it is simply missing the /designs so have changed that.

Changes
- Fixed Unice link