### PR TITLE
Fix: Error Boundary internal errors

### DIFF
--- a/sites/shared/components/error/error-boundary.js
+++ b/sites/shared/components/error/error-boundary.js
@@ -26,7 +26,7 @@ class ErrorBoundary extends React.Component {
 
   static getDerivedStateFromError(error) {
     // Update state so the next render will show the fallback UI.
-    return { hasError: true };
+    return { hasError: true, error };
   }
 
   componentDidCatch(error, errorInfo) {

--- a/sites/shared/components/workbench/events.js
+++ b/sites/shared/components/workbench/events.js
@@ -24,7 +24,7 @@ const Event = ({ evt, units }) => {
   return <Md>Note a recognized event: {JSON.stringify(evt, null ,2)}</Md>
 }
 
-const EventGroup = ({ type='info', events=[], units='metric' }) => events.length > 0 ? (
+export const EventGroup = ({ type='info', events=[], units='metric' }) => events.length > 0 ? (
   <div className="">
     <h3 className="capitalize" id={`events-${type}`}>{type}</h3>
     <table className="table w-full mdx">


### PR DESCRIPTION
Somehow this stuff didn't make it into the merge of the error boundary code, so the boundary wasn't actually working