### PR TITLE
notch/bnotch snippets come from plugin-notches, not plugin-theme

### DIFF
--- a/markdown/dev/reference/api/snippets/bnotch/en.md
+++ b/markdown/dev/reference/api/snippets/bnotch/en.md
@@ -5,7 +5,7 @@ title: bnotch
 The `bnotch` snippet is intended for notches at the back, or when you
 need an alternative to the default `notch`.
 
-It is provided by [plugin-theme](/reference/plugins/theme/).
+It is provided by [plugin-notches](/reference/plugins/notches/).
 
 ```js
 snippets.demo = new Snippet('bnotch', points.anchor)

--- a/markdown/dev/reference/api/snippets/notch/en.md
+++ b/markdown/dev/reference/api/snippets/notch/en.md
@@ -3,7 +3,7 @@ title: notch
 ---
 
 The `notch` snippet is intended for notches and is
-provided by [plugin-theme](/reference/plugins/theme/).
+provided by [plugin-notches](/reference/plugins/notches/).
 
 ```js
 snippets.demo = new Snippet('bnotch', points.anchor)


### PR DESCRIPTION
As I understand it, at one time notch and bnotch were in plugin-theme, but they were subsequently moved to plugin-notches. (A minor documentation issue, but it did cause me some grief spending time looking through the plugin-theme source code, trying to find where notch was defined.)