### PR TITLE
Document all plugin-bundle plugins.

### DIFF
--- a/markdown/dev/reference/plugins/banner/en.md
+++ b/markdown/dev/reference/plugins/banner/en.md
@@ -10,6 +10,12 @@ This macro allows you to add repeating text along a path.
 
 <Example part="plugin_banner">Example of the banner macro provided by this plugin</Example>
 
+<Tip>
+
+The banner plugin is part of our [plugin-bundle](/reference/plugins/bundle)
+
+</Tip>
+
 ## Installation
 
 ```sh

--- a/markdown/dev/reference/plugins/bartack/en.md
+++ b/markdown/dev/reference/plugins/bartack/en.md
@@ -11,6 +11,12 @@ tight zig-zag stitches used to enforce a seam — to your design.
 
 <Example part="plugin_bartack">Example of the bartack macro provided by this plugin</Example>
 
+<Tip>
+
+The bartack plugin is part of our [plugin-bundle](/reference/plugins/bundle)
+
+</Tip>
+
 ## Installation
 
 ```sh

--- a/markdown/dev/reference/plugins/bundle/en.md
+++ b/markdown/dev/reference/plugins/bundle/en.md
@@ -4,14 +4,20 @@ title: "@freesewing/plugin-bundle"
 
 The **@freesewing/plugin-bundle** plugin bundles the most common FreeSewing build-time plugins:
 
+- [plugin-banner](/reference/plugins/banner) : Add repeating text to your patterns
+- [plugin-bartack](/reference/plugins/bartack) : Add bartacks to your patterns
+- [plugin-buttons](/reference/plugins/buttons) : Add buttons, buttonholes, and snaps to your patterns
 - [plugin-cutonfold](/reference/plugins/cutonfold) : Add cut-on-fold indicators to your patterns
 - [plugin-dimension](/reference/plugins/dimension) : Add dimensions to your (paperless) patterns
 - [plugin-grainline](/reference/plugins/grainline) : Add grainline indicators to your patterns
-- [plugin-logo](/reference/plugins/logo) : Add a scalebox to your patterns
-- [plugin-scalebox](/reference/plugins/scalebox) : Add pretty titles to your pattern parts
+- [plugin-logo](/reference/plugins/logo) : Add a FreeSewing logo to your patterns
+- [plugin-measurements](/reference/plugins/measurements) : Make extra, calculated measurements available to your patterns
+- [plugin-mirror](/reference/plugins/mirror) : Mirror points and paths in your patterns
+- [plugin-notches](/reference/plugins/notches) : Add notches to your patterns
+- [plugin-scalebox](/reference/plugins/scalebox) : Add scaleboxes to your pattern parts
+- [plugin-round](/reference/plugins/round) : Create rounded corners in your patterns
+- [plugin-sprinkle](/reference/plugins/sprinkle) : Add multiple snippets to your patterns
 - [plugin-title](/reference/plugins/title) : Add pretty titles to your pattern parts
-- [plugin-round](/reference/plugins/round) : Rounds corners
-- [plugin-sprinkle](/reference/plugins/sprinkle) : Add multiple snippets to your pattern
 
 Almost all patterns use these plugins, so it made sense to bundle them.
 

--- a/markdown/dev/reference/plugins/measurements/en.md
+++ b/markdown/dev/reference/plugins/measurements/en.md
@@ -17,6 +17,12 @@ It will add the following measurements:
 - `waistFrontArc` (if both `waist` and `waistBack` are provided)
 - `crossSeamBack` (if both `crossSeam` and `crossSeamFront` are available)
 
+<Tip>
+
+The measurements plugin is part of our [plugin-bundle](/reference/plugins/bundle)
+
+</Tip>
+
 ## Installation
 
 ```sh

--- a/markdown/dev/reference/plugins/mirror/en.md
+++ b/markdown/dev/reference/plugins/mirror/en.md
@@ -8,6 +8,12 @@ a number of points and/or paths around a given mirror line.
 
 <Example part="plugin_mirror">Example of the mirror plugin</Example>
 
+<Tip>
+
+The mirror plugin is part of our [plugin-bundle](/reference/plugins/bundle)
+
+</Tip>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Some plugin-bundle plugins (the ones added later?) weren't listed in the documentation. This PR fixes that situation.