### PR TITLE
[fix] fix parsing errors in markdown preventing successful dev build

### DIFF
--- a/markdown/dev/guides/markdown/custom-components/en.md
+++ b/markdown/dev/guides/markdown/custom-components/en.md
@@ -59,7 +59,8 @@ user -> frontend
 
 ```
 
-An example graph using the **Dot** custom component </Dot>
+An example graph using the **Dot** custom component
+</Dot>
 
 Use **Dot** to add a [Graphviz](https://graphviz.org/) graph written in
 the [Dot graph description language](https://en.wikipedia.org/wiki/DOT_\(graph_description_language\)).

--- a/markdown/dev/howtos/ways-to-contribute/showcase-our-patterns/en.md
+++ b/markdown/dev/howtos/ways-to-contribute/showcase-our-patterns/en.md
@@ -42,7 +42,7 @@ Create an issue [on Github](https://github.com/freesewing/freesewing/issues/new?
 
 ### Email
 
-Email your pictures — or a link to them — to <showcase@freesewing.org>.
+Email your pictures — or a link to them — to [showcase@freesewing.org](showcase@freesewing.org).
 
 ## Tips for great pictures
 

--- a/markdown/dev/tutorials/getting-started-gitpod/en.md
+++ b/markdown/dev/tutorials/getting-started-gitpod/en.md
@@ -12,4 +12,5 @@ https://gitpod.io/#https://github.com/freesewing/freesewing
 We recommend that you fork our repository so you can push changes to the repository.
 To do so, simple adapt the URL above as follows:
 
-https://gitpod.io/#url-to-your-fork </Tip>
+https://gitpod.io/#url-to-your-fork
+</Tip>

--- a/markdown/dev/tutorials/getting-started-linux/dev-start/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/dev-start/en.md
@@ -28,7 +28,8 @@ This is all you need to work on existing designs. If you'd like to add a new des
 yarn new design
 ```
 
-Just make sure to re-start the lab afterwards with `yarn lab` </Tip>
+Just make sure to re-start the lab afterwards with `yarn lab`
+</Tip>
 
 ## Standalone development
 

--- a/markdown/dev/tutorials/getting-started-mac/dev-start/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/dev-start/en.md
@@ -28,7 +28,8 @@ This is all you need to work on existing designs. If you'd like to add a new des
 yarn new design
 ```
 
-Just make sure to re-start the lab afterwards with `yarn lab` </Tip>
+Just make sure to re-start the lab afterwards with `yarn lab`
+</Tip>
 
 ## Standalone development
 

--- a/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
@@ -45,8 +45,9 @@ Click on any of the options we've added to our pattern, and your bib will be dra
 
 The `lengthRatio` option controls the length of our bib. Testing it confirms that it only influences the length:
 
-\<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "option", option: "lengthRatio" } }}>
-Your bib with the lengthRatio option sampled </Example>
+<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "option", option: "lengthRatio" } }}>
+Your bib with the lengthRatio option sampled
+</Example>
 
 ### neckRatio
 
@@ -57,8 +58,9 @@ neck opening.
 Testing it confirms this. We can also see that as the neck opening gets smaller, we will rotate the straps
 further out of the way to avoid overlap:
 
-\<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "option", option: "neckRatio" } }} >
-Your bib with the neckRatio option sampled </Example>
+<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "option", option: "neckRatio" } }} >
+Your bib with the neckRatio option sampled
+</Example>
 
 ### widthRatio
 
@@ -79,8 +81,9 @@ covered in this tutorial. It is left _as an exercise to the reader_.
 
 </Note>
 
-\<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "option", option: "widthRatio" } }}>
-Your bib with the widthRatio option sampled </Example>
+<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "option", option: "widthRatio" } }}>
+Your bib with the widthRatio option sampled
+</Example>
 
 ## Testing measurements
 
@@ -89,8 +92,9 @@ This gives you the option to determine how any given measurement is influencing 
 
 For our bib, we only use one measurement, so it influences the entire pattern:
 
-\<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "measurement", measurement: "head" } }}>
-Your bib with the head circumference measurement sampled </Example>
+<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "measurement", measurement: "head" } }}>
+Your bib with the head circumference measurement sampled
+</Example>
 
 ## Testing models
 
@@ -104,8 +108,9 @@ set of measurements.
 But most patterns use multiple measurements, and you'll find this test gives you insight into how your
 pattern will adapt to differently sized bodies.
 
-\<Example sample pattern="tutorial" part="bib" settings={{ sample: { type: "models", models: { baby1: { head: 340 }, baby2: { head: 350 }, baby3: { head: 360 }, baby4: { head: 370 }, baby5: { head: 380 }, baby6: { head: 390 }, baby7: { head: 400 }, baby8: { head: 410 }, baby9: { head: 420 } } } }}>
-Your bib sampled for a range of baby sizes </Example>
+<Example sample pattern="tutorial" part="bib" settings={{ sample: { type: "models", models: { baby1: { head: 340 }, baby2: { head: 350 }, baby3: { head: 360 }, baby4: { head: 370 }, baby5: { head: 380 }, baby6: { head: 390 }, baby7: { head: 400 }, baby8: { head: 410 }, baby9: { head: 420 } } } }}>
+Your bib sampled for a range of baby sizes
+</Example>
 
 ## The antperson test
 
@@ -123,7 +128,8 @@ don't scale, and you should avoid them.
 
 The best patterns will pass the antperson test with 2 patterns exactly the same, where one will simply be 1/10th the scale of the other.
 
-\<Example sample pattern="tutorial" part="bib" settings={{ sample: { type: "models", models: { ant: { head: 39 }, man: { head: 390 }, } } }}>
-Congratulations, your bib passes the antperson test </Example>
+<Example sample pattern="tutorial" part="bib" settings={{ sample: { type: "models", models: { ant: { head: 39 }, man: { head: 390 }, } } }}>
+Congratulations, your bib passes the antperson test
+</Example>
 
 When you're happy with how your pattern passes these tests, it's time to complete it.


### PR DESCRIPTION
Fixes the errors returned when running `yarn build` in `sites/dev`. I guess maybe the linting made these changes, but running `yarn fixdocs` in root didn't reset them, so I'm not fully sure where they came from, but they're all from this commit: https://github.com/freesewing/freesewing/commit/265ad404da6763e105be51ec2aa1ca142f9e100f