### PR TITLE
Fix Snippet.attr() webpage URLs.

### DIFF
--- a/markdown/dev/reference/api/snippet/attr/en.md
+++ b/markdown/dev/reference/api/snippet/attr/en.md
@@ -10,10 +10,10 @@ Snippet snippet.attr(
 )
 ```
 
-This `Snippet.attr()` method calls [`Attributes.add()`](./attributes#add) under the hood,
+This `Snippet.attr()` method calls [`Attributes.add()`](/reference/api/attributes/add) under the hood,
 but returns the Snippet object.  This allows you to chain different calls together.
 
-If the third parameter is set to `true` it will call [`Attributes.set()`](./attributes#set) instead,
+If the third parameter is set to `true` it will call [`Attributes.set()`](/reference/api/attributes/set) instead,
 thereby overwriting the value of the attribute.
 
 <Example part="snippet_attr">


### PR DESCRIPTION
https://freesewing.dev/reference/api/snippet/attr

The current web page links to 404 pages:
https://freesewing.dev/reference/api/snippet/attributes#add
https://freesewing.dev/reference/api/snippet/attributes#set