### PR TITLE
Fix: Simon split yoke shouldn't cut on fold

### DIFF
--- a/designs/simon/src/yoke.js
+++ b/designs/simon/src/yoke.js
@@ -35,20 +35,16 @@ export default (part) => {
     snippets.logo = new Snippet('logo', points.logo)
     snippets.logo.attr('data-scale', 0.8)
     if (options.splitYoke) {
-      macro('cutonfold', {
-        from: points.cbNeck,
-        to: points.cbYoke,
-        grainline: true,
-      })
       snippets.sleeveNotch = new Snippet('bnotch', points.armholePitch)
-    } else {
-      points.grainlineFrom = points.cbYoke.shift(0, 20)
-      points.grainlineTo = points.cbNeck.shift(0, 20)
-      macro('grainline', {
-        from: points.grainlineFrom,
-        to: points.grainlineTo,
-      })
     }
+
+    points.grainlineFrom = points.cbYoke.shift(0, 20)
+    points.grainlineTo = points.cbNeck.shift(0, 20)
+    macro('grainline', {
+      from: points.grainlineFrom,
+      to: points.grainlineTo,
+    })
+
 
     if (sa) {
       paths.sa = paths.saBase.offset(sa).attr('class', 'fabric sa')


### PR DESCRIPTION
Simon split yoke adds a cut on fold macro, but it should just be a grainline

(this matters for cutting layout stuff down the line)