### PR TITLE
fix(simon): Remove superfluous notches. Fixes #2399

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 #### Fixed
 
  - Fix issue with boxPleat and yoke Fixes [#2400](https://github.com/freesewing/freesewing/issues/2400)
+ - Removed superfluous notches in button placket, buttonhole placket, and split yoke. Fixes [#2399](https://github.com/freesewing/freesewing/issues/2399)
 
 ### simone
 

--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -23,6 +23,8 @@ Unreleased:
     simon:
       - Fix issue with boxPleat and yoke
         Fixes [#2400](https://github.com/freesewing/freesewing/issues/2400)
+      - Removed superfluous notches in button placket, buttonhole placket, and split yoke.
+        Fixes [#2399](https://github.com/freesewing/freesewing/issues/2399)
     simone:
       - Don't do a negative FBA from there's no need for an FBA
         Fixes [#2121](https://github.com/freesewing/freesewing/issues/2121)

--- a/designs/simon/src/buttonholeplacket.js
+++ b/designs/simon/src/buttonholeplacket.js
@@ -25,6 +25,9 @@ export default (part) => {
   }
 
   for (const id in paths) delete part.paths[id]
+  for (const i of ['waist', 'armholePitch', 'hips', 'armhole']) {
+    delete snippets[i + '-notch']
+  }
   const width = store.get('buttonholePlacketWidth')
   const fold = store.get('buttonholePlacketFoldWidth')
 

--- a/designs/simon/src/buttonplacket.js
+++ b/designs/simon/src/buttonplacket.js
@@ -27,6 +27,9 @@ export default (part) => {
   for (const id in paths) {
     if (id !== 'seam') delete part.paths[id]
   }
+  for (const i in snippets) {
+     if (i.indexOf('notch')) delete snippets[i]
+  }
   macro('flip')
   const width = store.get('buttonPlacketWidth')
   points.placketTopIn = utils.lineIntersectsCurve(

--- a/designs/simon/src/yoke.js
+++ b/designs/simon/src/yoke.js
@@ -35,9 +35,6 @@ export default (part) => {
     points.logo = points.title.shift(-90, 50)
     snippets.logo = new Snippet('logo', points.logo)
     snippets.logo.attr('data-scale', 0.8)
-    if (options.splitYoke) {
-      snippets.sleeveNotch = new Snippet('bnotch', points.armholePitch)
-    }
 
     points.grainlineFrom = points.cbYoke.shift(0, 20)
     points.grainlineTo = points.cbNeck.shift(0, 20)


### PR DESCRIPTION
This fix removes the superfluous notches in Simon's button and buttonhole plackets. 

It also removes the floating bnotch that appears with a split yoke. I came to the conclusion that the bnotch was probably a leftover debug tool or otherwise unintended.

(I am not sure whether I also need to update `designs/simon/CHANGELOG.md`, but I didn't see it updated in a similar previous PR.)