### PR TITLE
Fix: Prebuild scripts for cibuild_step scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ prebuild/*.json
 sites/*/out
 sites/*/public/mdx
 sites/*/prebuild
+!sites/shared/prebuild
 
 # misc
 .DS_Store

--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -192,7 +192,7 @@ react-pattern:
     '@freesewing/i18n': *freesewing
 rehype-jargon:
   _:
-    'unist-util-visit': '^2.0.3'
+    'unist-util-visit': '^4.1.0'
     'hast-util-from-html': '^1.0.0'
 remark-jargon:
   _:

--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -31,7 +31,7 @@ core:
   testonly: 'npx mocha tests/*.test.js'
 i18n:
   # react-scripts doesn't handle .mjs files correctly
-  prebuild: 'node src/prebuild.mjs'
+  prebuild: 'node scripts/prebuilder.mjs'
   test: *test
   testci: *testci
 new-design:

--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -42,7 +42,7 @@ new-design:
   vbuild: '!'
 pattern-info:
   cibuild_step1: '!'
-  build: 'node src/prebuild.js && node build.js'
+  build: 'node build.js'
   prebuild: 'node src/prebuild.js'
 utils:
   clean: "rimraf backend && rimraf camelCase && rimraf capitalize && rimraf cloneObject && rimraf convertSize && rimraf defaultGist && rimraf defaultSa && rimraf formatImperial && rimraf formatMm && rimraf isDegMeasurement && rimraf measurementAsMm && rimraf measurementDiffers && rimraf neckstimate && rimraf optionDefault && rimraf optionType && rimraf roundMm && rimraf roundMmDown && rimraf roundMmUp && rimraf sliderStep && rimraf smallestImperialStep && rimraf storage && rimraf tiler && rimraf validateEmail && rimraf validateTld"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -33,6 +33,7 @@
     "tips": "node ../../scripts/help.mjs",
     "prebuild": "node src/prebuild.mjs",
     "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "precibuild_step7": "node src/prebuild.mjs",
     "cibuild_step7": "node build.js"
   },
   "peerDependencies": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -31,9 +31,9 @@
     "vbuild": "VERBOSE=1 node build.js",
     "lab": "cd ../../sites/lab && yarn start",
     "tips": "node ../../scripts/help.mjs",
-    "prebuild": "node src/prebuild.mjs",
+    "prebuild": "node scripts/prebuilder.mjs",
     "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
