### PR TITLE
Menu fixes

### DIFF
--- a/sites/lab/components/layouts/lab.js
+++ b/sites/lab/components/layouts/lab.js
@@ -10,7 +10,6 @@ export const BeforeNav = ({ app }) => (
       <LocalePicker app={app} />
     </div>
     <div className="md:hidden flex flex-row flex-wrap sm:flex-nowrap gap-2 mb-2">
-      <PatternPicker app={app} />
       <VersionPicker app={app} />
     </div>
   </>

--- a/sites/lab/components/layouts/lab.js
+++ b/sites/lab/components/layouts/lab.js
@@ -1,6 +1,5 @@
 import ThemePicker from 'shared/components/theme-picker.js'
 import LocalePicker from 'shared/components/locale-picker.js'
-import PatternPicker from 'site/components/pattern-picker.js'
 import VersionPicker from 'site/components/version-picker.js'
 
 export const BeforeNav = ({ app }) => (

--- a/sites/lab/components/pattern-picker.js
+++ b/sites/lab/components/pattern-picker.js
@@ -33,7 +33,7 @@ const PatternPicker = ({ app }) => {
           }
 
           return (<PickerLink {...patternProps} key={pattern}>
-            <span className="sr-only">{sectionTitle}</span> {app.navigation[section][pattern].__title}
+            <span className="sr-only" key={pattern}>{sectionTitle}</span> {app.navigation[section][pattern].__title}
           </PickerLink>)
         })}
       </React.Fragment>)}

--- a/sites/shared/components/locale-picker.js
+++ b/sites/shared/components/locale-picker.js
@@ -10,7 +10,8 @@ const LocalePicker = ({ app, iconOnly=false }) => {
   const pickerProps = {
     iconOnly,
     Icon: LocaleIcon,
-    title: t(router.locale)
+    title: t(router.locale),
+    end: true
   }
 
   return (

--- a/sites/shared/components/navigation/primary.js
+++ b/sites/shared/components/navigation/primary.js
@@ -142,7 +142,7 @@ const SubLevel = ({ nodes={}, active }) => (
                {child.__slug === active ? <>&bull;</> : <>&deg;</>}
               </span>
               <span className={child.__slug === active ? 'font-bold' : ''}>
-                {child.__linktitle}
+                {child.__linktitle || child.__title}
               </span>
             </a>
           </Link>

--- a/sites/shared/components/picker.js
+++ b/sites/shared/components/picker.js
@@ -3,9 +3,9 @@ import { Menu } from '@headlessui/react'
 import Link from 'next/link'
 
 /** an accessible dropdown menu for use by picker components */
-export const Picker = ({Icon, className, title, ariaLabel, iconOnly=false, children}) => {
+export const Picker = ({Icon, className, title, ariaLabel, iconOnly=false, children, ...props}) => {
 
-	return (<Menu as="div" className={`dropdown dropdown-end w-auto`}>
+	return (<Menu as="div" className={`dropdown w-auto ${props.end ? 'dropdown-end' : ''}`}>
 		<Menu.Button className={iconOnly
 			? `btn btn-sm`
 			: `m-0 btn btn-neutral flex flex-row gap-2

--- a/sites/shared/components/picker.js
+++ b/sites/shared/components/picker.js
@@ -3,9 +3,9 @@ import { Menu } from '@headlessui/react'
 import Link from 'next/link'
 
 /** an accessible dropdown menu for use by picker components */
-export const Picker = ({Icon, className, title, ariaLabel, iconOnly=false, children, ...props}) => {
+export const Picker = ({Icon, className, title, ariaLabel, iconOnly=false, children, end}) => {
 
-	return (<Menu as="div" className={`dropdown w-auto ${props.end ? 'dropdown-end' : ''}`}>
+	return (<Menu as="div" className={`dropdown w-auto ${end ? 'dropdown-end' : ''}`}>
 		<Menu.Button className={iconOnly
 			? `btn btn-sm`
 			: `m-0 btn btn-neutral flex flex-row gap-2

--- a/sites/shared/components/theme-picker.js
+++ b/sites/shared/components/theme-picker.js
@@ -16,7 +16,8 @@ const ThemePicker = ({ app, className, iconOnly=false }) => {
     iconOnly,
     Icon: ThemeIcon,
     title: t(`${app.theme}Theme`),
-    ariaLabel: t('themesPicker')
+    ariaLabel: t('themesPicker'),
+    end: true
   }
   return (<Picker {...pickerProps}>
     {Object.keys(themes).map(theme => (


### PR DESCRIPTION
- add missing design names to mobile nav
- remove pattern picker from mobile nav because the patterns are listed
- add key to pattern picker spans to get rid of no key error
- don't put `dropdown-end` class on pickers on left hand side of header to make sure the whole width of the picker is visible on narrower screens