### PR TITLE
Fix: Actually Ensure locale directories are made in i18n prebuild

### DIFF
--- a/packages/i18n/src/prebuild.mjs
+++ b/packages/i18n/src/prebuild.mjs
@@ -166,14 +166,11 @@ ${locales
  * Writes out files
  */
 const writeFiles = async allNamespaces => {
-  const dirPromises = []
   const filePromises = []
 
   for (const [locale, namespaces] of Object.entries(allNamespaces)) {
     // make sure there's a folder for the locale
-    dirPromises.push(
-      mkdir(path.resolve(__dirname, 'next', locale), {recursive: true})
-    )
+    await mkdir(path.resolve(__dirname, 'next', locale), {recursive: true})
 
     for (const [namespace, data] of Object.entries(namespaces)) {
       filePromises.push(
@@ -198,12 +195,9 @@ const writeFiles = async allNamespaces => {
       indexFile(Object.keys(allNamespaces), allNamespaces)
     )
   )
-  // make the folders first
-  await Promise.all(dirPromises)
-  // write the files
-  await Promise.all(filePromises)
 
-  return
+  // write the files
+  await Promise.all(filePromises).catch((e) => console.log('file', e))
 }
 
 /*


### PR DESCRIPTION
Well, I wasn't paying enough attention to how promises work, so the race condition wasn't solved. Now we're awaiting the directory creation to make sure that the files really aren't made without the directory