-    "precibuild_step7": "node src/prebuild.mjs",
+    "precibuild_step7": "node scripts/prebuilder.mjs",
     "cibuild_step7": "node build.js"
   },
   "peerDependencies": {

--- a/packages/i18n/scripts/prebuilder.mjs
+++ b/packages/i18n/scripts/prebuilder.mjs
@@ -1,0 +1,4 @@
+import {build} from '../src/prebuild.mjs'
+
+// call this here instead of in the src/prebuild.mjs so that build isn't called by other files importing that build function
+build()

--- a/packages/i18n/src/next.mjs
+++ b/packages/i18n/src/next.mjs
@@ -7,17 +7,20 @@ import enNamespaces from "./next/en/index.mjs"
 import esNamespaces from "./next/es/index.mjs"
 import frNamespaces from "./next/fr/index.mjs"
 import nlNamespaces from "./next/nl/index.mjs"
+import ukNamespaces from "./next/uk/index.mjs"
 
 export const de = deNamespaces
 export const en = enNamespaces
 export const es = esNamespaces
 export const fr = frNamespaces
 export const nl = nlNamespaces
+export const uk = ukNamespaces
 
 export const languages = {
   de: "Deutsch",
   en: "English",
   es: "Español",
   fr: "Français",
-  nl: "Nederlands"
+  nl: "Nederlands",
+  uk: "undefined"
 }

--- a/packages/i18n/src/prebuild.mjs
+++ b/packages/i18n/src/prebuild.mjs
@@ -108,10 +108,10 @@ const getNamespacesFromFileList = async (files, locales, only=false) => {
     let file = files[i]
 
     let loc = localeFromFileName(file);
-    if (locales.indexOf(loc) === -1) return
+    if (locales.indexOf(loc) === -1) continue
 
     let namespace = namespaceFromFile(file);
-    if (only === true && only.indexOf(namespace) === -1) return
+    if (only === true && only.indexOf(namespace) === -1) continue
 
     if (typeof namespaces[loc] === 'undefined') {
       namespaces[loc] = {}
@@ -216,12 +216,11 @@ const writeFiles = async allNamespaces => {
 export const build = async (localeFilter = () => true, only=false) => {
   const files = await getTranslationFileList()
   const locales = getLocalesFromFileList(files).filter(localeFilter)
+  console.log('building i18n for', locales)
   const namespaces = await getNamespacesFromFileList(files, locales, only)
 
   await writeFiles(namespaces)
 }
-
-build()
 
 //export default strings
 

--- a/packages/i18n/src/prebuild.mjs
+++ b/packages/i18n/src/prebuild.mjs
@@ -34,14 +34,19 @@ const getTranslationFileList = async () => {
   return files.sort()
 }
 
+/** extracts the locale from the file name */
+const localeFromFileName = (fileName) => {
+  const split1 = fileName.split(`${path.sep}locales${path.sep}`).pop()
+  return split1.split(`${path.sep}`).shift()
+}
+
 /*
  * Figures out the list of locales from the list of files
  * (by checking how many version of aaron.yaml exist)
  */
 const getLocalesFromFileList = files => files
   .filter(file => (file.slice(-10) === 'aaron.yaml'))
-  .map(file => file.split(`${path.sep}locales${path.sep}`).pop())
-  .map(file => file.split(`${path.sep}plugin${path.sep}`).shift())
+  .map(localeFromFileName)
 
 // Helper method to see if a dir occurs in a full path
 const pathContains = (fullPath, dir) => fullPath
@@ -97,25 +102,28 @@ const loadTranslationFile = async (file) => {
  * Creates an object with namespaces and the YAML/YML files
  * that go with them
  */
-const getNamespacesFromFileList = async (files, locales) => {
+const getNamespacesFromFileList = async (files, locales, only=false) => {
   const namespaces = {}
-  for (const locale of locales) {
-    namespaces[locale] = {}
-    const locFiles = files.filter(file => (
-      file.split(`${path.sep}locales${path.sep}${locale}${path.sep}`).length > 1)
-    )
-    for (const file of locFiles) {
-      const namespace = namespaceFromFile(file)
-      if (typeof namespaces[locale][namespace] === 'undefined') {
-        namespaces[locale][namespace] = {}
-      }
-      // Spread in the result of yaml.load since
-      //console.log((await loadTranslationFile(file)))
-      // some namespaces are made up of multiple files
-      namespaces[locale][namespace] = {
-        ...namespaces[locale][namespace],
-        ...(await loadTranslationFile(file))
-      }
+  for (var i = 0; i < files.length; i++) {
+    let file = files[i]
+
+    let loc = localeFromFileName(file);
+    if (locales.indexOf(loc) === -1) return
+
+    let namespace = namespaceFromFile(file);
+    if (only === true && only.indexOf(namespace) === -1) return
+
+    if (typeof namespaces[loc] === 'undefined') {
+      namespaces[loc] = {}
+    }
+
+    if (typeof namespaces[loc][namespace] === 'undefined') {
+      namespaces[loc][namespace] = {}
+    }
+
+    namespaces[loc][namespace] = {
+      ...namespaces[loc][namespace],
+      ...(await loadTranslationFile(file))
     }
   }
 
@@ -166,14 +174,11 @@ ${locales
  * Writes out files
  */
 const writeFiles = async allNamespaces => {
-  const dirPromises = []
   const filePromises = []
 
   for (const [locale, namespaces] of Object.entries(allNamespaces)) {
     // make sure there's a folder for the locale
-    dirPromises.push(
-      mkdir(path.resolve(__dirname, 'next', locale), {recursive: true})
-    )
+    await mkdir(path.resolve(__dirname, 'next', locale), {recursive: true})
 
     for (const [namespace, data] of Object.entries(namespaces)) {
       filePromises.push(
@@ -198,8 +203,7 @@ const writeFiles = async allNamespaces => {
       indexFile(Object.keys(allNamespaces), allNamespaces)
     )
   )
-  // make the folders first
-  await Promise.all(dirPromises)
+
   // write the files
   await Promise.all(filePromises)
 
@@ -209,13 +213,15 @@ const writeFiles = async allNamespaces => {
 /*
  * Turns YAML translation files into JS
  */
-const build = async () => {
+export const build = async (localeFilter = () => true, only=false) => {
   const files = await getTranslationFileList()
-  const locales = getLocalesFromFileList(files)
-  const namespaces = await getNamespacesFromFileList(files, locales)
+  const locales = getLocalesFromFileList(files).filter(localeFilter)
+  const namespaces = await getNamespacesFromFileList(files, locales, only)
+
   await writeFiles(namespaces)
 }
 
 build()
 
 //export default strings
+

--- a/packages/pattern-info/package.json
+++ b/packages/pattern-info/package.json
@@ -20,7 +20,7 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "scripts": {
-    "build": "node src/prebuild.js && node build.js",
+    "build": "node build.js",
     "clean": "rimraf dist",
     "mbuild": "NO_MINIFY=1 node build.js",
     "symlink": "mkdir -p ./node_modules/@freesewing && cd ./node_modules/@freesewing && ln -s -f ../../../* . && cd -",
@@ -29,7 +29,8 @@
     "lab": "cd ../../sites/lab && yarn start",
     "tips": "node ../../scripts/help.mjs",
     "prebuild": "node src/prebuild.js",
-    "cibuild_step6": "node src/prebuild.js && node build.js"
+    "precibuild_step6": "node src/prebuild.js",
+    "cibuild_step6": "node build.js"
   },
   "peerDependencies": {},
   "dependencies": {},

--- a/packages/rehype-jargon/CHANGELOG.md
+++ b/packages/rehype-jargon/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change log for: @freesewing/rehype-jargon
+# Change log for: rehype-jargon
 
 
 

--- a/packages/rehype-jargon/README.md
+++ b/packages/rehype-jargon/README.md
@@ -1,13 +1,13 @@
 ![FreeSewing](https://static.freesewing.org/banner.png)
 <p align='center'><a
-  href="https://www.npmjs.com/package/@freesewing/rehype-jargon"
-  title="@freesewing/rehype-jargon on NPM"
-  ><img src="https://img.shields.io/npm/v/@freesewing/rehype-jargon.svg"
-  alt="@freesewing/rehype-jargon on NPM"/>
+  href="https://www.npmjs.com/package/rehype-jargon"
+  title="rehype-jargon on NPM"
+  ><img src="https://img.shields.io/npm/v/rehype-jargon.svg"
+  alt="rehype-jargon on NPM"/>
   </a><a
   href="https://opensource.org/licenses/MIT"
   title="License: MIT"
-  ><img src="https://img.shields.io/npm/l/@freesewing/rehype-jargon.svg?label=License"
+  ><img src="https://img.shields.io/npm/l/rehype-jargon.svg?label=License"
   alt="License: MIT"/>
   </a><a
   href="https://deepscan.io/dashboard#view=project&tid=2114&pid=2993&bid=23256"
@@ -46,7 +46,7 @@
   alt="Follow @freesewing_org on Twitter"/>
   </a></p>
 
-# @freesewing/rehype-jargon
+# rehype-jargon
 
 A Rehype plugin for jargon terms
 
@@ -183,7 +183,7 @@ info and instructions on how to use this plugin with [Gatsby](https://www.gatsby
 This repository is our *monorepo* 
 holding [all our NPM packages](https://freesewing.dev/reference/packages/).  
 
-This folder holds: @freesewing/rehype-jargon
+This folder holds: rehype-jargon
 
 If you're not entirely sure what to do or how to start, type this command:
 

--- a/packages/rehype-jargon/package.json
+++ b/packages/rehype-jargon/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {},
   "dependencies": {
-    "unist-util-visit": "^2.0.3",
+    "unist-util-visit": "^4.1.0",
     "hast-util-from-html": "^1.0.0"
   },
   "devDependencies": {},

--- a/packages/rehype-jargon/package.json
+++ b/packages/rehype-jargon/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@freesewing/rehype-jargon",
+  "name": "rehype-jargon",
   "version": "2.21.3",
   "description": "A Rehype plugin for jargon terms",
   "author": "Joost De Cock <joost@joost.at> (https://github.com/joostdecock)",
@@ -32,8 +32,8 @@
   },
   "peerDependencies": {},
   "dependencies": {
-    "hast-util-from-html": "^1.0.0",
-    "unist-util-visit": "^4.1.0"
+    "unist-util-visit": "^2.0.3",
+    "hast-util-from-html": "^1.0.0"
   },
   "devDependencies": {},
   "files": [

--- a/packages/rehype-jargon/src/index.js
+++ b/packages/rehype-jargon/src/index.js
@@ -1,4 +1,4 @@
-import visit from 'unist-util-visit'
+import { visit } from 'unist-util-visit'
 import { fromHtml } from 'hast-util-from-html'
 
 const jargonTransform = (term, html) => `<span class="jargon-term">${term}<span class="jargon-info">${html}</span></span>`

--- a/packages/rehype-jargon/src/index.js
+++ b/packages/rehype-jargon/src/index.js
@@ -1,4 +1,4 @@
-import { visit } from 'unist-util-visit'
+import visit from 'unist-util-visit'
 import { fromHtml } from 'hast-util-from-html'
 
 const jargonTransform = (term, html) => `<span class="jargon-term">${term}<span class="jargon-info">${html}</span></span>`

--- a/packages/remark-jargon/package.json
+++ b/packages/remark-jargon/package.json
@@ -35,7 +35,7 @@
     "remark-html": "^13.0.1"
   },
   "dependencies": {
-    "unist-util-visit": "^2.0.3"
+    "unist-util-visit": "^4.1.0"
   },
   "devDependencies": {},
   "files": [

--- a/packages/remark-jargon/src/index.js
+++ b/packages/remark-jargon/src/index.js
@@ -1,4 +1,4 @@
-import visit from 'unist-util-visit'
+import {visit} from 'unist-util-visit'
 
 export default (options) => {
   if (!options || !options.jargon) {

--- a/scripts/reconfigure.mjs
+++ b/scripts/reconfigure.mjs
@@ -201,6 +201,7 @@ function scripts(pkg) {
   // Enforce build order by generating the cibuild_stepX scrips
   for (let step=0; step < buildOrder.length; step++) {
     if (buildOrder[step].indexOf(pkg.name) !== -1) {
+      if (runScripts.prebuild) runScripts[`precibuild_step${step}`] = runScripts.prebuild
       if (runScripts.build) runScripts[`cibuild_step${step}`] = runScripts.build
     }
   }

--- a/sites/shared/mdx/loader.js
+++ b/sites/shared/mdx/loader.js
@@ -16,7 +16,7 @@ import smartypants from 'remark-smartypants'
 import rehypeHighlight from 'rehype-highlight'
 import rehypeAutolinkHeadings from 'rehype-autolink-headings'
 import rehypeSlug from 'rehype-slug'
-import rehypeJargon from '../../../packages/rehype-jargon/src/index.js'
+import rehypeJargon from 'rehype-jargon/src/index.js'
 // Simple frontmatter extractor
 import frontmatter from 'front-matter'
 /*

--- a/sites/shared/prebuild/i18n.mjs
+++ b/sites/shared/prebuild/i18n.mjs
@@ -1,42 +1,7 @@
 import path from 'path'
 import fs from 'fs'
-import { en, de, es, fr, nl, languages } from '../../../packages/i18n/src/next.mjs'
+import {build} from '../../../packages/i18n/src/prebuild.mjs'
 
-const locales = { en, de, es, fr, nl }
-
-const writeJson = (site, locale, namespace, content) => fs.writeFileSync(
-  path.resolve(
-    '..',
-    site,
-    'public',
-    'locales',
-    locale,
-    `${namespace}.json`
-  ),
-  JSON.stringify(content)
-)
-
-/*
- * Main method that does what needs doing
- */
-export const prebuildI18n = async (site, only=false) => {
-  // Iterate over locales
-  for (const locale in locales) {
-    // Only English for dev site
-    if (site !== 'dev' || locale === 'en') {
-      console.log('Generating translation files for', locale)
-      const loc = locales[locale]
-      // Fan out into namespaces
-      for (const namespace in loc) {
-        if (!only || only.indexOf(namespace) !== -1) {
-          writeJson(
-            site, locale, namespace,
-            loc[namespace]
-          )
-        }
-      }
-      writeJson(site, locale, 'locales', languages)
-    }
-  }
+export const prebuildI18n = async(site, only=false) => {
+  build((loc) => site !== 'dev' || loc  === 'en', only)
 }
-

--- a/sites/shared/prebuild/i18n.mjs
+++ b/sites/shared/prebuild/i18n.mjs
@@ -1,5 +1,3 @@
-import path from 'path'
-import fs from 'fs'
 import {build} from '../../../packages/i18n/src/prebuild.mjs'
 
 export const prebuildI18n = async(site, only=false) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23670,7 +23670,7 @@ unist-util-visit@^1.4.1:
   dependencies:
     unist-util-visit-parents "^2.0.0"
 
-unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
+unist-util-visit@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==


### PR DESCRIPTION
- reconfigure script now checks if packages have a prebuild script when writing cibuild steps, and adds that as `precibuild_stepx` to the package.json of that package
- `sites/shared/prebuild/i18n.mjs` now calls the build method in `packages/i18n/src/prebuild.mjs` to reduce maintenance