### PR TITLE
chore(bee): Remove macros through the API, not manually

### DIFF
--- a/designs/bee/src/cup.js
+++ b/designs/bee/src/cup.js
@@ -22,25 +22,8 @@ export default function (part) {
   for (let i in paths) delete paths[i]
   for (let i in snippets) delete snippets[i]
   //removing macros not required from Bella
-  delete points.titleAnchor
-  delete points.__titleNr
-  delete points.__titleName
-  delete points.__titlePattern
-  delete points.scaleboxAnchor
-  delete points.__scaleboxImperialBottomLeft
-  delete points.__scaleboxMetricBottomLeft
-  delete points.__scaleboxImperialTopLeft
-  delete points.__scaleboxMetricTopLeft
-  delete points.__scaleboxImperialTopRight
-  delete points.__scaleboxMetricTopRight
-  delete points.__scaleboxImperialBottomRight
-  delete points.__scaleboxMetricBottomRight
-  delete points.__scaleboxLead
-  delete points.__scaleboxTitle
-  delete points.__scaleboxText
-  delete points.__scaleboxLink
-  delete points.__scaleboxImperial
-  delete points.__scaleboxMetric
+  macro('title', false)
+  macro('scalebox', false)
   //bella alterations
   points.sideHemNew = points.armhole.shiftOutwards(
     points.bustDartTop,


### PR DESCRIPTION
Saw that this was possible https://discord.com/channels/698854858052075530/698862765053575188/995694438250708993
Immediatedly updated.

Changes
- Manual removal of macros changed to automatic.