### PR TITLE
core: Code coverage and grain/cut changes

### DIFF
--- a/.github/workflows/tests.all.yml
+++ b/.github/workflows/tests.all.yml
@@ -38,4 +38,10 @@ jobs:
         run: npm run buildall
       - name: Run all tests
         run: npm run testall
-
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./packages/core/coverage/coverage-final.json
+          flags: core
+          name: codecov-core
+          fail_ci_if_error: true

--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -24,10 +24,9 @@ components:
   storybook: 'start-storybook -p 6663'
   test: *notests
 core:
-  coverage: 'nyc npm test && nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'
   report: 'nyc report --reporter=html'
   test: 'nyc -x node_modules -x tests/fixtures -x bin-pack npx mocha tests/*.test.js'
-  testci: "npx mocha tests/*.test.js --reporter ../../tests/reporters/terse.js"
+  testci: "nyc --silent npx mocha tests/*.test.js --reporter ../../tests/reporters/terse.js && nyc report --reporter=json"
   testonly: 'npx mocha tests/*.test.js'
 i18n:
   # react-scripts doesn't handle .mjs files correctly

--- a/markdown/dev/reference/api/part/en.md
+++ b/markdown/dev/reference/api/part/en.md
@@ -11,6 +11,7 @@ and multiple parts together typically make up a pattern.
 
 | Property | Description |
 | --------:| ----------- |
+| `attributes` | An [Attributes](/reference/api/attributes) instance holding the part's attributes |
 | `paths` | A plain object to store your paths in |
 | `points` |  A plain object to store your points in |
 | `render` |  A flag that controls whether to include the part in the render output |

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "chai": "^4.2.0",
     "chai-string": "^1.5.0",
     "chalk": "^4.1.0",
-    "codecov": "^3.7.2",
+    "codecov": "^3.8.3",
     "cross-env": "^7.0.2",
     "esbuild": "^0.14.43",
     "esbuild-plugin-yaml": "^0.0.1",

--- a/packages/core/.nycrc.yaml
+++ b/packages/core/.nycrc.yaml
@@ -1,0 +1,4 @@
+exclude:
+  - tests/fixtures
+  - bin-pack
+

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,9 +36,8 @@
     "vbuild": "VERBOSE=1 node build.js",
     "lab": "cd ../../sites/lab && yarn start",
     "tips": "node ../../scripts/help.mjs",
-    "coverage": "nyc npm test && nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov",
     "report": "nyc report --reporter=html",
-    "testci": "npx mocha tests/*.test.js --reporter ../../tests/reporters/terse.js",
+    "testci": "nyc --silent npx mocha tests/*.test.js --reporter ../../tests/reporters/terse.js && nyc report --reporter=json",
     "testonly": "npx mocha tests/*.test.js",
     "cibuild_step0": "node build.js"
   },

--- a/packages/core/src/part.js
+++ b/packages/core/src/part.js
@@ -359,4 +359,20 @@ Part.prototype.generateTransform = function(transforms) {
   }
 }
 
+/** Chainable way to set the grain property */
+Part.prototype.setGrain = function (grain = 90) {
+  this.attributes.set('data-grain', grain)
+
+  return this
+}
+
+/** Chainable way to set the grain property */
+Part.prototype.setCut = function (cut = { count: 2, mirror: true, onFold: false }) {
+  this.attributes.set('data-cut', cut)
+
+  return this
+}
+
+
+
 export default Part

--- a/packages/core/src/path.js
+++ b/packages/core/src/path.js
@@ -35,6 +35,13 @@ Path.prototype.setRender = function (render = true) {
   return this
 }
 
+/** Chainable way to set the class property */
+Path.prototype.setClass = function (className = false) {
+  if (className) this.attributes.set('class', className)
+
+  return this
+}
+
 /** Adds a move operation to Point to */
 Path.prototype.move = function (to) {
   if (to instanceof Point !== true)

--- a/packages/core/src/point.js
+++ b/packages/core/src/point.js
@@ -231,4 +231,20 @@ Point.prototype.translate = function (x, y) {
   return p
 }
 
+/** Chainable way to set the data-text property (and optional class) */
+Point.prototype.setText = function (text = '', className=false) {
+  this.attributes.set('data-text', text)
+  if (className) this.attributes.set('data-text-class', className)
+
+  return this
+}
+
+/** Chainable way to set the data-circle property (and optional class) */
+Point.prototype.setCircle = function (radius = false, className=false) {
+  if (radius) this.attributes.set('data-circle', radius)
+  if (className) this.attributes.set('data-circle-class', className)
+
+  return this
+}
+
 export default Point

--- a/yarn.lock
+++ b/yarn.lock
@@ -6826,7 +6826,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
 
-codecov@^3.7.2:
+codecov@^3.7.2, codecov@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.8.3.tgz#9c3e364b8a700c597346ae98418d09880a3fdbe7"
   integrity sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==


### PR DESCRIPTION
This started out as me working on keeping grainline and cut info in the part properties. 
But then I added some utility methods to core. And then I was like, hmm tests. 
And then I realized we don't have coverage reports integrated in the repo. So now it's all that. 