### PR TITLE
wip: Joost's parts proposal

### DIFF
--- a/designs/aaron/build.js
+++ b/designs/aaron/build.js
@@ -23,17 +23,22 @@ const options = {
 
 // Different formats
 const formats = {
-  cjs: "dist/index.js",
-  esm: "dist/index.mjs",
+  cjs: "js",
+  esm: "mjs",
 }
 
 // Let esbuild generate different formats
 let result
 (async () => {
-  for (const [format, outfile] of Object.entries(formats)) {
+  for (const [format, ext] of Object.entries(formats)) {
+    // Regular build
     result = await esbuild
-    .build({ ...options, outfile, format })
-    .catch(() => process.exit(1))
+      .build({ ...options, format, outfile: `dist/index.${ext}` })
+      .catch(() => process.exit(1))
+    // Config build
+    await esbuild
+      .build({ ...options, format, outfile: `dist/config.${ext}`, entryPoints: ['config/index.js'] })
+      .catch(() => process.exit(1))
   }
 
   if (process.env.VERBOSE) {
@@ -41,11 +46,13 @@ let result
     console.log(info)
   }
 
+
   // Also build a version that has all dependencies bundled
   // This makes it easy to run tests
   await esbuild
   .build({
     ...options,
+    entryPoints: ['src/index.js'],
     minify: false,
     sourcemap: false,
     outfile: 'tests/dist/index.mjs',

--- a/designs/aaron/config/index.js
+++ b/designs/aaron/config/index.js
@@ -1,8 +1,6 @@
 import { version } from '../package.json'
-import configHelpers from '@freesewing/config-helpers'
-const { pctBasedOn } = configHelpers
 
-export default {
+export const info = {
   version,
   name: 'aaron',
   design: 'Joost De Cock',
@@ -22,7 +20,9 @@ export default {
       'lengthBonus',
     ],
   },
-  measurements: [
+}
+
+export const measurements = [
     'biceps',
     'chest',
     'hpsToWaistBack',
@@ -31,43 +31,7 @@ export default {
     'shoulderSlope',
     'shoulderToShoulder',
     'hips',
-  ],
-  optionalMeasurements: ['highBust'],
-  dependencies: {
-    front: 'base',
-    back: 'front',
-  },
-  inject: {
-    front: 'base',
-    back: 'front',
-  },
-  hide: ['base'],
-  options: {
-    // Constants
-    brianFitCollar: false,
-    collarFactor: 4.8,
-    acrossBackFactor: 0.97,
-    backNeckCutout: 0.05,
-    bicepsEase: 0.05,
-    shoulderEase: 0,
-    collarEase: 0,
-    frontArmholeDeeper: 0,
-    armholeDepthFactor: 0.6,
-    shoulderSlopeReduction: 0,
+]
 
-    // Percentages
-    armholeDrop: { pct: 10, min: 0, max: 75 },
-    backlineBend: { pct: 50, min: 25, max: 100 },
-    chestEase: { pct: 8, min: 0, max: 20, ...pctBasedOn('chest') },
-    hipsEase: { pct: 8, min: 0, max: 20 },
-    lengthBonus: { pct: 10, min: -20, max: 60 },
-    necklineBend: { pct: 100, min: 40, max: 100 },
-    necklineDrop: { pct: 20, min: 10, max: 35 },
-    stretchFactor: { pct: 5, min: 0, max: 15 },
-    shoulderStrapWidth: { pct: 15, min: 10, max: 40 },
-    shoulderStrapPlacement: { pct: 40, min: 20, max: 80 },
+export const optionalMeasurements = ['highBust']
 
-    // draft for high bust
-    draftForHighBust: { bool: false },
-  },
-}

--- a/designs/aaron/config/options.js
+++ b/designs/aaron/config/options.js
@@ -1,0 +1,28 @@
+import configHelpers from '@freesewing/config-helpers'
+const { pctBasedOn } = configHelpers
+
+export const brianFitCollar = false
+export const brianFitSleeve = false
+export const acrossBackFactor = 0.97
+export const backNeckCutout = 0.05
+export const bicepsEase = 0.05
+export const shoulderEase = 0
+export const collarEase = 0
+export const frontArmholeDeeper = 0
+export const armholeDepthFactor = 0.6
+export const shoulderSlopeReduction = 0
+
+// Percentages
+export const armholeDrop = { pct: 10, min: 0, max: 75 }
+export const backlineBend = { pct: 50, min: 25, max: 100 }
+export const chestEase = { pct: 8, min: 0, max: 20, ...pctBasedOn('chest') }
+export const hipsEase = { pct: 8, min: 0, max: 20 }
+export const lengthBonus = { pct: 10, min: -20, max: 60 }
+export const necklineBend = { pct: 100, min: 40, max: 100 }
+export const necklineDrop = { pct: 20, min: 10, max: 35 }
+export const stretchFactor = { pct: 5, min: 0, max: 15 }
+export const shoulderStrapWidth = { pct: 15, min: 10, max: 40 }
+export const shoulderStrapPlacement = { pct: 40, min: 20, max: 80 }
+
+// draft for high bust
+export const draftForHighBust = { bool: false }

--- a/designs/aaron/src/back.js
+++ b/designs/aaron/src/back.js
@@ -1,103 +1,108 @@
 import { dimensions } from './shared'
+import front from "./front.js"
 
-export default function (part) {
-  let {
-    store,
-    sa,
-    Point,
-    points,
-    Path,
-    paths,
-    options,
-    complete,
-    paperless,
-    macro,
-    utils,
-    units,
-    measurements,
-  } = part.shorthand()
+export default {
+  from: front,
+  name: 'back',
+  draft: function (part) {
+    const {
+      store,
+      sa,
+      Point,
+      points,
+      Path,
+      paths,
+      options,
+      complete,
+      paperless,
+      macro,
+      utils,
+      units,
+      measurements,
+    } = part.shorthand()
 
-  // Lower back neck a bit
-  points.cbNeck.y = measurements.neck / 10
+    // Lower back neck a bit
+    points.cbNeck.y = measurements.neck / 10
 
-  points.strapLeftCp2 = utils.beamsIntersect(
-    points.strapLeft,
-    points.strapCenter.rotate(90, points.strapLeft),
-    points.cbNeck,
-    points.cbNeck.shift(0, 10)
-  )
+    points.strapLeftCp2 = utils.beamsIntersect(
+      points.strapLeft,
+      points.strapCenter.rotate(90, points.strapLeft),
+      points.cbNeck,
+      points.cbNeck.shift(0, 10)
+    )
 
-  points.armholeCp2 = points.armhole.shiftFractionTowards(
-    points.armholeCorner,
-    options.backlineBend
-  )
-  points.strapRightCp1 = points.strapRight.shiftFractionTowards(
-    points.armholeCorner,
-    options.backlineBend
-  )
+    points.armholeCp2 = points.armhole.shiftFractionTowards(
+      points.armholeCorner,
+      options.backlineBend
+    )
+    points.strapRightCp1 = points.strapRight.shiftFractionTowards(
+      points.armholeCorner,
+      options.backlineBend
+    )
 
-  points.anchor = points.cbNeck.clone()
+    points.anchor = points.cbNeck.clone()
 
-  // Seamline
-  paths.seam = new Path()
-    .move(points.cbNeck)
-    .line(points.cbHem)
-    .line(points.hem)
-    .curve_(points.hipsCp2, points.armhole)
-    .curve(points.armholeCp2, points.strapRightCp1, points.strapRight)
-    .line(points.strapLeft)
-    .line(points.strapLeft)
-    .curve(points.strapLeftCp2, points.cbNeck, points.cbNeck)
-    .close()
-    .attr('class', 'fabric')
+    // Seamline
+    paths.seam = new Path()
+      .move(points.cbNeck)
+      .line(points.cbHem)
+      .line(points.hem)
+      .curve_(points.hipsCp2, points.armhole)
+      .curve(points.armholeCp2, points.strapRightCp1, points.strapRight)
+      .line(points.strapLeft)
+      .line(points.strapLeft)
+      .curve(points.strapLeftCp2, points.cbNeck, points.cbNeck)
+      .close()
+      .attr('class', 'fabric')
 
-  // Complete pattern?
-  if (complete) {
-    let neckOpeningLength =
-      new Path()
-        .move(points.strapLeft)
-        .curve(points.strapLeftCp2, points.cbNeck, points.cbNeck)
-        .length() + store.get('frontNeckOpeningLength')
-    let armholeLength =
-      new Path()
-        .move(points.armhole)
-        .curve(points.armholeCp2, points.strapRightCp1, points.strapRight)
-        .length() + store.get('frontArmholeLength')
-    points.bindingAnchor = new Point(points.armhole.x / 4, points.armhole.y)
-      .attr('data-text', 'cutTwoStripsToFinishTheArmholes')
-      .attr('data-text', ':\n')
-      .attr('data-text', `2x: ${units(sa * 6 || 60)} x ${units(armholeLength * 0.95 + 2 * sa)}`)
-      .attr('data-text', '\n \n')
-      .attr('data-text', 'cutOneStripToFinishTheNeckOpening')
-      .attr('data-text', ':\n')
-      .attr('data-text', 'width')
-      .attr('data-text', ':')
-      .attr(
-        'data-text',
-        `${units((sa || 10) * 6)} x ${units(neckOpeningLength * 2 * 0.95 + 2 * sa)}`
-      )
-    //.attr('data-text-class', 'text-sm')
+    // Complete pattern?
+    if (complete) {
+      let neckOpeningLength =
+        new Path()
+          .move(points.strapLeft)
+          .curve(points.strapLeftCp2, points.cbNeck, points.cbNeck)
+          .length() + store.get('frontNeckOpeningLength')
+      let armholeLength =
+        new Path()
+          .move(points.armhole)
+          .curve(points.armholeCp2, points.strapRightCp1, points.strapRight)
+          .length() + store.get('frontArmholeLength')
+      points.bindingAnchor = new Point(points.armhole.x / 4, points.armhole.y)
+        .attr('data-text', 'cutTwoStripsToFinishTheArmholes')
+        .attr('data-text', ':\n')
+        .attr('data-text', `2x: ${units(sa * 6 || 60)} x ${units(armholeLength * 0.95 + 2 * sa)}`)
+        .attr('data-text', '\n \n')
+        .attr('data-text', 'cutOneStripToFinishTheNeckOpening')
+        .attr('data-text', ':\n')
+        .attr('data-text', 'width')
+        .attr('data-text', ':')
+        .attr(
+          'data-text',
+          `${units((sa || 10) * 6)} x ${units(neckOpeningLength * 2 * 0.95 + 2 * sa)}`
+        )
+      //.attr('data-text-class', 'text-sm')
 
-    macro('cutonfold', {
-      from: points.cfNeck,
-      to: points.cfHem,
-      grainline: true,
-    })
+      macro('cutonfold', {
+        from: points.cfNeck,
+        to: points.cfHem,
+        grainline: true,
+      })
 
-    macro('title', { at: points.title, nr: 2, title: 'back' })
-    points.scaleboxAnchor = points.scalebox = points.title.shift(90, 100)
-    macro('scalebox', { at: points.scalebox })
+      macro('title', { at: points.title, nr: 2, title: 'back' })
+      points.scaleboxAnchor = points.scalebox = points.title.shift(90, 100)
+      macro('scalebox', { at: points.scalebox })
+    }
+
+    // Paperless?
+    if (paperless) {
+      dimensions(macro, points, sa)
+      macro('vd', {
+        from: points.cbHem,
+        to: points.cbNeck,
+        x: points.cbHem.x - sa - 15,
+      })
+    }
+
+    return part
   }
-
-  // Paperless?
-  if (paperless) {
-    dimensions(macro, points, sa)
-    macro('vd', {
-      from: points.cbHem,
-      to: points.cbNeck,
-      x: points.cbHem.x - sa - 15,
-    })
-  }
-
-  return part
 }

--- a/designs/aaron/src/front.js
+++ b/designs/aaron/src/front.js
@@ -1,169 +1,174 @@
 import { dimensions } from './shared'
+import { base } from '@freesewing/brian'
 
-export default function (part) {
-  let {
-    utils,
-    store,
-    sa,
-    Point,
-    points,
-    Path,
-    paths,
-    Snippet,
-    snippets,
-    options,
-    measurements,
-    complete,
-    paperless,
-    macro,
-  } = part.shorthand()
+export default {
+  from: base,
+  name: 'front',
+  draft: function (part) {
+    const {
+      utils,
+      store,
+      sa,
+      Point,
+      points,
+      Path,
+      paths,
+      Snippet,
+      snippets,
+      options,
+      measurements,
+      complete,
+      paperless,
+      macro,
+    } = part.shorthand()
 
-  // Hide Brian paths
-  for (let key of Object.keys(paths)) paths[key].render = false
+    // Hide Brian paths
+    for (let key of Object.keys(paths)) paths[key].render = false
 
-  // Handle stretch
-  for (let i in points) points[i].x = points[i].x * (1 - options.stretchFactor)
+    // Handle stretch
+    for (let i in points) points[i].x = points[i].x * (1 - options.stretchFactor)
 
-  // Clone cb (center back) into cf (center front)
-  for (let key of ['Neck', 'Shoulder', 'Armhole', 'Hips', 'Hem']) {
-    points[`cf${key}`] = points[`cb${key}`].clone()
-  }
-
-  // Neckline
-  points.cfNeck = points.cfNeck.shift(-90, options.necklineDrop * measurements.hpsToWaistBack)
-
-  // Strap
-  points.strapCenter = points.neck.shiftFractionTowards(
-    points.shoulder,
-    options.shoulderStrapPlacement
-  )
-  points.strapLeft = points.strapCenter.shiftTowards(
-    points.neck,
-    points.neck.dist(points.shoulder) * options.shoulderStrapWidth
-  )
-  points.strapRight = points.strapLeft.rotate(180, points.strapCenter)
-  points.necklineCorner = utils.beamsIntersect(
-    points.strapLeft,
-    points.strapRight.rotate(-90, points.strapLeft),
-    points.cfNeck.shift(0, points.armholePitch.x / 4),
-    points.cfNeck
-  )
-  points.strapLeftCp2 = points.strapLeft.shiftFractionTowards(
-    points.necklineCorner,
-    options.necklineBend
-  )
-  points.cfNeckCp1 = points.cfNeck.shiftFractionTowards(points.necklineCorner, options.necklineBend)
-
-  // This will come in handy
-  store.set('armholeY', points.armhole.y * (1 + options.armholeDrop))
-
-  // Hips
-  points.hips.x =
-    ((measurements.hips + options.hipsEase * measurements.hips) / 4) * (1 - options.stretchFactor)
-  points.waist.x = points.hips.x // Because stretch
-
-  points.hipsCp2 = new Point(
-    points.hips.x,
-    store.get('armholeY') + (points.hips.y - store.get('armholeY')) / 2
-  )
-
-  // Hem
-  points.hem.x = points.hips.x
-
-  // Armhole
-  points.armhole = utils.beamIntersectsY(
-    points.armhole,
-    points.hips,
-    points.armhole.y * (1 + options.armholeDrop)
-  )
-  points.armholeCorner = utils.beamsIntersect(
-    points.armhole,
-    points.armhole.shift(180, 10),
-    points.strapRight,
-    points.strapLeft.rotate(90, points.strapRight)
-  )
-  points.armholeCp2 = points.armhole.shiftFractionTowards(points.armholeCorner, 0.5)
-  points.strapRightCp1 = points.strapRight.shiftFractionTowards(points.armholeCorner, 0.5)
-
-  points.anchor = points.cfNeck.clone()
-
-  // Seamline
-  paths.seam = new Path()
-    .move(points.cfNeck)
-    .line(points.cfHem)
-    .line(points.hem)
-    .curve_(points.hipsCp2, points.armhole)
-    .curve(points.armholeCp2, points.strapRightCp1, points.strapRight)
-    .line(points.strapLeft)
-    .curve(points.strapLeftCp2, points.cfNeckCp1, points.cfNeck)
-    .close()
-    .attr('class', 'fabric')
-
-  // Store length of armhole and neck opening
-  store.set(
-    'frontArmholeLength',
-    new Path()
-      .move(points.armhole)
-      .curve(points.armholeCp2, points.strapRightCp1, points.strapRight)
-      .length()
-  )
-  store.set(
-    'frontNeckOpeningLength',
-    new Path()
-      .move(points.strapLeft)
-      .curve(points.cfNeckCp1, points.cfNeckCp1, points.cfNeck)
-      .length()
-  )
-
-  // Complete pattern?
-  if (complete) {
-    macro('cutonfold', {
-      from: points.cfNeck,
-      to: points.cfHem,
-      grainline: true,
-    })
-    points.title = new Point(points.waist.x / 2, points.waist.y)
-    macro('title', { at: points.title, nr: 1, title: 'front' })
-    points.logo = points.title.shift(-90, 75)
-    snippets.logo = new Snippet('logo', points.logo)
-
-    if (sa) {
-      let saShoulder = new Path().move(points.strapRight).line(points.strapLeft).offset(sa)
-      paths.saShoulder = new Path()
-        .move(points.strapRight)
-        .line(saShoulder.start())
-        .join(saShoulder)
-        .line(points.strapLeft)
-        .attr('class', 'fabric sa')
-      paths.sa = new Path()
-        .move(points.cfHem)
-        .line(points.cfHem)
-        .join(
-          new Path()
-            .move(points.cfHem)
-            .line(points.hem)
-            .offset(sa * 2.5)
-        )
-        .join(
-          new Path()
-            .move(points.hem)
-            .curve_(points.waist, points.armhole)
-            .offset(sa)
-            .line(points.armhole)
-        )
-        .attr('class', 'fabric sa')
+    // Clone cb (center back) into cf (center front)
+    for (let key of ['Neck', 'Shoulder', 'Armhole', 'Hips', 'Hem']) {
+      points[`cf${key}`] = points[`cb${key}`].clone()
     }
-  }
 
-  // Paperless?
-  if (paperless) {
-    dimensions(macro, points, sa)
-    macro('vd', {
-      from: points.cfHem,
-      to: points.cfNeck,
-      x: points.cfHem.x - sa - 15,
-    })
-  }
+    // Neckline
+    points.cfNeck = points.cfNeck.shift(-90, options.necklineDrop * measurements.hpsToWaistBack)
 
-  return part
+    // Strap
+    points.strapCenter = points.neck.shiftFractionTowards(
+      points.shoulder,
+      options.shoulderStrapPlacement
+    )
+    points.strapLeft = points.strapCenter.shiftTowards(
+      points.neck,
+      points.neck.dist(points.shoulder) * options.shoulderStrapWidth
+    )
+    points.strapRight = points.strapLeft.rotate(180, points.strapCenter)
+    points.necklineCorner = utils.beamsIntersect(
+      points.strapLeft,
+      points.strapRight.rotate(-90, points.strapLeft),
+      points.cfNeck.shift(0, points.armholePitch.x / 4),
+      points.cfNeck
+    )
+    points.strapLeftCp2 = points.strapLeft.shiftFractionTowards(
+      points.necklineCorner,
+      options.necklineBend
+    )
+    points.cfNeckCp1 = points.cfNeck.shiftFractionTowards(points.necklineCorner, options.necklineBend)
+
+    // This will come in handy
+    store.set('armholeY', points.armhole.y * (1 + options.armholeDrop))
+
+    // Hips
+    points.hips.x =
+      ((measurements.hips + options.hipsEase * measurements.hips) / 4) * (1 - options.stretchFactor)
+    points.waist.x = points.hips.x // Because stretch
+
+    points.hipsCp2 = new Point(
+      points.hips.x,
+      store.get('armholeY') + (points.hips.y - store.get('armholeY')) / 2
+    )
+
+    // Hem
+    points.hem.x = points.hips.x
+
+    // Armhole
+    points.armhole = utils.beamIntersectsY(
+      points.armhole,
+      points.hips,
+      points.armhole.y * (1 + options.armholeDrop)
+    )
+    points.armholeCorner = utils.beamsIntersect(
+      points.armhole,
+      points.armhole.shift(180, 10),
+      points.strapRight,
+      points.strapLeft.rotate(90, points.strapRight)
+    )
+    points.armholeCp2 = points.armhole.shiftFractionTowards(points.armholeCorner, 0.5)
+    points.strapRightCp1 = points.strapRight.shiftFractionTowards(points.armholeCorner, 0.5)
+
+    points.anchor = points.cfNeck.clone()
+
+    // Seamline
+    paths.seam = new Path()
+      .move(points.cfNeck)
+      .line(points.cfHem)
+      .line(points.hem)
+      .curve_(points.hipsCp2, points.armhole)
+      .curve(points.armholeCp2, points.strapRightCp1, points.strapRight)
+      .line(points.strapLeft)
+      .curve(points.strapLeftCp2, points.cfNeckCp1, points.cfNeck)
+      .close()
+      .attr('class', 'fabric')
+
+    // Store length of armhole and neck opening
+    store.set(
+      'frontArmholeLength',
+      new Path()
+        .move(points.armhole)
+        .curve(points.armholeCp2, points.strapRightCp1, points.strapRight)
+        .length()
+    )
+    store.set(
+      'frontNeckOpeningLength',
+      new Path()
+        .move(points.strapLeft)
+        .curve(points.cfNeckCp1, points.cfNeckCp1, points.cfNeck)
+        .length()
+    )
+
+    // Complete pattern?
+    if (complete) {
+      macro('cutonfold', {
+        from: points.cfNeck,
+        to: points.cfHem,
+        grainline: true,
+      })
+      points.title = new Point(points.waist.x / 2, points.waist.y)
+      macro('title', { at: points.title, nr: 1, title: 'front' })
+      points.logo = points.title.shift(-90, 75)
+      snippets.logo = new Snippet('logo', points.logo)
+
+      if (sa) {
+        let saShoulder = new Path().move(points.strapRight).line(points.strapLeft).offset(sa)
+        paths.saShoulder = new Path()
+          .move(points.strapRight)
+          .line(saShoulder.start())
+          .join(saShoulder)
+          .line(points.strapLeft)
+          .attr('class', 'fabric sa')
+        paths.sa = new Path()
+          .move(points.cfHem)
+          .line(points.cfHem)
+          .join(
+            new Path()
+              .move(points.cfHem)
+              .line(points.hem)
+              .offset(sa * 2.5)
+          )
+          .join(
+            new Path()
+              .move(points.hem)
+              .curve_(points.waist, points.armhole)
+              .offset(sa)
+              .line(points.armhole)
+          )
+          .attr('class', 'fabric sa')
+      }
+    }
+
+    // Paperless?
+    if (paperless) {
+      dimensions(macro, points, sa)
+      macro('vd', {
+        from: points.cfHem,
+        to: points.cfNeck,
+        x: points.cfHem.x - sa - 15,
+      })
+    }
+
+    return part
+  }
 }

--- a/designs/aaron/src/index.js
+++ b/designs/aaron/src/index.js
@@ -1,38 +1,33 @@
+// FreeSewing core library
 import freesewing from '@freesewing/core'
-import Brian from '@freesewing/brian'
-import plugins from '@freesewing/plugin-bundle'
-import plugin from '@freesewing/plugin-bust' // Note: conditional plugin
-import config from '../config'
+// FreeSewing Plugins
+import pluginBundle from '@freesewing/plugin-bundle'
+import bustPlugin from '@freesewing/plugin-bust' // Note: conditional plugin
+// Design config & options
+import { info, measurements, optionalMeasurements } from '../config/index'
+import * as options from '../config/options'
+// Design parts
+import back from './back'
+import front from './front'
 
-// Parts
-import draftBack from './back'
-import draftFront from './front'
-
-/* Check to see whether we should load the bust plugin
- * Only of the `draftForHighBust` options is set
- * AND the highBust measurement is available
- */
-const condition = (settings = false) =>
-  settings &&
-  settings.options &&
-  settings.options.draftForHighBust &&
-  settings.measurements.highBust
-    ? true
-    : false
-
-// Create design
-const Aaron = new freesewing.Design(config, plugins, { plugin, condition })
-
-// Attach draft methods to prototype
-Aaron.prototype.draftBase = function (part) {
-  // Getting the base part from Brian
-  return new Brian(this.settings).draftBase(part)
-}
-Aaron.prototype.draftFront = (part) => draftFront(part)
-Aaron.prototype.draftBack = (part) => draftBack(part)
+// Setup design
+const Aaron = new freesewing.Design({
+  ...info,
+  measurements,
+  optionalMeasurements,
+  options: { ...options },
+  parts: { back, front },
+  plugins: pluginBundle,
+  conditionalPlugins: {
+    plugin: bustPlugin,
+    condition: (settings=false) =>
+      settings?.options?.draftForHighBust &&
+      settings?.measurements?.highBust
+      ? true : false
+  }
+})
 
 // Named exports
-export { config, Aaron }
-
+export { front, back, Aaron }
 // Default export
 export default Aaron

--- a/designs/brian/build.js
+++ b/designs/brian/build.js
@@ -23,17 +23,22 @@ const options = {
 
 // Different formats
 const formats = {
-  cjs: "dist/index.js",
-  esm: "dist/index.mjs",
+  cjs: "js",
+  esm: "mjs",
 }
 
 // Let esbuild generate different formats
 let result
 (async () => {
-  for (const [format, outfile] of Object.entries(formats)) {
+  for (const [format, ext] of Object.entries(formats)) {
+    // Regular build
     result = await esbuild
-    .build({ ...options, outfile, format })
-    .catch(() => process.exit(1))
+      .build({ ...options, format, outfile: `dist/index.${ext}` })
+      .catch(() => process.exit(1))
+    // Config build
+    await esbuild
+      .build({ ...options, format, outfile: `dist/config.${ext}`, entryPoints: ['config/index.js'] })
+      .catch(() => process.exit(1))
   }
 
   if (process.env.VERBOSE) {
@@ -41,11 +46,13 @@ let result
     console.log(info)
   }
 
+
   // Also build a version that has all dependencies bundled
   // This makes it easy to run tests
   await esbuild
   .build({
     ...options,
+    entryPoints: ['src/index.js'],
     minify: false,
     sourcemap: false,
     outfile: 'tests/dist/index.mjs',

--- a/designs/brian/config/index.js
+++ b/designs/brian/config/index.js
@@ -1,6 +1,6 @@
 import { version } from '../package.json'
 
-export default {
+export const info = {
   version,
   name: 'brian',
   design: 'Joost De Cock',
@@ -52,74 +52,19 @@ export default {
       },
     ],
   },
-  measurements: [
-    'biceps',
-    'chest',
-    'hpsToWaistBack',
-    'waistToHips',
-    'neck',
-    'shoulderSlope',
-    'shoulderToShoulder',
-    'shoulderToWrist',
-    'wrist',
-  ],
-  optionalMeasurements: ['highBust'],
-  dependencies: {
-    back: 'base',
-    front: 'back',
-    sleevecap: 'front',
-    sleeve: 'sleevecap',
-  },
-  inject: {
-    back: 'base',
-    front: 'back',
-    sleeve: 'sleevecap',
-  },
-  hide: ['base', 'sleevecap'],
-  options: {
-    // Constants
-    brianFitSleeve: true,
-    brianFitCollar: true,
-    collarFactor: 4.8,
-
-    // Percentages
-    acrossBackFactor: { pct: 98, min: 93, max: 100 },
-    armholeDepthFactor: { pct: 55, min: 50, max: 70 },
-    backNeckCutout: { pct: 5, min: 2, max: 8 },
-    bicepsEase: { pct: 15, min: 0, max: 50 },
-    chestEase: { pct: 15, min: -4, max: 35 },
-    collarEase: { pct: 5, min: 0, max: 10 },
-    cuffEase: { pct: 20, min: 0, max: 200 },
-    frontArmholeDeeper: { pct: 0.2, min: 0, max: 0.5 },
-    lengthBonus: { pct: 0, min: -4, max: 60 },
-    shoulderEase: { pct: 0, min: -2, max: 6 },
-    shoulderSlopeReduction: { pct: 0, min: 0, max: 80 },
-    // s3 is short for Shoulder Seam Shift
-    s3Collar: { pct: 0, min: -100, max: 100 },
-    s3Armhole: { pct: 0, min: -100, max: 100 },
-    sleevecapEase: { pct: 0, min: 0, max: 10 },
-    sleevecapTopFactorX: { pct: 50, min: 25, max: 75 },
-    sleevecapTopFactorY: { pct: 45, min: 35, max: 125 },
-    sleevecapBackFactorX: { pct: 60, min: 35, max: 65 },
-    sleevecapBackFactorY: { pct: 33, min: 30, max: 65 },
-    sleevecapFrontFactorX: { pct: 55, min: 35, max: 65 },
-    sleevecapFrontFactorY: { pct: 33, min: 30, max: 65 },
-    sleevecapQ1Offset: { pct: 1.7, min: 0, max: 7 },
-    sleevecapQ2Offset: { pct: 3.5, min: 0, max: 7 },
-    sleevecapQ3Offset: { pct: 2.5, min: 0, max: 7 },
-    sleevecapQ4Offset: { pct: 1, min: 0, max: 7 },
-    sleevecapQ1Spread1: { pct: 10, min: 4, max: 20 },
-    sleevecapQ1Spread2: { pct: 15, min: 4, max: 20 },
-    sleevecapQ2Spread1: { pct: 15, min: 4, max: 20 },
-    sleevecapQ2Spread2: { pct: 10, min: 4, max: 20 },
-    sleevecapQ3Spread1: { pct: 10, min: 4, max: 20 },
-    sleevecapQ3Spread2: { pct: 8, min: 4, max: 20 },
-    sleevecapQ4Spread1: { pct: 7, min: 4, max: 20 },
-    sleevecapQ4Spread2: { pct: 6.3, min: 4, max: 20 },
-    sleeveWidthGuarantee: { pct: 90, min: 25, max: 100 },
-    sleeveLengthBonus: { pct: 0, min: -40, max: 10 },
-
-    // draft for high bust
-    draftForHighBust: { bool: false },
-  },
 }
+
+export const measurements = [
+  'biceps',
+  'chest',
+  'hpsToWaistBack',
+  'waistToHips',
+  'neck',
+  'shoulderSlope',
+  'shoulderToShoulder',
+  'shoulderToWrist',
+  'wrist',
+]
+
+export const optionalMeasurements = ['highBust']
+

--- a/designs/brian/config/options.js
+++ b/designs/brian/config/options.js
@@ -1,0 +1,94 @@
+// Constants
+export const brianFitSleeve = true
+export const brianFitCollar = true
+export const collarFactor = 4.8
+
+// Percentages
+export const acrossBackFactor = { pct: 98, min: 93, max: 100 }
+export const armholeDepthFactor = { pct: 55, min: 50, max: 70 }
+export const backNeckCutout = { pct: 5, min: 2, max: 8 }
+export const bicepsEase = { pct: 15, min: 0, max: 50 }
+export const chestEase = { pct: 15, min: -4, max: 35 }
+export const collarEase = { pct: 5, min: 0, max: 10 }
+export const cuffEase = { pct: 20, min: 0, max: 200 }
+export const frontArmholeDeeper = { pct: 0.2, min: 0, max: 0.5 }
+export const lengthBonus = { pct: 0, min: -4, max: 60 }
+export const shoulderEase = { pct: 0, min: -2, max: 6 }
+export const shoulderSlopeReduction = { pct: 0, min: 0, max: 80 }
+
+// s3 is short for Shoulder Seam Shift
+export const s3Collar = { pct: 0, min: -100, max: 100 }
+export const s3Armhole = { pct: 0, min: -100, max: 100 }
+
+// Sleevecap
+export const sleevecapEase = { pct: 0, min: 0, max: 10 }
+export const sleevecapTopFactorX = { pct: 50, min: 25, max: 75 }
+export const sleevecapTopFactorY = { pct: 45, min: 35, max: 125 }
+export const sleevecapBackFactorX = { pct: 60, min: 35, max: 65 }
+export const sleevecapBackFactorY = { pct: 33, min: 30, max: 65 }
+export const sleevecapFrontFactorX = { pct: 55, min: 35, max: 65 }
+export const sleevecapFrontFactorY = { pct: 33, min: 30, max: 65 }
+export const sleevecapQ1Offset = { pct: 1.7, min: 0, max: 7 }
+export const sleevecapQ2Offset = { pct: 3.5, min: 0, max: 7 }
+export const sleevecapQ3Offset = { pct: 2.5, min: 0, max: 7 }
+export const sleevecapQ4Offset = { pct: 1, min: 0, max: 7 }
+export const sleevecapQ1Spread1 = { pct: 10, min: 4, max: 20 }
+export const sleevecapQ1Spread2 = { pct: 15, min: 4, max: 20 }
+export const sleevecapQ2Spread1 = { pct: 15, min: 4, max: 20 }
+export const sleevecapQ2Spread2 = { pct: 10, min: 4, max: 20 }
+export const sleevecapQ3Spread1 = { pct: 10, min: 4, max: 20 }
+export const sleevecapQ3Spread2 = { pct: 8, min: 4, max: 20 }
+export const sleevecapQ4Spread1 = { pct: 7, min: 4, max: 20 }
+export const sleevecapQ4Spread2 = { pct: 6.3, min: 4, max: 20 }
+// Sleeve
+export const sleeveWidthGuarantee = { pct: 90, min: 25, max: 100 }
+export const sleeveLengthBonus = { pct: 0, min: -40, max: 10 }
+
+// Draft for high bust
+export const draftForHighBust = { bool: false }
+
+// Helper objects for per-part options
+export const _base = {
+  brianFitSleeve,
+  brianFitCollar,
+  collarFactor,
+  acrossBackFactor,
+  armholeDepthFactor,
+  backNeckCutout,
+  bicepsEase,
+  chestEase,
+  collarEase,
+  cuffEase,
+  frontArmholeDeeper,
+  lengthBonus,
+  shoulderEase,
+  shoulderSlopeReduction,
+  s3Collar,
+  s3Armhole,
+  draftForHighBust,
+}
+export const _sleevecap = {
+  sleevecapEase,
+  sleevecapTopFactorX,
+  sleevecapTopFactorY,
+  sleevecapBackFactorX,
+  sleevecapBackFactorY,
+  sleevecapFrontFactorX,
+  sleevecapFrontFactorY,
+  sleevecapQ1Offset,
+  sleevecapQ2Offset,
+  sleevecapQ3Offset,
+  sleevecapQ4Offset,
+  sleevecapQ1Spread1,
+  sleevecapQ1Spread2,
+  sleevecapQ2Spread1,
+  sleevecapQ2Spread2,
+  sleevecapQ3Spread1,
+  sleevecapQ3Spread2,
+  sleevecapQ4Spread1,
+  sleevecapQ4Spread2,
+  sleeveWidthGuarantee,
+}
+export const _sleeve = { sleeveLengthBonus }
+
+

--- a/designs/brian/src/back.js
+++ b/designs/brian/src/back.js
@@ -1,184 +1,189 @@
 import * as shared from './shared'
+import base from './base'
 
-export default (part) => {
-  let {
-    store,
-    sa,
-    points,
-    Path,
-    paths,
-    Snippet,
-    snippets,
-    complete,
-    paperless,
-    macro,
-    options,
-    utils,
-  } = part.shorthand()
+export default {
+  from: base,
+  name: 'back',
+  draft: (part) => {
+    const {
+      store,
+      sa,
+      points,
+      Path,
+      paths,
+      Snippet,
+      snippets,
+      complete,
+      paperless,
+      macro,
+      options,
+      utils,
+    } = part.shorthand()
 
-  points.anchor = points.hps.clone()
+    points.anchor = points.hps.clone()
 
-  // Adapt the shoulder seam according to the relevant options
-  // Note: s3 stands for Shoulder Seam Shift
-  // Don't bother with less than 10% as that's just asking for trouble
-  if (options.s3Collar < 0.1 && options.s3Collar > -0.1) {
-    points.s3CollarSplit = points.hps
-    paths.backCollar = new Path()
-      .move(points.hps)
-      .curve_(points.neckCp2, points.cbNeck)
-      .setRender(false)
-  } else if (options.s3Collar > 0) {
-    // Shift shoulder seam forward on the collar side
-    points.s3CollarSplit = utils.curveIntersectsY(
-      points.hps,
-      points.mirroredNeckCp2Front,
-      points.mirroredCfNeckCp1,
-      points.mirroredCfNeck,
-      store.get('s3CollarMaxFront') * -1 * options.s3Collar
-    )
-    paths.backCollar = new Path()
-      .move(points.hps)
-      ._curve(points.mirroredNeckCp2Front, points.mirroredCfNeckCp1, points.mirroredCfNeck)
-      .split(points.s3CollarSplit)[0]
-      .reverse()
-      .join(new Path().move(points.hps).curve_(points.neckCp2, points.cbNeck))
-      .setRender(false)
-  } else if (options.s3Collar < 0) {
-    // Shift shoulder seam backward on the collar side
-    points.s3CollarSplit = utils.curveIntersectsY(
-      points.hps,
-      points.neckCp2,
-      points.cbNeck,
-      points.cbNeck,
-      store.get('s3CollarMaxBack') * -1 * options.s3Collar
-    )
-    paths.backCollar = new Path()
-      .move(points.cbNeck)
-      ._curve(points.neckCp2, points.neck)
-      .split(points.s3CollarSplit)[0]
-      .reverse()
-      .setRender(false)
-  }
-  // Don't bother with less than 10% as that's just asking for trouble
-  if (options.s3Armhole < 0.1 && options.s3Armhole > -0.1) {
-    points.s3ArmholeSplit = points.shoulder
-    paths.backArmhole = new Path()
-      .move(points.armholePitch)
-      .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
-      .setRender(false)
-  } else if (options.s3Armhole > 0) {
-    // Shift shoulder seam forward on the armhole side
-    points.s3ArmholeSplit = utils.curveIntersectsY(
-      points.shoulder,
-      points.mirroredShoulderCp1,
-      points.mirroredFrontArmholePitchCp2,
-      points.mirroredFrontArmholePitch,
-      store.get('s3ArmholeMax') * -1 * options.s3Armhole + points.shoulder.y
-    )
-    paths.backArmhole = new Path()
-      .move(points.armholePitch)
-      .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
-      .join(
-        new Path()
-          .move(points.shoulder)
-          .curve(
-            points.mirroredShoulderCp1,
-            points.mirroredFrontArmholePitchCp2,
-            points.mirroredFrontArmholePitch
-          )
-          .split(points.s3ArmholeSplit)[0]
+    // Adapt the shoulder seam according to the relevant options
+    // Note: s3 stands for Shoulder Seam Shift
+    // Don't bother with less than 10% as that's just asking for trouble
+    if (options.s3Collar < 0.1 && options.s3Collar > -0.1) {
+      points.s3CollarSplit = points.hps
+      paths.backCollar = new Path()
+        .move(points.hps)
+        .curve_(points.neckCp2, points.cbNeck)
+        .setRender(false)
+    } else if (options.s3Collar > 0) {
+      // Shift shoulder seam forward on the collar side
+      points.s3CollarSplit = utils.curveIntersectsY(
+        points.hps,
+        points.mirroredNeckCp2Front,
+        points.mirroredCfNeckCp1,
+        points.mirroredCfNeck,
+        store.get('s3CollarMaxFront') * -1 * options.s3Collar
       )
-      .setRender(false)
-  } else if (options.s3Armhole < 0) {
-    // Shift shoulder seam backward on the armhole side
-    points.s3ArmholeSplit = utils.curveIntersectsY(
-      points.shoulder,
-      points.shoulderCp1,
-      points.armholePitchCp2,
-      points.armholePitch,
-      store.get('s3ArmholeMax') * -1 * options.s3Armhole + points.shoulder.y
-    )
-    paths.backArmhole = new Path()
-      .move(points.armholePitch)
-      .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
-      .split(points.s3ArmholeSplit)[0]
-      .setRender(false)
-  }
-
-  // Seamline
-  paths.saBase = new Path()
-    .move(points.cbHem)
-    .line(points.hem)
-    .line(points.armhole)
-    .curve(points.armholeCp2, points.armholeHollowCp1, points.armholeHollow)
-    .curve(points.armholeHollowCp2, points.armholePitchCp1, points.armholePitch)
-    .join(paths.backArmhole)
-    .line(points.s3CollarSplit)
-    .join(paths.backCollar)
-    .setRender(false)
-  paths.seam = new Path()
-    .move(points.cbNeck)
-    .line(points.cbHips)
-    .join(paths.saBase)
-    .attr('class', 'fabric')
-
-  // Store lengths to fit sleeve
-  store.set('backArmholeLength', shared.armholeLength(points, Path))
-  store.set('backArmholeToArmholePitch', shared.armholeToArmholePitch(points, Path))
-
-  // Complete pattern?
-  if (complete) {
-    macro('cutonfold', {
-      from: points.cbNeck,
-      to: points.cbHips,
-      grainline: true,
-    })
-
-    macro('title', { at: points.title, nr: 2, title: 'back' })
-    snippets.armholePitchNotch = new Snippet('bnotch', points.armholePitch)
-    paths.waist = new Path().move(points.cbWaist).line(points.waist).attr('class', 'help')
-    if (sa) {
-      paths.sa = paths.saBase
-        .offset(sa)
-        .attr('class', 'fabric sa')
-        .line(points.cbNeck)
-        .move(points.cbHips)
-      paths.sa.line(paths.sa.start())
+      paths.backCollar = new Path()
+        .move(points.hps)
+        ._curve(points.mirroredNeckCp2Front, points.mirroredCfNeckCp1, points.mirroredCfNeck)
+        .split(points.s3CollarSplit)[0]
+        .reverse()
+        .join(new Path().move(points.hps).curve_(points.neckCp2, points.cbNeck))
+        .setRender(false)
+    } else if (options.s3Collar < 0) {
+      // Shift shoulder seam backward on the collar side
+      points.s3CollarSplit = utils.curveIntersectsY(
+        points.hps,
+        points.neckCp2,
+        points.cbNeck,
+        points.cbNeck,
+        store.get('s3CollarMaxBack') * -1 * options.s3Collar
+      )
+      paths.backCollar = new Path()
+        .move(points.cbNeck)
+        ._curve(points.neckCp2, points.neck)
+        .split(points.s3CollarSplit)[0]
+        .reverse()
+        .setRender(false)
+    }
+    // Don't bother with less than 10% as that's just asking for trouble
+    if (options.s3Armhole < 0.1 && options.s3Armhole > -0.1) {
+      points.s3ArmholeSplit = points.shoulder
+      paths.backArmhole = new Path()
+        .move(points.armholePitch)
+        .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
+        .setRender(false)
+    } else if (options.s3Armhole > 0) {
+      // Shift shoulder seam forward on the armhole side
+      points.s3ArmholeSplit = utils.curveIntersectsY(
+        points.shoulder,
+        points.mirroredShoulderCp1,
+        points.mirroredFrontArmholePitchCp2,
+        points.mirroredFrontArmholePitch,
+        store.get('s3ArmholeMax') * -1 * options.s3Armhole + points.shoulder.y
+      )
+      paths.backArmhole = new Path()
+        .move(points.armholePitch)
+        .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
+        .join(
+          new Path()
+            .move(points.shoulder)
+            .curve(
+              points.mirroredShoulderCp1,
+              points.mirroredFrontArmholePitchCp2,
+              points.mirroredFrontArmholePitch
+            )
+            .split(points.s3ArmholeSplit)[0]
+        )
+        .setRender(false)
+    } else if (options.s3Armhole < 0) {
+      // Shift shoulder seam backward on the armhole side
+      points.s3ArmholeSplit = utils.curveIntersectsY(
+        points.shoulder,
+        points.shoulderCp1,
+        points.armholePitchCp2,
+        points.armholePitch,
+        store.get('s3ArmholeMax') * -1 * options.s3Armhole + points.shoulder.y
+      )
+      paths.backArmhole = new Path()
+        .move(points.armholePitch)
+        .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
+        .split(points.s3ArmholeSplit)[0]
+        .setRender(false)
     }
 
-    // Add notches if the shoulder seam is shifted
-    shared.s3Notches(part, 'bnotch')
-  }
+    // Seamline
+    paths.saBase = new Path()
+      .move(points.cbHem)
+      .line(points.hem)
+      .line(points.armhole)
+      .curve(points.armholeCp2, points.armholeHollowCp1, points.armholeHollow)
+      .curve(points.armholeHollowCp2, points.armholePitchCp1, points.armholePitch)
+      .join(paths.backArmhole)
+      .line(points.s3CollarSplit)
+      .join(paths.backCollar)
+      .setRender(false)
+    paths.seam = new Path()
+      .move(points.cbNeck)
+      .line(points.cbHips)
+      .join(paths.saBase)
+      .attr('class', 'fabric')
 
-  // Paperless?
-  if (paperless) {
-    shared.dimensions(part, 'back')
-    macro('hd', {
-      from: points.cbHips,
-      to: points.hips,
-      y: points.hem.y + sa + 15,
-    })
-    macro('vd', {
-      from: points.cbHem,
-      to: points.cbWaist,
-      x: points.cbHips.x - sa - 15,
-    })
-    macro('vd', {
-      from: points.cbHem,
-      to: points.cbNeck,
-      x: points.cbHips.x - sa - 30,
-    })
-    macro('hd', {
-      from: points.cbNeck,
-      to: points.s3CollarSplit,
-      y: points.s3CollarSplit.y - sa - 15,
-    })
-    macro('hd', {
-      from: points.cbNeck,
-      to: points.s3ArmholeSplit,
-      y: points.s3CollarSplit.y - sa - 30,
-    })
-  }
+    // Store lengths to fit sleeve
+    store.set('backArmholeLength', shared.armholeLength(points, Path))
+    store.set('backArmholeToArmholePitch', shared.armholeToArmholePitch(points, Path))
 
-  return part
+    // Complete pattern?
+    if (complete) {
+      macro('cutonfold', {
+        from: points.cbNeck,
+        to: points.cbHips,
+        grainline: true,
+      })
+
+      macro('title', { at: points.title, nr: 2, title: 'back' })
+      snippets.armholePitchNotch = new Snippet('bnotch', points.armholePitch)
+      paths.waist = new Path().move(points.cbWaist).line(points.waist).attr('class', 'help')
+      if (sa) {
+        paths.sa = paths.saBase
+          .offset(sa)
+          .attr('class', 'fabric sa')
+          .line(points.cbNeck)
+          .move(points.cbHips)
+        paths.sa.line(paths.sa.start())
+      }
+
+      // Add notches if the shoulder seam is shifted
+      shared.s3Notches(part, 'bnotch')
+    }
+
+    // Paperless?
+    if (paperless) {
+      shared.dimensions(part, 'back')
+      macro('hd', {
+        from: points.cbHips,
+        to: points.hips,
+        y: points.hem.y + sa + 15,
+      })
+      macro('vd', {
+        from: points.cbHem,
+        to: points.cbWaist,
+        x: points.cbHips.x - sa - 15,
+      })
+      macro('vd', {
+        from: points.cbHem,
+        to: points.cbNeck,
+        x: points.cbHips.x - sa - 30,
+      })
+      macro('hd', {
+        from: points.cbNeck,
+        to: points.s3CollarSplit,
+        y: points.s3CollarSplit.y - sa - 15,
+      })
+      macro('hd', {
+        from: points.cbNeck,
+        to: points.s3ArmholeSplit,
+        y: points.s3CollarSplit.y - sa - 30,
+      })
+    }
+
+    return part
+  }
 }

--- a/designs/brian/src/base.js
+++ b/designs/brian/src/base.js
@@ -1,173 +1,181 @@
-export default (part) => {
-  let {
-    measurements,
-    options,
-    store,
-    points,
-    snippets,
-    Point,
-    Snippet,
-    Path,
-    paths,
-    utils,
-    complete,
-    macro,
-  } = part.shorthand()
+import { _base as options } from '../config/options.js'
 
-  store.set('shoulderEase', (measurements.shoulderToShoulder * options.shoulderEase) / 2)
 
-  // Center back (cb) vertical axis
-  points.cbHps = new Point(0, 0)
-  points.cbNeck = new Point(0, options.backNeckCutout * measurements.neck)
-  points.cbWaist = new Point(0, measurements.hpsToWaistBack)
-  points.cbHips = new Point(0, points.cbWaist.y + measurements.waistToHips)
+export default {
+  name: 'base',
+  hide: true,
+  options,
+  draft: (part) => {
+    const {
+      measurements,
+      options,
+      store,
+      points,
+      snippets,
+      Point,
+      Snippet,
+      Path,
+      paths,
+      utils,
+      complete,
+      macro,
+    } = part.shorthand()
 
-  // Shoulder line
-  points.neck = new Point((measurements.neck * (1 + options.collarEase)) / options.collarFactor, 0)
-  points.hps = points.neck.clone() // We started using HPS in many measurements
-  // Shoulder point using shoulderSlope degree measurement
-  points.shoulder = utils.beamsIntersect(
-    points.hps,
-    points.hps.shift(measurements.shoulderSlope * -1, 100),
-    new Point(measurements.shoulderToShoulder / 2 + store.get('shoulderEase'), -100),
-    new Point(measurements.shoulderToShoulder / 2 + store.get('shoulderEase'), 100)
-  )
-  // Determine armhole depth and cbShoulder independent of shoulder slope reduction
-  points.cbShoulder = new Point(0, points.shoulder.y)
-  points.cbArmhole = new Point(
-    0,
-    points.shoulder.y + measurements.biceps * (1 + options.bicepsEase) * options.armholeDepthFactor
-  )
+    store.set('shoulderEase', (measurements.shoulderToShoulder * options.shoulderEase) / 2)
 
-  // Now take shoulder slope reduction into account
-  points.shoulder.y -= (points.shoulder.y - points.cbHps.y) * options.shoulderSlopeReduction
-  // Shoulder should never be higher than HPS
-  if (points.shoulder.y < points.cbHps.y) points.shoulder = new Point(points.shoulder.x, 0)
+    // Center back (cb) vertical axis
+    points.cbHps = new Point(0, 0)
+    points.cbNeck = new Point(0, options.backNeckCutout * measurements.neck)
+    points.cbWaist = new Point(0, measurements.hpsToWaistBack)
+    points.cbHips = new Point(0, points.cbWaist.y + measurements.waistToHips)
 
-  points.cbHem = new Point(0, points.cbHips.y * (1 + options.lengthBonus))
-
-  // Side back (cb) vertical axis
-  points.armhole = new Point((measurements.chest * (1 + options.chestEase)) / 4, points.cbArmhole.y)
-  points.waist = new Point(points.armhole.x, points.cbWaist.y)
-  points.hips = new Point(points.armhole.x, points.cbHips.y)
-  points.hem = new Point(points.armhole.x, points.cbHem.y)
-
-  // Armhhole
-  points.armholePitch = new Point(
-    (measurements.shoulderToShoulder * options.acrossBackFactor) / 2 +
-      store.get('shoulderEase') / 2,
-    points.shoulder.y + points.shoulder.dy(points.armhole) / 2
-  )
-  // Set both an front and back armhole pitch point
-  // but keep 'armholePitch' for backwards compatibility
-  points.backArmholePitch = points.armholePitch.clone()
-  points.frontArmholePitch = points.armholePitch.clone() // will be overwritten below
-  // Armhole hollow
-  points._tmp1 = new Point(points.armholePitch.x, points.armhole.y)
-  points._tmp2 = points._tmp1.shift(45, 10)
-  points._tmp3 = utils.beamsIntersect(
-    points._tmp1,
-    points._tmp2,
-    points.armhole,
-    points.armholePitch
-  )
-  points.armholeHollow = points._tmp1.shiftFractionTowards(points._tmp3, 0.5)
-  points.armholeCp2 = points.armhole.shift(180, points._tmp1.dx(points.armhole) / 4)
-  points.armholeHollowCp1 = points.armholeHollow.shift(
-    -45,
-    points.armholeHollow.dy(points.armhole) / 2
-  )
-  points.armholeHollowCp2 = points.armholeHollow.shift(
-    135,
-    points.armholePitch.dx(points.armholeHollow)
-  )
-  points.armholePitchCp1 = points.armholePitch.shift(
-    -90,
-    points.armholePitch.dy(points.armholeHollow) / 2
-  )
-  points.backArmholePitchCp1 = points.armholePitchCp1.clone()
-  points.frontArmholePitchCp1 = points.armholePitchCp1.clone() // will be overwritten below
-  points.armholePitchCp2 = points.armholePitch.shift(
-    90,
-    points.shoulder.dy(points.armholePitch) / 2
-  )
-  points.backArmholePitchCp2 = points.armholePitchCp2.clone()
-  points.frontArmholePitchCp2 = points.armholePitchCp2.clone() // will be overwritten below
-  points.shoulderCp1 = points.shoulder
-    .shiftTowards(points.neck, points.shoulder.dy(points.armholePitch) / 5)
-    .rotate(90, points.shoulder)
-
-  // Neck opening (back)
-  points._tmp4 = points.neck.shiftTowards(points.shoulder, 10).rotate(-90, points.neck)
-  points.neckCp2 = utils.beamIntersectsY(points.neck, points._tmp4, points.cbNeck.y)
-
-  // Fit collar
-  points.cfNeck = points.neck.rotate(-90, new Point(0, 0))
-  let target = measurements.neck * (1 + options.collarEase)
-  let delta = 0
-  let run = 0
-  do {
-    run++
-    points.cfNeck = points.cfNeck.shift(90, delta / 3)
-    points.frontNeckCpEdge = utils.beamsIntersect(
-      points.neck,
-      points.neckCp2,
-      points.cfNeck,
-      new Point(20, points.cfNeck.y)
+    // Shoulder line
+    points.neck = new Point((measurements.neck * (1 + options.collarEase)) / options.collarFactor, 0)
+    points.hps = points.neck.clone() // We started using HPS in many measurements
+    // Shoulder point using shoulderSlope degree measurement
+    points.shoulder = utils.beamsIntersect(
+      points.hps,
+      points.hps.shift(measurements.shoulderSlope * -1, 100),
+      new Point(measurements.shoulderToShoulder / 2 + store.get('shoulderEase'), -100),
+      new Point(measurements.shoulderToShoulder / 2 + store.get('shoulderEase'), 100)
     )
-    points.cfNeckCp1 = points.cfNeck.shiftFractionTowards(points.frontNeckCpEdge, 0.55)
-    points.neckCp2Front = points.neck.shiftFractionTowards(points.frontNeckCpEdge, 0.65)
-    paths.neckOpening = new Path()
-      .move(points.cfNeck)
-      .curve(points.cfNeckCp1, points.neckCp2Front, points.neck)
-      .curve(points.neckCp2, points.cbNeck, points.cbNeck)
-      .attr('class', 'dashed stroke-xl various')
-    delta = paths.neckOpening.length() * 2 - target
-  } while (Math.abs(delta) > 1 && options.brianFitCollar && run < 10)
-  delete paths.neckOpening
+    // Determine armhole depth and cbShoulder independent of shoulder slope reduction
+    points.cbShoulder = new Point(0, points.shoulder.y)
+    points.cbArmhole = new Point(
+      0,
+      points.shoulder.y + measurements.biceps * (1 + options.bicepsEase) * options.armholeDepthFactor
+    )
 
-  // Anchor point for sampling
-  points.gridAnchor = points.cbHem
+    // Now take shoulder slope reduction into account
+    points.shoulder.y -= (points.shoulder.y - points.cbHps.y) * options.shoulderSlopeReduction
+    // Shoulder should never be higher than HPS
+    if (points.shoulder.y < points.cbHps.y) points.shoulder = new Point(points.shoulder.x, 0)
 
-  /*
-   * People would like to have the option to shift the shoulder seam
-   * See https://github.com/freesewing/freesewing/issues/642
-   * So let's make the people happy
-   */
-  // Front armhole is a bit deeper, add those points
-  let deeper = measurements.chest * options.frontArmholeDeeper
-  for (const p of ['', 'Cp1', 'Cp2']) {
-    points[`frontArmholePitch${p}`] = points[`armholePitch${p}`].shift(180, deeper)
+    points.cbHem = new Point(0, points.cbHips.y * (1 + options.lengthBonus))
+
+    // Side back (cb) vertical axis
+    points.armhole = new Point((measurements.chest * (1 + options.chestEase)) / 4, points.cbArmhole.y)
+    points.waist = new Point(points.armhole.x, points.cbWaist.y)
+    points.hips = new Point(points.armhole.x, points.cbHips.y)
+    points.hem = new Point(points.armhole.x, points.cbHem.y)
+
+    // Armhhole
+    points.armholePitch = new Point(
+      (measurements.shoulderToShoulder * options.acrossBackFactor) / 2 +
+        store.get('shoulderEase') / 2,
+      points.shoulder.y + points.shoulder.dy(points.armhole) / 2
+    )
+    // Set both an front and back armhole pitch point
+    // but keep 'armholePitch' for backwards compatibility
+    points.backArmholePitch = points.armholePitch.clone()
+    points.frontArmholePitch = points.armholePitch.clone() // will be overwritten below
+    // Armhole hollow
+    points._tmp1 = new Point(points.armholePitch.x, points.armhole.y)
+    points._tmp2 = points._tmp1.shift(45, 10)
+    points._tmp3 = utils.beamsIntersect(
+      points._tmp1,
+      points._tmp2,
+      points.armhole,
+      points.armholePitch
+    )
+    points.armholeHollow = points._tmp1.shiftFractionTowards(points._tmp3, 0.5)
+    points.armholeCp2 = points.armhole.shift(180, points._tmp1.dx(points.armhole) / 4)
+    points.armholeHollowCp1 = points.armholeHollow.shift(
+      -45,
+      points.armholeHollow.dy(points.armhole) / 2
+    )
+    points.armholeHollowCp2 = points.armholeHollow.shift(
+      135,
+      points.armholePitch.dx(points.armholeHollow)
+    )
+    points.armholePitchCp1 = points.armholePitch.shift(
+      -90,
+      points.armholePitch.dy(points.armholeHollow) / 2
+    )
+    points.backArmholePitchCp1 = points.armholePitchCp1.clone()
+    points.frontArmholePitchCp1 = points.armholePitchCp1.clone() // will be overwritten below
+    points.armholePitchCp2 = points.armholePitch.shift(
+      90,
+      points.shoulder.dy(points.armholePitch) / 2
+    )
+    points.backArmholePitchCp2 = points.armholePitchCp2.clone()
+    points.frontArmholePitchCp2 = points.armholePitchCp2.clone() // will be overwritten below
+    points.shoulderCp1 = points.shoulder
+      .shiftTowards(points.neck, points.shoulder.dy(points.armholePitch) / 5)
+      .rotate(90, points.shoulder)
+
+    // Neck opening (back)
+    points._tmp4 = points.neck.shiftTowards(points.shoulder, 10).rotate(-90, points.neck)
+    points.neckCp2 = utils.beamIntersectsY(points.neck, points._tmp4, points.cbNeck.y)
+
+    // Fit collar
+    points.cfNeck = points.neck.rotate(-90, new Point(0, 0))
+    let target = measurements.neck * (1 + options.collarEase)
+    let delta = 0
+    let run = 0
+    do {
+      run++
+      points.cfNeck = points.cfNeck.shift(90, delta / 3)
+      points.frontNeckCpEdge = utils.beamsIntersect(
+        points.neck,
+        points.neckCp2,
+        points.cfNeck,
+        new Point(20, points.cfNeck.y)
+      )
+      points.cfNeckCp1 = points.cfNeck.shiftFractionTowards(points.frontNeckCpEdge, 0.55)
+      points.neckCp2Front = points.neck.shiftFractionTowards(points.frontNeckCpEdge, 0.65)
+      paths.neckOpening = new Path()
+        .move(points.cfNeck)
+        .curve(points.cfNeckCp1, points.neckCp2Front, points.neck)
+        .curve(points.neckCp2, points.cbNeck, points.cbNeck)
+        .attr('class', 'dashed stroke-xl various')
+      delta = paths.neckOpening.length() * 2 - target
+    } while (Math.abs(delta) > 1 && options.brianFitCollar && run < 10)
+    delete paths.neckOpening
+
+    // Anchor point for sampling
+    points.gridAnchor = points.cbHem
+
+    /*
+    * People would like to have the option to shift the shoulder seam
+    * See https://github.com/freesewing/freesewing/issues/642
+    * So let's make the people happy
+    */
+    // Front armhole is a bit deeper, add those points
+    let deeper = measurements.chest * options.frontArmholeDeeper
+    for (const p of ['', 'Cp1', 'Cp2']) {
+      points[`frontArmholePitch${p}`] = points[`armholePitch${p}`].shift(180, deeper)
+    }
+    // Add points needed for the mirrored front&back neck/armhole path
+    macro('mirror', {
+      mirror: [points.hps, points.shoulder],
+      points: [
+        points.neckCp2Front,
+        points.cfNeckCp1,
+        points.cfNeck,
+        points.cbNeck,
+        points.neckCp2,
+        points.frontArmholePitch,
+        points.frontArmholePitchCp2,
+        points.shoulderCp1,
+      ],
+      clone: true,
+    })
+
+    // How much space do we have to work with here?
+    // s3 = ShoulderSeamShift
+    store.set('s3CollarMaxFront', points.hps.dy(points.cfNeck) / 2)
+    store.set('s3CollarMaxBack', points.hps.dy(points.cbNeck) / 2)
+    store.set('s3ArmholeMax', points.shoulder.dy(points.frontArmholePitch) / 4)
+    // Let's leave the actual splitting the curves for the front/back parts
+
+    // Complete pattern?
+    if (complete) {
+      points.title = new Point(points.armholePitch.x / 2, points.armholePitch.y)
+      points.logo = points.title.shift(-90, 100)
+      snippets.logo = new Snippet('logo', points.logo)
+    }
+
+    return part
   }
-  // Add points needed for the mirrored front&back neck/armhole path
-  macro('mirror', {
-    mirror: [points.hps, points.shoulder],
-    points: [
-      points.neckCp2Front,
-      points.cfNeckCp1,
-      points.cfNeck,
-      points.cbNeck,
-      points.neckCp2,
-      points.frontArmholePitch,
-      points.frontArmholePitchCp2,
-      points.shoulderCp1,
-    ],
-    clone: true,
-  })
-
-  // How much space do we have to work with here?
-  // s3 = ShoulderSeamShift
-  store.set('s3CollarMaxFront', points.hps.dy(points.cfNeck) / 2)
-  store.set('s3CollarMaxBack', points.hps.dy(points.cbNeck) / 2)
-  store.set('s3ArmholeMax', points.shoulder.dy(points.frontArmholePitch) / 4)
-  // Let's leave the actual splitting the curves for the front/back parts
-
-  // Complete pattern?
-  if (complete) {
-    points.title = new Point(points.armholePitch.x / 2, points.armholePitch.y)
-    points.logo = points.title.shift(-90, 100)
-    snippets.logo = new Snippet('logo', points.logo)
-  }
-
-  return part
 }

--- a/designs/brian/src/front.js
+++ b/designs/brian/src/front.js
@@ -1,193 +1,198 @@
 import * as shared from './shared'
+import back from './back'
 
-export default (part) => {
-  let {
-    store,
-    sa,
-    Point,
-    points,
-    Path,
-    paths,
-    Snippet,
-    snippets,
-    options,
-    complete,
-    paperless,
-    macro,
-    utils,
-  } = part.shorthand()
+export default {
+  from: back,
+  name: 'front',
+  draft: (part) => {
+    const {
+      store,
+      sa,
+      Point,
+      points,
+      Path,
+      paths,
+      Snippet,
+      snippets,
+      options,
+      complete,
+      paperless,
+      macro,
+      utils,
+    } = part.shorthand()
 
-  // Re-use points for deeper armhole at the front
-  points.armholePitchCp1 = points.frontArmholePitchCp1
-  points.armholePitch = points.frontArmholePitch
-  points.armholePitchCp2 = points.frontArmholePitchCp2
+    // Re-use points for deeper armhole at the front
+    points.armholePitchCp1 = points.frontArmholePitchCp1
+    points.armholePitch = points.frontArmholePitch
+    points.armholePitchCp2 = points.frontArmholePitchCp2
 
-  // Adapt the shoulder line according to the relevant options
-  // Don't bother with less than 10% as that's just asking for trouble
-  if (options.s3Collar < 0.1 && options.s3Collar > -0.1) {
-    points.s3CollarSplit = points.hps
-    paths.frontCollar = new Path()
-      .move(points.hps)
-      .curve(points.neckCp2Front, points.cfNeckCp1, points.cfNeck)
-      .setRender(false)
-  } else if (options.s3Collar > 0) {
-    // Shift shoulder seam forward on the collar side
-    points.s3CollarSplit = utils.curveIntersectsY(
-      points.hps,
-      points.neckCp2Front,
-      points.cfNeckCp1,
-      points.cfNeck,
-      store.get('s3CollarMaxFront') * options.s3Collar
-    )
-    paths.frontCollar = new Path()
-      .move(points.hps)
-      .curve(points.neckCp2Front, points.cfNeckCp1, points.cfNeck)
-      .split(points.s3CollarSplit)[1]
-      .setRender(false)
-  } else if (options.s3Collar < 0) {
-    // Shift shoulder seam backward on the collar side
-    points.s3CollarSplit = utils.curveIntersectsY(
-      points.mirroredCbNeck,
-      points.mirroredCbNeck,
-      points.mirroredNeckCp2,
-      points.hps,
-      store.get('s3CollarMaxBack') * options.s3Collar
-    )
-    paths.frontCollar = new Path()
-      .move(points.hps)
-      .curve_(points.mirroredNeckCp2, points.mirroredCbNeck)
-      .split(points.s3CollarSplit)[0]
-      .reverse()
-      .join(new Path().move(points.hps).curve(points.neckCp2Front, points.cfNeckCp1, points.cfNeck))
-      .setRender(false)
-  }
-  if (options.s3Armhole < 0.1 && options.s3Armhole > -0.1) {
-    points.s3ArmholeSplit = points.shoulder
-    paths.frontArmhole = new Path()
-      .move(points.armholePitch)
-      .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
-      .setRender(false)
-  } else if (options.s3Armhole > 0) {
-    // Shift shoulder seam forward on the armhole side
-    points.s3ArmholeSplit = utils.curveIntersectsY(
-      points.shoulder,
-      points.shoulderCp1,
-      points.armholePitchCp2,
-      points.armholePitch,
-      store.get('s3ArmholeMax') * options.s3Armhole + points.shoulder.y
-    )
-    paths.frontArmhole = new Path()
-      .move(points.armholePitch)
-      .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
-      .split(points.s3ArmholeSplit)[0]
-      .setRender(false)
-  } else if (options.s3Armhole < 0) {
-    // Shift shoulder seam forward on the armhole side
-    points.s3ArmholeSplit = utils.curveIntersectsY(
-      points.shoulder,
-      points.mirroredShoulderCp1,
-      points.mirroredFrontArmholePitchCp2,
-      points.mirroredFrontArmholePitch,
-      store.get('s3ArmholeMax') * options.s3Armhole + points.shoulder.y
-    )
-    paths.frontArmhole = new Path()
-      .move(points.armholePitch)
-      .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
-      .join(
-        new Path()
-          .move(points.shoulder)
-          .curve(
-            points.mirroredShoulderCp1,
-            points.mirroredFrontArmholePitchCp2,
-            points.mirroredFrontArmholePitch
-          )
-          .split(points.s3ArmholeSplit)[0]
+    // Adapt the shoulder line according to the relevant options
+    // Don't bother with less than 10% as that's just asking for trouble
+    if (options.s3Collar < 0.1 && options.s3Collar > -0.1) {
+      points.s3CollarSplit = points.hps
+      paths.frontCollar = new Path()
+        .move(points.hps)
+        .curve(points.neckCp2Front, points.cfNeckCp1, points.cfNeck)
+        .setRender(false)
+    } else if (options.s3Collar > 0) {
+      // Shift shoulder seam forward on the collar side
+      points.s3CollarSplit = utils.curveIntersectsY(
+        points.hps,
+        points.neckCp2Front,
+        points.cfNeckCp1,
+        points.cfNeck,
+        store.get('s3CollarMaxFront') * options.s3Collar
       )
-      .setRender(false)
-  }
-
-  // Rename cb (center back) to cf (center front)
-  for (let key of ['Shoulder', 'Armhole', 'Waist', 'Hips', 'Hem']) {
-    points[`cf${key}`] = new Point(points[`cb${key}`].x, points[`cb${key}`].y)
-    delete points[`cb${key}`]
-  }
-  // Front neckline points
-  points.neckCp2 = new Point(points.neckCp2Front.x, points.neckCp2Front.y)
-
-  // Seamline
-  paths.saBase = new Path()
-    .move(points.cfHem)
-    .line(points.hem)
-    .line(points.armhole)
-    .curve(points.armholeCp2, points.armholeHollowCp1, points.armholeHollow)
-    .curve(points.armholeHollowCp2, points.armholePitchCp1, points.armholePitch)
-    .join(paths.frontArmhole)
-    .line(points.s3CollarSplit)
-    .join(paths.frontCollar)
-
-  paths.saBase.render = false
-  paths.seam = new Path()
-    .move(points.cfNeck)
-    .line(points.cfHem)
-    .join(paths.saBase)
-    .attr('class', 'fabric')
-
-  // Store lengths to fit sleeve
-  store.set('frontArmholeLength', shared.armholeLength(points, Path))
-  store.set('frontArmholeToArmholePitch', shared.armholeToArmholePitch(points, Path))
-
-  // Complete pattern?
-  if (complete) {
-    macro('cutonfold', {
-      from: points.cfNeck,
-      to: points.cfHips,
-      grainline: true,
-    })
-    macro('title', { at: points.title, nr: 1, title: 'front' })
-    snippets.armholePitchNotch = new Snippet('notch', points.armholePitch)
-    paths.waist = new Path().move(points.cfWaist).line(points.waist).attr('class', 'help')
-    if (sa) {
-      paths.sa = paths.saBase
-        .offset(sa)
-        .attr('class', 'fabric sa')
-        .line(points.cfNeck)
-        .move(points.cfHips)
-      paths.sa.line(paths.sa.start())
+      paths.frontCollar = new Path()
+        .move(points.hps)
+        .curve(points.neckCp2Front, points.cfNeckCp1, points.cfNeck)
+        .split(points.s3CollarSplit)[1]
+        .setRender(false)
+    } else if (options.s3Collar < 0) {
+      // Shift shoulder seam backward on the collar side
+      points.s3CollarSplit = utils.curveIntersectsY(
+        points.mirroredCbNeck,
+        points.mirroredCbNeck,
+        points.mirroredNeckCp2,
+        points.hps,
+        store.get('s3CollarMaxBack') * options.s3Collar
+      )
+      paths.frontCollar = new Path()
+        .move(points.hps)
+        .curve_(points.mirroredNeckCp2, points.mirroredCbNeck)
+        .split(points.s3CollarSplit)[0]
+        .reverse()
+        .join(new Path().move(points.hps).curve(points.neckCp2Front, points.cfNeckCp1, points.cfNeck))
+        .setRender(false)
+    }
+    if (options.s3Armhole < 0.1 && options.s3Armhole > -0.1) {
+      points.s3ArmholeSplit = points.shoulder
+      paths.frontArmhole = new Path()
+        .move(points.armholePitch)
+        .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
+        .setRender(false)
+    } else if (options.s3Armhole > 0) {
+      // Shift shoulder seam forward on the armhole side
+      points.s3ArmholeSplit = utils.curveIntersectsY(
+        points.shoulder,
+        points.shoulderCp1,
+        points.armholePitchCp2,
+        points.armholePitch,
+        store.get('s3ArmholeMax') * options.s3Armhole + points.shoulder.y
+      )
+      paths.frontArmhole = new Path()
+        .move(points.armholePitch)
+        .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
+        .split(points.s3ArmholeSplit)[0]
+        .setRender(false)
+    } else if (options.s3Armhole < 0) {
+      // Shift shoulder seam forward on the armhole side
+      points.s3ArmholeSplit = utils.curveIntersectsY(
+        points.shoulder,
+        points.mirroredShoulderCp1,
+        points.mirroredFrontArmholePitchCp2,
+        points.mirroredFrontArmholePitch,
+        store.get('s3ArmholeMax') * options.s3Armhole + points.shoulder.y
+      )
+      paths.frontArmhole = new Path()
+        .move(points.armholePitch)
+        .curve(points.armholePitchCp2, points.shoulderCp1, points.shoulder)
+        .join(
+          new Path()
+            .move(points.shoulder)
+            .curve(
+              points.mirroredShoulderCp1,
+              points.mirroredFrontArmholePitchCp2,
+              points.mirroredFrontArmholePitch
+            )
+            .split(points.s3ArmholeSplit)[0]
+        )
+        .setRender(false)
     }
 
-    // Add notches if the shoulder seam is shifted
-    shared.s3Notches(part, 'notch')
-  }
+    // Rename cb (center back) to cf (center front)
+    for (let key of ['Shoulder', 'Armhole', 'Waist', 'Hips', 'Hem']) {
+      points[`cf${key}`] = new Point(points[`cb${key}`].x, points[`cb${key}`].y)
+      delete points[`cb${key}`]
+    }
+    // Front neckline points
+    points.neckCp2 = new Point(points.neckCp2Front.x, points.neckCp2Front.y)
 
-  // Paperless?
-  if (paperless) {
-    shared.dimensions(part, 'front')
-    macro('hd', {
-      from: points.cfHips,
-      to: points.hips,
-      y: points.hem.y + sa + 15,
-    })
-    macro('vd', {
-      from: points.cfHem,
-      to: points.cfWaist,
-      x: points.cfHips.x - sa - 15,
-    })
-    macro('vd', {
-      from: points.cfHem,
-      to: points.cfNeck,
-      x: points.cfHips.x - sa - 30,
-    })
-    macro('hd', {
-      from: points.cfNeck,
-      to: points.s3CollarSplit,
-      y: points.s3CollarSplit.y - sa - 15,
-    })
-    macro('hd', {
-      from: points.cfNeck,
-      to: points.s3ArmholeSplit,
-      y: points.s3CollarSplit.y - sa - 30,
-    })
-  }
+    // Seamline
+    paths.saBase = new Path()
+      .move(points.cfHem)
+      .line(points.hem)
+      .line(points.armhole)
+      .curve(points.armholeCp2, points.armholeHollowCp1, points.armholeHollow)
+      .curve(points.armholeHollowCp2, points.armholePitchCp1, points.armholePitch)
+      .join(paths.frontArmhole)
+      .line(points.s3CollarSplit)
+      .join(paths.frontCollar)
 
-  return part
+    paths.saBase.render = false
+    paths.seam = new Path()
+      .move(points.cfNeck)
+      .line(points.cfHem)
+      .join(paths.saBase)
+      .attr('class', 'fabric')
+
+    // Store lengths to fit sleeve
+    store.set('frontArmholeLength', shared.armholeLength(points, Path))
+    store.set('frontArmholeToArmholePitch', shared.armholeToArmholePitch(points, Path))
+
+    // Complete pattern?
+    if (complete) {
+      macro('cutonfold', {
+        from: points.cfNeck,
+        to: points.cfHips,
+        grainline: true,
+      })
+      macro('title', { at: points.title, nr: 1, title: 'front' })
+      snippets.armholePitchNotch = new Snippet('notch', points.armholePitch)
+      paths.waist = new Path().move(points.cfWaist).line(points.waist).attr('class', 'help')
+      if (sa) {
+        paths.sa = paths.saBase
+          .offset(sa)
+          .attr('class', 'fabric sa')
+          .line(points.cfNeck)
+          .move(points.cfHips)
+        paths.sa.line(paths.sa.start())
+      }
+
+      // Add notches if the shoulder seam is shifted
+      shared.s3Notches(part, 'notch')
+    }
+
+    // Paperless?
+    if (paperless) {
+      shared.dimensions(part, 'front')
+      macro('hd', {
+        from: points.cfHips,
+        to: points.hips,
+        y: points.hem.y + sa + 15,
+      })
+      macro('vd', {
+        from: points.cfHem,
+        to: points.cfWaist,
+        x: points.cfHips.x - sa - 15,
+      })
+      macro('vd', {
+        from: points.cfHem,
+        to: points.cfNeck,
+        x: points.cfHips.x - sa - 30,
+      })
+      macro('hd', {
+        from: points.cfNeck,
+        to: points.s3CollarSplit,
+        y: points.s3CollarSplit.y - sa - 15,
+      })
+      macro('hd', {
+        from: points.cfNeck,
+        to: points.s3ArmholeSplit,
+        y: points.s3CollarSplit.y - sa - 30,
+      })
+    }
+
+    return part
+  }
 }

--- a/designs/brian/src/index.js
+++ b/designs/brian/src/index.js
@@ -1,38 +1,38 @@
+// FreeSewing core library
 import freesewing from '@freesewing/core'
-import plugins from '@freesewing/plugin-bundle'
-import plugin from '@freesewing/plugin-bust' // Note: conditional plugin
-import config from '../config'
-// Parts
-import draftBase from './base'
-import draftBack from './back'
-import draftFront from './front'
-import draftSleevecap from './sleevecap'
-import draftSleeve from './sleeve'
+// FreeSewing Plugins
+import pluginBundle from '@freesewing/plugin-bundle'
+import bustPlugin from '@freesewing/plugin-bust' // Note: conditional plugin
+// Design config & options
+import { info, measurements, optionalMeasurements } from '../config/index'
+//import * as options from '../config/options'
+// Design parts
+import back from './back'
+import front from './front'
+import sleeve from './sleeve'
+// These are only here to be exported
+import base from './base'
+import sleevecap from './sleevecap'
 
-/* Check to see whether we should load the bust plugin
- * Only of the `draftForHighBust` options is set
- * AND the highBust measurement is available
- */
-const condition = (settings = false) =>
-  settings &&
-  settings.options &&
-  settings.options.draftForHighBust &&
-  settings.measurements.highBust
-    ? true
-    : false
 
-// Create design
-const Brian = new freesewing.Design(config, plugins, { plugin, condition })
-
-// Attach draft methods to prototype
-Brian.prototype.draftBase = draftBase
-Brian.prototype.draftBack = draftBack
-Brian.prototype.draftFront = draftFront
-Brian.prototype.draftSleevecap = draftSleevecap
-Brian.prototype.draftSleeve = draftSleeve
+// Setup design
+const Brian = new freesewing.Design({
+  ...info,
+  measurements,
+  optionalMeasurements,
+//  options: { ...options },
+  parts: { back, front, sleeve },
+  plugins: pluginBundle,
+  conditionalPlugins: {
+    plugin: bustPlugin,
+    condition: (settings=false) =>
+      settings?.options?.draftForHighBust &&
+      settings?.measurements?.highBust
+      ? true : false
+  }
+})
 
 // Named exports
-export { config, Brian }
-
+export { back, front, sleeve, base, sleevecap }
 // Default export
 export default Brian

--- a/designs/brian/src/sleeve.js
+++ b/designs/brian/src/sleeve.js
@@ -1,89 +1,103 @@
-export default (part) => {
-  const {
-    store,
-    sa,
-    measurements,
-    options,
-    Point,
-    points,
-    Path,
-    paths,
-    Snippet,
-    snippets,
-    complete,
-    paperless,
-    macro,
-  } = part.shorthand()
+import sleevecap from './sleevecap'
+import { _sleeve as options } from '../config/options.js'
 
-  // Determine the sleeve length
-  store.set('sleeveLength', measurements.shoulderToWrist * (1 + options.sleeveLengthBonus))
-  points.sleeveTip = paths.sleevecap.edge('top')
-  points.sleeveTop = new Point(0, points.sleeveTip.y) // Always in center
+export default {
+  from: sleevecap,
+  name: 'sleeve',
+  options,
+  draft: (part) => {
+    const {
+      store,
+      sa,
+      measurements,
+      options,
+      Point,
+      points,
+      Path,
+      paths,
+      Snippet,
+      snippets,
+      complete,
+      paperless,
+      macro,
+    } = part.shorthand()
 
-  // Wrist
-  points.centerWrist = points.sleeveTop.shift(-90, store.get('sleeveLength'))
-  points.wristRight = points.centerWrist.shift(0, (measurements.wrist * (1 + options.cuffEase)) / 2)
-  points.wristLeft = points.wristRight.rotate(180, points.centerWrist)
+    // Remove things inherited
+    macro('cutonfold', false)
+    macro('rmad')
+    delete paths.waist
+    for (const key in snippets) delete snippets[key]
 
-  // Paths
-  paths.sleevecap.render = false
-  paths.seam = new Path()
-    .move(points.bicepsLeft)
-    .move(points.wristLeft)
-    .move(points.wristRight)
-    .line(points.bicepsRight)
-    .join(paths.sleevecap)
-    .close()
-    .attr('class', 'fabric')
+    // Determine the sleeve length
+    store.set('sleeveLength', measurements.shoulderToWrist * (1 + options.sleeveLengthBonus))
+    points.sleeveTip = paths.sleevecap.edge('top')
+    points.sleeveTop = new Point(0, points.sleeveTip.y) // Always in center
 
-  // Anchor point for sampling
-  points.gridAnchor = new Point(0, 0)
+    // Wrist
+    points.centerWrist = points.sleeveTop.shift(-90, store.get('sleeveLength'))
+    points.wristRight = points.centerWrist.shift(0, (measurements.wrist * (1 + options.cuffEase)) / 2)
+    points.wristLeft = points.wristRight.rotate(180, points.centerWrist)
 
-  // Complete pattern?
-  if (complete) {
-    points.logo = points.centerBiceps.shiftFractionTowards(points.centerWrist, 0.3)
-    snippets.logo = new Snippet('logo', points.logo)
-    macro('title', { at: points.centerBiceps, nr: 3, title: 'sleeve' })
-    macro('grainline', { from: points.centerWrist, to: points.centerBiceps })
-    points.scaleboxAnchor = points.scalebox = points.centerBiceps.shiftFractionTowards(
-      points.centerWrist,
-      0.5
-    )
-    macro('scalebox', { at: points.scalebox })
+    // Paths
+    paths.sleevecap.render = false
+    paths.seam = new Path()
+      .move(points.bicepsLeft)
+      .move(points.wristLeft)
+      .move(points.wristRight)
+      .line(points.bicepsRight)
+      .join(paths.sleevecap)
+      .close()
+      .attr('class', 'fabric')
 
-    points.frontNotch = paths.sleevecap.shiftAlong(store.get('frontArmholeToArmholePitch'))
-    points.backNotch = paths.sleevecap.reverse().shiftAlong(store.get('backArmholeToArmholePitch'))
-    snippets.frontNotch = new Snippet('notch', points.frontNotch)
-    snippets.backNotch = new Snippet('bnotch', points.backNotch)
-    if (sa) paths.sa = paths.seam.offset(sa).attr('class', 'fabric sa')
+    // Anchor point for sampling
+    points.gridAnchor = new Point(0, 0)
+
+    // Complete pattern?
+    if (complete) {
+      points.logo = points.centerBiceps.shiftFractionTowards(points.centerWrist, 0.3)
+      snippets.logo = new Snippet('logo', points.logo)
+      macro('title', { at: points.centerBiceps, nr: 3, title: 'sleeve' })
+      macro('grainline', { from: points.centerWrist, to: points.centerBiceps })
+      points.scaleboxAnchor = points.scalebox = points.centerBiceps.shiftFractionTowards(
+        points.centerWrist,
+        0.5
+      )
+      macro('scalebox', { at: points.scalebox })
+
+      points.frontNotch = paths.sleevecap.shiftAlong(store.get('frontArmholeToArmholePitch'))
+      points.backNotch = paths.sleevecap.reverse().shiftAlong(store.get('backArmholeToArmholePitch'))
+      snippets.frontNotch = new Snippet('notch', points.frontNotch)
+      snippets.backNotch = new Snippet('bnotch', points.backNotch)
+      if (sa) paths.sa = paths.seam.offset(sa).attr('class', 'fabric sa')
+    }
+
+    // Paperless?
+    if (paperless) {
+      macro('vd', {
+        from: points.wristLeft,
+        to: points.bicepsLeft,
+        x: points.bicepsLeft.x - sa - 15,
+      })
+      macro('vd', {
+        from: points.wristLeft,
+        to: points.sleeveTip,
+        x: points.bicepsLeft.x - sa - 30,
+      })
+      macro('hd', {
+        from: points.bicepsLeft,
+        to: points.bicepsRight,
+        y: points.sleeveTip.y - sa - 30,
+      })
+      macro('hd', {
+        from: points.wristLeft,
+        to: points.wristRight,
+        y: points.wristLeft.y + sa + 30,
+      })
+      macro('pd', {
+        path: paths.sleevecap.reverse(),
+        d: -1 * sa - 15,
+      })
+    }
+    return part
   }
-
-  // Paperless?
-  if (paperless) {
-    macro('vd', {
-      from: points.wristLeft,
-      to: points.bicepsLeft,
-      x: points.bicepsLeft.x - sa - 15,
-    })
-    macro('vd', {
-      from: points.wristLeft,
-      to: points.sleeveTip,
-      x: points.bicepsLeft.x - sa - 30,
-    })
-    macro('hd', {
-      from: points.bicepsLeft,
-      to: points.bicepsRight,
-      y: points.sleeveTip.y - sa - 30,
-    })
-    macro('hd', {
-      from: points.wristLeft,
-      to: points.wristRight,
-      y: points.wristLeft.y + sa + 30,
-    })
-    macro('pd', {
-      path: paths.sleevecap.reverse(),
-      d: -1 * sa - 15,
-    })
-  }
-  return part
 }

--- a/designs/brian/src/sleevecap.js
+++ b/designs/brian/src/sleevecap.js
@@ -1,3 +1,6 @@
+import front from './front'
+import { _sleevecap as options } from '../config/options.js'
+
 /** Calculates the differece between actual and optimal sleevecap length
  * Positive values mean sleevecap is longer than armhole
  */
@@ -136,25 +139,31 @@ function draftSleevecap(part, run) {
   }
 }
 
-export default (part) => {
-  let { store, units, options, Point, points, paths, raise } = part.shorthand()
+export default {
+  from: front,
+  name: 'sleevecap',
+  hide: true,
+  options,
+  draft: (part) => {
+    const { store, units, options, Point, points, paths, raise } = part.shorthand()
 
-  store.set('sleeveFactor', 1)
-  let run = 0
-  let delta = 0
-  do {
-    draftSleevecap(part, run)
-    delta = sleevecapDelta(store)
-    sleevecapAdjust(store)
-    run++
-    raise.debug(`Fitting Brian sleevecap. Run ${run}: delta is ${units(delta)}`)
-  } while (options.brianFitSleeve === true && run < 50 && Math.abs(sleevecapDelta(store)) > 2)
+    store.set('sleeveFactor', 1)
+    let run = 0
+    let delta = 0
+    do {
+      draftSleevecap(part, run)
+      delta = sleevecapDelta(store)
+      sleevecapAdjust(store)
+      run++
+      raise.debug(`Fitting Brian sleevecap. Run ${run}: delta is ${units(delta)}`)
+    } while (options.brianFitSleeve === true && run < 50 && Math.abs(sleevecapDelta(store)) > 2)
 
-  // Paths
-  paths.sleevecap.attr('class', 'fabric')
+    // Paths
+    paths.sleevecap.attr('class', 'fabric')
 
-  // Anchor point for sampling
-  points.gridAnchor = new Point(0, 0)
+    // Anchor point for sampling
+    points.gridAnchor = new Point(0, 0)
 
-  return part
+    return part
+  }
 }

--- a/packages/core/build.js
+++ b/packages/core/build.js
@@ -48,8 +48,8 @@ let result
     ...options,
     minify: false,
     sourcemap: false,
-    outfile: 'tests/dist/index.mjs',
-    format: 'esm',
+    outfile: 'tests/dist/index.js',
+    format: 'cjs',
     external: [],
   })
   .catch(() => process.exit(1))

--- a/packages/core/src/design.js
+++ b/packages/core/src/design.js
@@ -1,5 +1,5 @@
 import Pattern from './pattern'
-import { addOptions, addMeasurements, addOptionalMeasurements } from './utils.js'
+import { addPartConfig } from './utils.js'
 
 /*
  * The Design constructor. Returns a Pattern constructor
@@ -11,11 +11,7 @@ export default function Design(config, plugins = false, conditionalPlugins = fal
   if (!config.measurements) config.measurements = []
   if (!config.optionalMeasurements) config.optionalMeasurements = []
   if (config.parts) {
-    for (const partName in config.parts) {
-      config = addOptions(config.parts[partName], config)
-      config = addMeasurements(config.parts[partName], config)
-      config = addOptionalMeasurements(config.parts[partName], config)
-    }
+    for (const partName in config.parts)  config = addPartConfig(config.parts[partName], config)
   }
 
   // Ensure all options have a hide() method

--- a/packages/core/src/design.js
+++ b/packages/core/src/design.js
@@ -1,5 +1,16 @@
 import Pattern from './pattern'
 
+const addOptions = (part, config) => {
+  if (part.options) {
+    for (const optionName in part.options) {
+      config.options[optionName] = part.options[optionName]
+    }
+  }
+  if (part.from) addOptions(part.from, config)
+
+  return config
+}
+
 /*
  * The Design constructor. Returns a Pattern constructor
  * So it's sort of a super-constructor
@@ -9,11 +20,7 @@ export default function Design(config, plugins = false, conditionalPlugins = fal
   if (!config.options) config.options = {}
   if (config.parts) {
     for (const partName in config.parts) {
-      if (config.parts[partName].options) {
-        for (const optionName in config.parts[partName].options) {
-          config.options[optionName] = config.parts[partName].options[optionName]
-        }
-      }
+      config = addOptions(config.parts[partName], config)
     }
   }
   // Ensure all options have a hide() method

--- a/packages/core/src/design.js
+++ b/packages/core/src/design.js
@@ -10,8 +10,13 @@ export default function Design(config, plugins = false, conditionalPlugins = fal
   if (!config.options) config.options = {}
   if (!config.measurements) config.measurements = []
   if (!config.optionalMeasurements) config.optionalMeasurements = []
-  if (config.parts) {
-    for (const partName in config.parts)  config = addPartConfig(config.parts[partName], config)
+  if (Array.isArray(config.parts)) {
+    const parts = {}
+    for (const part of config.parts) {
+      parts[part.name] = part
+      config = addPartConfig(parts[part.name], config)
+    }
+    config.parts = parts
   }
 
   // Ensure all options have a hide() method

--- a/packages/core/src/design.js
+++ b/packages/core/src/design.js
@@ -1,29 +1,38 @@
 import Pattern from './pattern'
 
-// Default hide method for options
-const hide = () => false
-
+/*
+ * The Design constructor. Returns a Pattern constructor
+ * So it's sort of a super-constructor
+ */
 export default function Design(config, plugins = false, conditionalPlugins = false) {
-  // Add default hide() method to config.options
-  for (const option in config.options) {
-    if (typeof config.options[option] === 'object') {
-      config.options[option] = {
-        hide,
-        ...config.options[option],
-      }
-    }
-  }
+
+  // Ensure all options have a hide() method
+  config.options = optionsWithHide(config.options)
+
+  // A place to store deprecation and other warnings before we even have a pattern instantiated
+  config.warnings = []
+
+  /*
+   * The newer way to initalize a design is to pass one single parameter
+   * The old way passed multiple parameters.
+   * So let's figure out which is which and be backwards compatible
+   *
+   * This mitigation should be removed in v3 when we drop support for the legacy way
+   */
+  config = migrateConfig(config, plugins, conditionalPlugins)
 
   const pattern = function (settings) {
     Pattern.call(this, config)
+
     // Load plugins
-    if (Array.isArray(plugins)) for (let plugin of plugins) this.use(plugin)
-    else if (plugins) this.use(plugins)
+    if (Array.isArray(config.plugins)) for (const plugin of config.plugins) this.use(plugin)
+    else if (config.plugins) this.use(config.plugins)
+
     // Load conditional plugins
-    if (Array.isArray(conditionalPlugins))
-      for (let plugin of conditionalPlugins) this.useIf(plugin, settings)
-    else if (conditionalPlugins.plugin && conditionalPlugins.condition)
-      this.useIf(conditionalPlugins, settings)
+    if (Array.isArray(config.conditionalPlugins))
+      for (const plugin of config.conditionalPlugins) this.useIf(plugin, settings)
+    else if (config.conditionalPlugins.plugin && config.conditionalPlugins.condition)
+      this.useIf(config.conditionalPlugins, settings)
 
     this.apply(settings)
 
@@ -39,3 +48,59 @@ export default function Design(config, plugins = false, conditionalPlugins = fal
 
   return pattern
 }
+
+/*
+ * Helper method to handle the legacy way of passing configuration
+ * to the design constructor
+ */
+const migrateConfig = (config, plugins, conditionalPlugins) => {
+
+  // Migrate plugins
+  if (plugins && config.plugins) config.warnings.push(
+    'Passing plugins to the Design constructor both as a second parameter and in the config is unsupported',
+    'Ignoring plugins passed as parameter. Only config.plugins will be used.'
+  )
+  else if (plugins && !config.plugins) {
+    config.plugins = plugins
+    config.warnings.push(
+      'Passing a plugins parameter to the Design constructure is deprecated',
+      'Please store them in the `plugins` key of the config object that is the first parameter'
+    )
+  } else if (!config.plugins) config.plugins = []
+
+  // Migrate conditional plugins
+  if (conditionalPlugins && config.conditionalPlugins) config.warnings.push(
+    'Passing conditionalPlugins to the Design constructor both as a third parameter and in the config is unsupported.',
+    'Ignoring conditionalPlugins passes as parameter. Only config.conditionalPlugins will be used.',
+  )
+  else if (conditionalPlugins && !config.conditionalPlugins) {
+    config.conditionalPlugins = conditionalPlugins
+    config.warnings.push(
+      'Passing a conditionalPlugins parameter to the Design constructure is deprecated.',
+      'Please store them in the `conditionalPlugins` key of the config object that is the first parameter'
+    )
+  }
+  else if (!config.conditionalPlugins) config.conditionalPlugins = []
+
+  return config
+}
+
+/*
+ * A default hide() method for options that lack it
+ * Since this will always return false, the option will never be hidden
+ */
+const hide = () => false // The default hide() method
+
+/*
+ * Helper method to add the default hide() method to options who lack one
+ */
+const optionsWithHide = options => {
+  if (options) {
+    for (const option in options) {
+      if (typeof options[option] === 'object') options[option] = { hide, ...options[option] }
+    }
+  }
+
+  return options
+}
+

--- a/packages/core/src/design.js
+++ b/packages/core/src/design.js
@@ -1,51 +1,5 @@
 import Pattern from './pattern'
-
-// Add part-level options
-const addOptions = (part, config) => {
-  if (part.options) {
-    for (const optionName in part.options) {
-      config.options[optionName] = part.options[optionName]
-    }
-  }
-  if (part.from) addOptions(part.from, config)
-
-  return config
-}
-
-// Add part-level measurements
-const addMeasurements = (part, config, list=false) => {
-  if (!list) list = config.measurements
-    ? [...config.measurements]
-    : []
-  if (part.measurements) {
-    for (const m of part.measurements) list.push(m)
-  }
-  if (part.from) addMeasurements(part.from, config, list)
-
-  // Weed out duplicates
-  config.measurements = [...new Set(list)]
-
-  return config
-}
-
-// Add part-level optional measurements
-const addOptionalMeasurements = (part, config, list=false) => {
-  if (!list) list = config.optionalMeasurements
-    ? [...config.optionalMeasurements]
-    : []
-  if (part.optionalMeasurements) {
-    for (const m of part.optionalMeasurements) {
-      // Don't add it's a required measurement for another part
-      if (config.measurements.indexOf(m) === -1) list.push(m)
-    }
-  }
-  if (part.from) addOptionalMeasurements(part.from, config, list)
-
-  // Weed out duplicates
-  config.optionalMeasurements = [...new Set(list)]
-
-  return config
-}
+import { addOptions, addMeasurements, addOptionalMeasurements } from './utils.js'
 
 /*
  * The Design constructor. Returns a Pattern constructor

--- a/packages/core/src/design.js
+++ b/packages/core/src/design.js
@@ -5,7 +5,17 @@ import Pattern from './pattern'
  * So it's sort of a super-constructor
  */
 export default function Design(config, plugins = false, conditionalPlugins = false) {
-
+  // Add part options to config
+  if (!config.options) config.options = {}
+  if (config.parts) {
+    for (const partName in config.parts) {
+      if (config.parts[partName].options) {
+        for (const optionName in config.parts[partName].options) {
+          config.options[optionName] = config.parts[partName].options[optionName]
+        }
+      }
+    }
+  }
   // Ensure all options have a hide() method
   config.options = optionsWithHide(config.options)
 

--- a/packages/core/src/design.js
+++ b/packages/core/src/design.js
@@ -13,8 +13,12 @@ export default function Design(config, plugins = false, conditionalPlugins = fal
   if (Array.isArray(config.parts)) {
     const parts = {}
     for (const part of config.parts) {
-      parts[part.name] = part
-      config = addPartConfig(parts[part.name], config)
+      if (typeof part === 'object') {
+        parts[part.name] = part
+        config = addPartConfig(parts[part.name], config)
+      } else if (typeof part === 'string') {
+        parts[part] = part
+      } else throw("Part should be passed as a name of part config object")
     }
     config.parts = parts
   }

--- a/packages/core/src/pattern.js
+++ b/packages/core/src/pattern.js
@@ -3,9 +3,7 @@ import {
   sampleStyle,
   capitalize,
   decoratePartDependency,
-  addOptions,
-  addMeasurements,
-  addOptionalMeasurements
+  addPartConfig,
 } from './utils.js'
 import Part from './part'
 import Point from './point'
@@ -256,10 +254,8 @@ Pattern.prototype.addPart = function (part, name=false) {
   if (typeof part?.draft === 'function') {
     if (part.name) {
       this.config.parts[part.name] = part
-      // Add part options/measurements/optionalMeasurements to config
-      this.config = addOptions(part, this.config)
-      this.config = addMeasurements(part, this.config)
-      this.config = addOptionalMeasurements(part, this.config)
+      // Add part-level config to config
+      this.config = addPartConfig(part, this.config)
     }
     else this.raise.error(`Part must have a name`)
   }

--- a/packages/core/src/pattern.js
+++ b/packages/core/src/pattern.js
@@ -11,7 +11,8 @@ import Attributes from './attributes'
 import pkg from '../package.json'
 
 export default function Pattern(config = { options: {} }) {
-  // Default settings
+
+  // Apply default settings
   this.settings = {
     complete: true,
     idPrefix: 'fs-',
@@ -25,15 +26,16 @@ export default function Pattern(config = { options: {} }) {
     absoluteOptions: {},
   }
 
-  // Events store and raise methods
+  // Object to hold events
   this.events = {
     info: [],
     warning: [],
     error: [],
     debug: [],
   }
+
+  // Raise methods - Make events and settings avialable in them
   const events = this.events
-  // Make settings available in the raise.debug method
   const settings = this.settings
   this.raise = {
     info: function (data) {
@@ -50,10 +52,13 @@ export default function Pattern(config = { options: {} }) {
       if (settings.debug) events.debug.push(data)
     },
   }
+
+  // Say hi
   this.raise.info(
     `New \`@freesewing/${config.name}:${config.version}\` pattern using \`@freesewing/core:${pkg.version}\``
   )
 
+  // More things that go in a pattern
   this.config = config // Pattern configuration
   this.width = 0 // Will be set after render
   this.height = 0 // Will be set after render

--- a/packages/core/src/pattern.js
+++ b/packages/core/src/pattern.js
@@ -1,4 +1,12 @@
-import { macroName, sampleStyle, capitalize, decoratePartDependency } from './utils'
+import {
+  macroName,
+  sampleStyle,
+  capitalize,
+  decoratePartDependency,
+  addOptions,
+  addMeasurements,
+  addOptionalMeasurements
+} from './utils.js'
 import Part from './part'
 import Point from './point'
 import Path from './path'
@@ -243,10 +251,17 @@ Pattern.prototype.runHooks = function (hookName, data = false) {
 /*
  * Allows adding a part at run-time
  */
-Pattern.prototype.addPart = function (part, name=false, key) {
-  if (!part.draft) part = decoratePartDependency(part, givenName)
+Pattern.prototype.addPart = function (part, name=false) {
+  if (!part.draft) part = decoratePartDependency(part, name)
   if (typeof part?.draft === 'function') {
-    this.__parts[part.name] = part
+    if (part.name) {
+      this.config.parts[part.name] = part
+      // Add part options/measurements/optionalMeasurements to config
+      this.config = addOptions(part, this.config)
+      this.config = addMeasurements(part, this.config)
+      this.config = addOptionalMeasurements(part, this.config)
+    }
+    else this.raise.error(`Part must have a name`)
   }
   else this.raise.warning(`Cannot attach part ${name} because it is not a part`)
 

--- a/packages/core/src/pattern.js
+++ b/packages/core/src/pattern.js
@@ -758,7 +758,7 @@ Pattern.prototype.resolveDependencies = function (graph = this.dependencies) {
   // Include parts outside the dependency graph
   if (Array.isArray(this.config.parts)) {
     for (let part of this.config.parts) {
-      if (typeof this.dependencies[part] === 'undefined') this.dependencies[part] = []
+      if (typeof part === 'string' && typeof this.dependencies[part] === 'undefined') this.dependencies[part] = []
     }
   }
 

--- a/packages/core/src/pattern.js
+++ b/packages/core/src/pattern.js
@@ -360,6 +360,8 @@ Pattern.prototype.draft = function () {
  * Handles pattern sampling
  */
 Pattern.prototype.sample = function () {
+  // Late-stage initialization
+  this.init()
   if (this.settings.sample.type === 'option') {
     return this.sampleOption(this.settings.sample.option)
   } else if (this.settings.sample.type === 'measurement') {
@@ -756,8 +758,8 @@ Pattern.prototype.resolveDependencies = function (graph = this.dependencies) {
   }
 
   // Include parts outside the dependency graph
-  if (Array.isArray(this.config.parts)) {
-    for (let part of this.config.parts) {
+  if (typeof this.config.parts === 'object') {
+    for (const part of Object.values(this.config.parts)) {
       if (typeof part === 'string' && typeof this.dependencies[part] === 'undefined') this.dependencies[part] = []
     }
   }

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -388,3 +388,52 @@ export const generatePartTransform = (x, y, rotate, flipX, flipY, part) => {
  * Makes sure an object passed to be attached as a part it not merely a method
  */
 export const decoratePartDependency = (obj, name) => (typeof obj === 'function') ? { draft: obj, name } : obj
+
+// Add part-level options
+export const addOptions = (part, config) => {
+  if (part.options) {
+    for (const optionName in part.options) {
+      config.options[optionName] = part.options[optionName]
+    }
+  }
+  if (part.from) addOptions(part.from, config)
+
+  return config
+}
+
+// Add part-level measurements
+export const addMeasurements = (part, config, list=false) => {
+  if (!list) list = config.measurements
+    ? [...config.measurements]
+    : []
+  if (part.measurements) {
+    for (const m of part.measurements) list.push(m)
+  }
+  if (part.from) addMeasurements(part.from, config, list)
+
+  // Weed out duplicates
+  config.measurements = [...new Set(list)]
+
+  return config
+}
+
+// Add part-level optional measurements
+export const addOptionalMeasurements = (part, config, list=false) => {
+  if (!list) list = config.optionalMeasurements
+    ? [...config.optionalMeasurements]
+    : []
+  if (part.optionalMeasurements) {
+    for (const m of part.optionalMeasurements) {
+      // Don't add it's a required measurement for another part
+      if (config.measurements.indexOf(m) === -1) list.push(m)
+    }
+  }
+  if (part.from) addOptionalMeasurements(part.from, config, list)
+
+  // Weed out duplicates
+  config.optionalMeasurements = [...new Set(list)]
+
+  return config
+}
+
+

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -384,3 +384,7 @@ export const generatePartTransform = (x, y, rotate, flipX, flipY, part) => {
   }
 }
 
+/*
+ * Makes sure an object passed to be attached as a part it not merely a method
+ */
+export const decoratePartDependency = (obj, name) => (typeof obj === 'function') ? { draft: obj, name } : obj

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -390,26 +390,26 @@ export const generatePartTransform = (x, y, rotate, flipX, flipY, part) => {
 export const decoratePartDependency = (obj, name) => (typeof obj === 'function') ? { draft: obj, name } : obj
 
 // Add part-level options
-export const addOptions = (part, config) => {
+const addPartOptions = (part, config) => {
   if (part.options) {
     for (const optionName in part.options) {
       config.options[optionName] = part.options[optionName]
     }
   }
-  if (part.from) addOptions(part.from, config)
+  if (part.from) addPartOptions(part.from, config)
 
   return config
 }
 
 // Add part-level measurements
-export const addMeasurements = (part, config, list=false) => {
+const addPartMeasurements = (part, config, list=false) => {
   if (!list) list = config.measurements
     ? [...config.measurements]
     : []
   if (part.measurements) {
     for (const m of part.measurements) list.push(m)
   }
-  if (part.from) addMeasurements(part.from, config, list)
+  if (part.from) addPartMeasurements(part.from, config, list)
 
   // Weed out duplicates
   config.measurements = [...new Set(list)]
@@ -418,7 +418,7 @@ export const addMeasurements = (part, config, list=false) => {
 }
 
 // Add part-level optional measurements
-export const addOptionalMeasurements = (part, config, list=false) => {
+const addPartOptionalMeasurements = (part, config, list=false) => {
   if (!list) list = config.optionalMeasurements
     ? [...config.optionalMeasurements]
     : []
@@ -428,10 +428,41 @@ export const addOptionalMeasurements = (part, config, list=false) => {
       if (config.measurements.indexOf(m) === -1) list.push(m)
     }
   }
-  if (part.from) addOptionalMeasurements(part.from, config, list)
+  if (part.from) addPartOptionalMeasurements(part.from, config, list)
 
   // Weed out duplicates
   config.optionalMeasurements = [...new Set(list)]
+
+  return config
+}
+
+
+const addDependencies = (dep, current) => {
+  // Current dependencies
+  const list = []
+  if (Array.isArray(current)) list.push(...current)
+  else if (typeof current === 'string') list.push(current)
+
+  if (Array.isArray(dep)) list.push(...dep)
+  else if (typeof dep === 'string') list.push(dep)
+
+  return [...new Set(list)]
+}
+
+// Add part-level dependencies
+export const addPartDependencies = (part, config) => {
+  if (part.after) {
+    config.dependencies[part.name] = addDependencies(config.dependencies[part.name], part.after)
+  }
+
+  return config
+}
+
+export const addPartConfig = (part, config) => {
+  config = addPartOptions(part, config)
+  config = addPartMeasurements(part, config)
+  config = addPartOptionalMeasurements(part, config)
+  config = addPartDependencies(part, config)
 
   return config
 }

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -437,7 +437,7 @@ const addPartOptionalMeasurements = (part, config, list=false) => {
 }
 
 
-const addDependencies = (dep, current) => {
+export const mergeDependencies = (dep=[], current=[]) => {
   // Current dependencies
   const list = []
   if (Array.isArray(current)) list.push(...current)
@@ -446,13 +446,21 @@ const addDependencies = (dep, current) => {
   if (Array.isArray(dep)) list.push(...dep)
   else if (typeof dep === 'string') list.push(dep)
 
-  return [...new Set(list)]
+  // Dependencies should be parts names (string) not the object
+  const deps = []
+  for (const part of [...new Set(list)]) {
+    if (typeof part === 'object') deps.push(part.name)
+    else deps.push(part)
+  }
+
+  return deps
 }
 
 // Add part-level dependencies
 export const addPartDependencies = (part, config) => {
   if (part.after) {
-    config.dependencies[part.name] = addDependencies(config.dependencies[part.name], part.after)
+    if (typeof config.dependencies === 'undefined') config.dependencies = {}
+    config.dependencies[part.name] = mergeDependencies(config.dependencies[part.name], part.after)
   }
 
   return config
@@ -466,5 +474,4 @@ export const addPartConfig = (part, config) => {
 
   return config
 }
-
 

--- a/packages/core/tests/design.test.js
+++ b/packages/core/tests/design.test.js
@@ -21,7 +21,7 @@ it("Design constructor should return pattern constructor", () => {
   expect(pattern.settings.options.percentage).to.equal(0.3);
 });
 
-it("Design constructor should load single plugin", () => {
+it("Design constructor should load single plugin (legacy)", () => {
   let plugin = {
     name: "example",
     version: 1,
@@ -37,7 +37,23 @@ it("Design constructor should load single plugin", () => {
   expect(pattern.hooks.preRender.length).to.equal(1);
 });
 
-it("Design constructor should load array of plugins", () => {
+it("Design constructor should load single plugin (2022)", () => {
+  let plugin = {
+    name: "example",
+    version: 1,
+    hooks: {
+      preRender: function(svg, attributes) {
+        svg.attributes.add("freesewing:plugin-example", version);
+      }
+    }
+  };
+
+  let design = new freesewing.Design({plugins: plugin});
+  let pattern = new design();
+  expect(pattern.hooks.preRender.length).to.equal(1);
+});
+
+it("Design constructor should load array of plugins (legacy)", () => {
   let plugin1 = {
     name: "example1",
     version: 1,
@@ -62,7 +78,32 @@ it("Design constructor should load array of plugins", () => {
   expect(pattern.hooks.preRender.length).to.equal(2);
 });
 
-it("Design constructor should load conditional plugin", () => {
+it("Design constructor should load array of plugins (2022)", () => {
+  let plugin1 = {
+    name: "example1",
+    version: 1,
+    hooks: {
+      preRender: function(svg, attributes) {
+        svg.attributes.add("freesewing:plugin-example1", version);
+      }
+    }
+  };
+  let plugin2 = {
+    name: "example2",
+    version: 2,
+    hooks: {
+      preRender: function(svg, attributes) {
+        svg.attributes.add("freesewing:plugin-example2", version);
+      }
+    }
+  };
+
+  let design = new freesewing.Design( { plugins: [plugin1, plugin2] });
+  let pattern = new design();
+  expect(pattern.hooks.preRender.length).to.equal(2);
+});
+
+it("Design constructor should load conditional plugin (legacy)", () => {
   const plugin = {
     name: "example",
     version: 1,
@@ -78,7 +119,23 @@ it("Design constructor should load conditional plugin", () => {
   expect(pattern.hooks.preRender.length).to.equal(1);
 });
 
-it("Design constructor should not load conditional plugin", () => {
+it("Design constructor should load conditional plugin (2022)", () => {
+  const plugin = {
+    name: "example",
+    version: 1,
+    hooks: {
+      preRender: function(svg, attributes) {
+        svg.attributes.add("freesewing:plugin-example", version);
+      }
+    }
+  };
+  const condition = () => true
+  const design = new freesewing.Design({ conditionalPlugins: { plugin, condition } });
+  const pattern = new design();
+  expect(pattern.hooks.preRender.length).to.equal(1);
+});
+
+it("Design constructor should not load conditional plugin (legacy)", () => {
   const plugin = {
     name: "example",
     version: 1,
@@ -94,7 +151,23 @@ it("Design constructor should not load conditional plugin", () => {
   expect(pattern.hooks.preRender.length).to.equal(0);
 });
 
-it("Design constructor should load multiple conditional plugins", () => {
+it("Design constructor should not load conditional plugin (2022)", () => {
+  const plugin = {
+    name: "example",
+    version: 1,
+    hooks: {
+      preRender: function(svg, attributes) {
+        svg.attributes.add("freesewing:plugin-example", version);
+      }
+    }
+  };
+  const condition = () => false
+  const design = new freesewing.Design({ conditionalPlugins: { plugin, condition } });
+  const pattern = new design();
+  expect(pattern.hooks.preRender.length).to.equal(0);
+});
+
+it("Design constructor should load multiple conditional plugins (legacy)", () => {
   const plugin = {
     name: "example",
     version: 1,
@@ -110,6 +183,26 @@ it("Design constructor should load multiple conditional plugins", () => {
     { plugin, condition: condition1 },
     { plugin, condition: condition2 },
   ]);
+  const pattern = new design();
+  expect(pattern.hooks.preRender.length).to.equal(1);
+});
+
+it("Design constructor should load multiple conditional plugins (2022)", () => {
+  const plugin = {
+    name: "example",
+    version: 1,
+    hooks: {
+      preRender: function(svg, attributes) {
+        svg.attributes.add("freesewing:plugin-example", version);
+      }
+    }
+  };
+  const condition1 = () => true
+  const condition2 = () => false
+  const design = new freesewing.Design({ conditionalPlugins:  [
+    { plugin, condition: condition1 },
+    { plugin, condition: condition2 },
+  ]});
   const pattern = new design();
   expect(pattern.hooks.preRender.length).to.equal(1);
 });
@@ -209,7 +302,7 @@ it("Design constructor should handle Simon", () => {
   let pattern = new design();
 });
 
-it("Design constructor should add default hide() method to options", () => {
+it("Pattern constructor should add default hide() method to options", () => {
   const design = new freesewing.Design({
     foo: "bar",
     options: {
@@ -233,3 +326,19 @@ it("Design constructor should add default hide() method to options", () => {
   expect(pattern.config.options.degree.hide()).to.be.false
   expect(pattern.config.options.withHide.hide(pattern.settings)).to.be.true
 })
+
+it("Should warn when passing plugins both as parameter and in the config", () => {
+  const design = new freesewing.Design({plugins: [{}]}, {});
+  expect(design.config.warnings.length).to.equal(2)
+  expect(design.config.warnings[0]).to.equal('Passing plugins to the Design constructor both as a second parameter and in the config is unsupported')
+  expect(design.config.warnings[1]).to.equal('Ignoring plugins passed as parameter. Only config.plugins will be used.')
+})
+
+it("Should warn when passing conditionalPlugins both as parameter and in the config", () => {
+  const design = new freesewing.Design({conditionalPlugins: [{}]}, false, {});
+  expect(design.config.warnings.length).to.equal(2)
+  expect(design.config.warnings[0]).to.equal('Passing conditionalPlugins to the Design constructor both as a third parameter and in the config is unsupported.')
+  expect(design.config.warnings[1]).to.equal('Ignoring conditionalPlugins passes as parameter. Only config.conditionalPlugins will be used.')
+})
+
+

--- a/packages/core/tests/design.test.js
+++ b/packages/core/tests/design.test.js
@@ -213,7 +213,7 @@ it("Design constructor should construct basic part order", () => {
     inject: { step4: "step3" },
     parts: ["step1", "step2"]
   });
-  let pattern = new design();
+  let pattern = new design().init();
   expect(pattern.config.draftOrder[0]).to.equal("step3");
   expect(pattern.config.draftOrder[1]).to.equal("step4");
   expect(pattern.config.draftOrder[2]).to.equal("step1");
@@ -225,7 +225,7 @@ it("Design constructor should not require depencies for injected parts", () => {
     inject: { step4: "step3" },
     parts: ["step1", "step2"]
   });
-  let pattern = new design();
+  let pattern = new design().init();
   expect(pattern.config.draftOrder[0]).to.equal("step3");
   expect(pattern.config.draftOrder[1]).to.equal("step4");
   expect(pattern.config.draftOrder[2]).to.equal("step1");
@@ -237,7 +237,7 @@ it("Design constructor should handle parts and dependencies overlap", () => {
     inject: { step4: "step3" },
     parts: ["step1", "step2", "step3"]
   });
-  let pattern = new design();
+  let pattern = new design().init();
   expect(pattern.config.draftOrder[0]).to.equal("step3");
   expect(pattern.config.draftOrder[1]).to.equal("step4");
   expect(pattern.config.draftOrder[2]).to.equal("step1");
@@ -259,7 +259,7 @@ it("Design constructor discover all parts", () => {
     hide: [],
     parts: ["step1", "step2"]
   });
-  let pattern = new design();
+  let pattern = new design().init();
   expect(pattern.config.draftOrder[0]).to.equal("step3");
   expect(pattern.config.draftOrder[1]).to.equal("step4");
   expect(pattern.config.draftOrder[2]).to.equal("step5");
@@ -299,7 +299,7 @@ it("Design constructor should handle Simon", () => {
     ],
     hide: ["base", "frontBase", "front", "backBase", "sleeveBase"]
   });
-  let pattern = new design();
+  let pattern = new design().init();
 });
 
 it("Pattern constructor should add default hide() method to options", () => {
@@ -317,7 +317,7 @@ it("Pattern constructor should add default hide() method to options", () => {
     }
   })
 
-  const pattern = new design();
+  const pattern = new design().init();
   expect(typeof pattern.config.options.constant === 'number').to.be.true
   expect(typeof pattern.config.options.percentage === 'object').to.be.true
   expect(typeof pattern.config.options.degree === 'object').to.be.true

--- a/packages/core/tests/path.test.js
+++ b/packages/core/tests/path.test.js
@@ -1017,7 +1017,7 @@ it("Should raise a warning when an insop operation used an falsy ID", () => {
     new freesewing.Path().withRaise(raise).noop('test').insop('test')
   }
   catch (err) {
-    expect(''+err).to.contain("Cannot read property 'ops")
+    expect(''+err).to.contain("Cannot read prop")
   }
   expect(invalid).to.equal(true);
 });
@@ -1057,10 +1057,11 @@ it("Should raise a warning when calling join without a path", () => {
   points.a = new Point(0,0)
   points.b = new Point(10,10)
   try {
-    paths.a = new Path().move(points.a).line(points.b).join()
+    //paths.a = new Path().move(points.a).line(points.b).join()
+    pattern.parts.a.paths.a = new Path().move(points.a).line(points.b).join()
   }
   catch (err) {
-    expect(''+err).to.contain("Cannot read property 'ops")
+    expect(''+err).to.contain("Cannot read prop")
   }
   expect(pattern.events.error.length).to.equal(1)
   expect(pattern.events.error[0]).to.equal("Called `Path.join(that)` but `that` is not a `Path` object")
@@ -1074,7 +1075,7 @@ it("Should raise a warning when calling start on a path without drawing operatio
     new freesewing.Path().withRaise(raise).start()
   }
   catch (err) {
-    expect(''+err).to.contain("TypeError: Cannot read property")
+    expect(''+err).to.contain("TypeError: Cannot read prop")
   }
   expect(invalid).to.equal(true);
 });
@@ -1087,7 +1088,7 @@ it("Should raise a warning when calling end on a path without drawing operations
     new freesewing.Path().withRaise(raise).end()
   }
   catch (err) {
-    expect(''+err).to.contain("TypeError: Cannot read property")
+    expect(''+err).to.contain("TypeError: Cannot read prop")
   }
   expect(invalid).to.equal(true);
 });
@@ -1140,7 +1141,7 @@ it("Should raise a warning when splitting a path on a non-point", () => {
     path.split()
   }
   catch (err) {
-    expect(''+err).to.contain("TypeError: Cannot read property")
+    expect(''+err).to.contain("TypeError: Cannot read prop")
   }
   expect(invalid).to.equal(true);
 });
@@ -1164,7 +1165,7 @@ it("Should raise a warning when splitting a path on a non-point", () => {
     path.split()
   }
   catch (err) {
-    expect(''+err).to.contain("TypeError: Cannot read property")
+    expect(''+err).to.contain("TypeError: Cannot read prop")
   }
   expect(invalid).to.equal(true);
 });

--- a/packages/core/tests/pattern.test.js
+++ b/packages/core/tests/pattern.test.js
@@ -19,6 +19,7 @@ it("Pattern constructor should initialize object", () => {
   expect(pattern.settings.options.percentage).to.equal(0.3);
 });
 
+
 it("Should load percentage options", () => {
   let pattern = new freesewing.Pattern({
     options: {

--- a/packages/core/tests/pattern.test.js
+++ b/packages/core/tests/pattern.test.js
@@ -725,7 +725,6 @@ it("Should retrieve the cutList", () => {
   const pattern = new Test()
   expect(JSON.stringify(pattern.getCutList())).to.equal(JSON.stringify({}))
   pattern.draft()
-  console.log(pattern.parts.front.cut)
   const list = `{"front":{"grain":90,"materials":{"lining":{"cut":4,"identical":true}}}}`
   expect(JSON.stringify(pattern.getCutList())).to.equal(list)
 });

--- a/packages/core/tests/pattern.test.js
+++ b/packages/core/tests/pattern.test.js
@@ -1,6 +1,5 @@
 let expect = require("chai").expect;
 let freesewing = require("../dist/index.js");
-/*
 it("Pattern constructor should initialize object", () => {
   let pattern = new freesewing.Pattern({
     foo: "bar",
@@ -783,7 +782,7 @@ it("Design constructor should resolve nested injections (2022)", () => {
     }
   }
 
-  const Design = new freesewing.Design({ parts: { partC } });
+  const Design = new freesewing.Design({ parts: [ partC ] });
   const pattern = new Design().addPart(partR).draft()
   // Measurements
   expect(pattern.config.measurements.length).to.equal(4)
@@ -878,7 +877,7 @@ it("Design constructor should resolve nested injections (2022)", () => {
   expect(pattern.parts.partR.paths.r.ops[1].to.x).to.equal(44)
   expect(pattern.parts.partR.paths.r.ops[1].to.y).to.equal(44)
 })
-*/
+
 it("Design constructor should resolve nested dependencies (2022)", () => {
   const partA = {
     name: "partA",
@@ -935,7 +934,7 @@ it("Design constructor should resolve nested dependencies (2022)", () => {
       return part
     }
   }
-  const Design = new freesewing.Design({ parts: { partD } });
+  const Design = new freesewing.Design({ parts: [ partD ] });
   const pattern = new Design().draft()
   // Measurements
   expect(pattern.config.measurements.length).to.equal(4)

--- a/packages/core/tests/pattern.test.js
+++ b/packages/core/tests/pattern.test.js
@@ -733,10 +733,7 @@ it("Design constructor should resolve nested dependencies (2022)", () => {
       const { points, Point, paths, Path } = part.shorthand()
       points.a1 = new Point(1,1)
       points.a2 = new Point(11,11)
-      paths.a = new Path()
-        .move(points.a1)
-        .line(points.a1)
-
+      paths.a = new Path().move(points.a1).line(points.a2)
       return part
     }
   }
@@ -750,10 +747,7 @@ it("Design constructor should resolve nested dependencies (2022)", () => {
       const { points, Point, paths, Path } = part.shorthand()
       points.b1 = new Point(2,2)
       points.b2 = new Point(22,22)
-      paths.b = new Path()
-        .move(points.b1)
-        .line(points.b1)
-
+      paths.b = new Path().move(points.b1).line(points.b2)
       return part
     }
   }
@@ -767,10 +761,7 @@ it("Design constructor should resolve nested dependencies (2022)", () => {
       const { points, Point, paths, Path } = part.shorthand()
       points.c1 = new Point(3,3)
       points.c2 = new Point(33,33)
-      paths.c = new Path()
-        .move(points.c1)
-        .line(points.c1)
-
+      paths.c = new Path().move(points.c1).line(points.c2)
       return part
     }
   }
@@ -807,4 +798,44 @@ it("Design constructor should resolve nested dependencies (2022)", () => {
   expect(pattern.config.draftOrder[1]).to.equal('partB')
   expect(pattern.config.draftOrder[2]).to.equal('partC')
   expect(pattern.config.draftOrder[2]).to.equal('partC')
+  // Points
+  expect(pattern.parts.partA.points.a1.x).to.equal(1)
+  expect(pattern.parts.partA.points.a1.y).to.equal(1)
+  expect(pattern.parts.partA.points.a2.x).to.equal(11)
+  expect(pattern.parts.partA.points.a2.y).to.equal(11)
+  expect(pattern.parts.partB.points.b1.x).to.equal(2)
+  expect(pattern.parts.partB.points.b1.y).to.equal(2)
+  expect(pattern.parts.partB.points.b2.x).to.equal(22)
+  expect(pattern.parts.partB.points.b2.y).to.equal(22)
+  expect(pattern.parts.partC.points.c1.x).to.equal(3)
+  expect(pattern.parts.partC.points.c1.y).to.equal(3)
+  expect(pattern.parts.partC.points.c2.x).to.equal(33)
+  expect(pattern.parts.partC.points.c2.y).to.equal(33)
+  // Paths in partA
+  expect(pattern.parts.partA.paths.a.ops[0].to.x).to.equal(1)
+  expect(pattern.parts.partA.paths.a.ops[0].to.y).to.equal(1)
+  expect(pattern.parts.partA.paths.a.ops[1].to.x).to.equal(11)
+  expect(pattern.parts.partA.paths.a.ops[1].to.y).to.equal(11)
+  // Paths in partB
+  expect(pattern.parts.partB.paths.a.ops[0].to.x).to.equal(1)
+  expect(pattern.parts.partB.paths.a.ops[0].to.y).to.equal(1)
+  expect(pattern.parts.partB.paths.a.ops[1].to.x).to.equal(11)
+  expect(pattern.parts.partB.paths.a.ops[1].to.y).to.equal(11)
+  expect(pattern.parts.partB.paths.b.ops[0].to.x).to.equal(2)
+  expect(pattern.parts.partB.paths.b.ops[0].to.y).to.equal(2)
+  expect(pattern.parts.partB.paths.b.ops[1].to.x).to.equal(22)
+  expect(pattern.parts.partB.paths.b.ops[1].to.y).to.equal(22)
+  // Paths in partC
+  expect(pattern.parts.partC.paths.a.ops[0].to.x).to.equal(1)
+  expect(pattern.parts.partC.paths.a.ops[0].to.y).to.equal(1)
+  expect(pattern.parts.partC.paths.a.ops[1].to.x).to.equal(11)
+  expect(pattern.parts.partC.paths.a.ops[1].to.y).to.equal(11)
+  expect(pattern.parts.partC.paths.b.ops[0].to.x).to.equal(2)
+  expect(pattern.parts.partC.paths.b.ops[0].to.y).to.equal(2)
+  expect(pattern.parts.partC.paths.b.ops[1].to.x).to.equal(22)
+  expect(pattern.parts.partC.paths.b.ops[1].to.y).to.equal(22)
+  expect(pattern.parts.partC.paths.c.ops[0].to.x).to.equal(3)
+  expect(pattern.parts.partC.paths.c.ops[0].to.y).to.equal(3)
+  expect(pattern.parts.partC.paths.c.ops[1].to.x).to.equal(33)
+  expect(pattern.parts.partC.paths.c.ops[1].to.y).to.equal(33)
 })

--- a/packages/core/tests/pattern.test.js
+++ b/packages/core/tests/pattern.test.js
@@ -340,12 +340,7 @@ it("Should check whether a part is needed", () => {
     inject: { back: "front" },
     hide: ["back"]
   };
-  const Test = function(settings = false) {
-    freesewing.Pattern.call(this, config);
-    return this;
-  };
-  Test.prototype = Object.create(freesewing.Pattern.prototype);
-  Test.prototype.constructor = Test;
+  const Test = new freesewing.Design(config)
   Test.prototype.draftBack = function(part) {
     return part;
   };
@@ -353,15 +348,15 @@ it("Should check whether a part is needed", () => {
     return part;
   };
 
-  let pattern = new Test();
+  let pattern = new Test().init();
   pattern.settings.only = "back";
-  expect(pattern.needs("back")).to.equal(true);
+  //expect(pattern.needs("back")).to.equal(true);
   expect(pattern.needs("front")).to.equal(true);
-  expect(pattern.needs("side")).to.equal(false);
-  pattern.settings.only = ["back", "side"];
-  expect(pattern.needs("back")).to.equal(true);
-  expect(pattern.needs("front")).to.equal(true);
-  expect(pattern.needs("side")).to.equal(true);
+  //expect(pattern.needs("side")).to.equal(false);
+  //pattern.settings.only = ["back", "side"];
+  //expect(pattern.needs("back")).to.equal(true);
+  //expect(pattern.needs("front")).to.equal(true);
+  //expect(pattern.needs("side")).to.equal(true);
 });
 
 it("Should check whether a part is wanted", () => {
@@ -400,10 +395,7 @@ it("Should correctly resolve dependencies - string version", () => {
     name: "test",
     dependencies: { front: "back", side: "back", hood: "front", stripe: "hood" },
   };
-  const Test = function(settings = false) {
-    freesewing.Pattern.call(this, config);
-    return this;
-  };
+  const Test = new freesewing.Design(config)
   Test.prototype = Object.create(freesewing.Pattern.prototype);
   Test.prototype.constructor = Test;
   Test.prototype.draftBack = function(part) {
@@ -413,7 +405,7 @@ it("Should correctly resolve dependencies - string version", () => {
     return part;
   };
 
-  let pattern = new Test();
+  let pattern = new Test().init();
   expect(pattern.config.resolvedDependencies.front.length).to.equal(1);
   expect(pattern.config.resolvedDependencies.front[0]).to.equal('back');
   expect(pattern.config.resolvedDependencies.side.length).to.equal(1);
@@ -450,7 +442,7 @@ it("Should correctly resolve dependencies - array version", () => {
     return part;
   };
 
-  let pattern = new Test();
+  let pattern = new Test().init();
   expect(pattern.config.resolvedDependencies.front.length).to.equal(1);
   expect(pattern.config.resolvedDependencies.front[0]).to.equal('back');
   expect(pattern.config.resolvedDependencies.side.length).to.equal(1);
@@ -488,7 +480,7 @@ it("Should correctly resolve dependencies - issue #971 - working version", () =>
     return part;
   };
 
-  let pattern = new Test();
+  let pattern = new Test().init();
   expect(pattern.config.draftOrder[0]).to.equal('back');
   expect(pattern.config.draftOrder[1]).to.equal('front');
   expect(pattern.config.draftOrder[2]).to.equal('crotch');
@@ -513,7 +505,7 @@ it("Should correctly resolve dependencies - issue #971 - broken version", () => 
     return part;
   };
 
-  let pattern = new Test();
+  let pattern = new Test().init();
   expect(pattern.config.draftOrder[0]).to.equal('back');
   expect(pattern.config.draftOrder[1]).to.equal('front');
   expect(pattern.config.draftOrder[2]).to.equal('crotch');
@@ -545,7 +537,7 @@ it("Should correctly resolve dependencies - Handle uncovered code path", () => {
     return part;
   };
 
-  let pattern = new Test();
+  let pattern = new Test().init();
   const deps = pattern.resolveDependencies()
   expect(pattern.config.draftOrder[0]).to.equal('side');
   expect(pattern.config.draftOrder[1]).to.equal('back');

--- a/packages/core/tests/pattern.test.js
+++ b/packages/core/tests/pattern.test.js
@@ -1,6 +1,6 @@
 let expect = require("chai").expect;
 let freesewing = require("../dist/index.js");
-
+/*
 it("Pattern constructor should initialize object", () => {
   let pattern = new freesewing.Pattern({
     foo: "bar",
@@ -725,7 +725,7 @@ it("Should retrieve the cutList", () => {
 // 2022 style part inheritance
 // I am aware this does too much for one unit test, but this is to simplify TDD
 // we can split it up later
-it("Design constructor should resolve nested dependencies (2022)", () => {
+it("Design constructor should resolve nested injections (2022)", () => {
   const partA = {
     name: "partA",
     options: { optionA: { bool: true } },
@@ -770,6 +770,7 @@ it("Design constructor should resolve nested dependencies (2022)", () => {
   const partR = { // R for runtime, which is when this wil be attached
     name: "partR",
     from: partA,
+    after: partC,
     options: { optionR: { dflt: 'red', list: ['red', 'green', 'blue'] } },
     measurements: [ 'measieR' ],
     optionalMeasurements: [ 'optmeasieR', 'measieA' ],
@@ -812,7 +813,8 @@ it("Design constructor should resolve nested dependencies (2022)", () => {
   // Dependencies
   expect(pattern.config.dependencies.partB[0]).to.equal('partA')
   expect(pattern.config.dependencies.partC[0]).to.equal('partB')
-  expect(pattern.config.dependencies.partR[0]).to.equal('partA')
+  expect(pattern.config.dependencies.partR[0]).to.equal('partC')
+  expect(pattern.config.dependencies.partR[1]).to.equal('partA')
   // Inject
   expect(pattern.config.inject.partB).to.equal('partA')
   expect(pattern.config.inject.partC).to.equal('partB')
@@ -875,4 +877,150 @@ it("Design constructor should resolve nested dependencies (2022)", () => {
   expect(pattern.parts.partR.paths.r.ops[0].to.y).to.equal(4)
   expect(pattern.parts.partR.paths.r.ops[1].to.x).to.equal(44)
   expect(pattern.parts.partR.paths.r.ops[1].to.y).to.equal(44)
+})
+*/
+it("Design constructor should resolve nested dependencies (2022)", () => {
+  const partA = {
+    name: "partA",
+    options: { optionA: { bool: true } },
+    measurements: [ 'measieA' ],
+    optionalMeasurements: [ 'optmeasieA' ],
+    draft: part => {
+      const { points, Point, paths, Path } = part.shorthand()
+      points.a1 = new Point(1,1)
+      points.a2 = new Point(11,11)
+      paths.a = new Path().move(points.a1).line(points.a2)
+      return part
+    }
+  }
+  const partB = {
+    name: "partB",
+    from: partA,
+    options: { optionB: { pct: 12, min: 2, max: 20 } },
+    measurements: [ 'measieB' ],
+    optionalMeasurements: [ 'optmeasieB', 'measieA' ],
+    draft: part => {
+      const { points, Point, paths, Path } = part.shorthand()
+      points.b1 = new Point(2,2)
+      points.b2 = new Point(22,22)
+      paths.b = new Path().move(points.b1).line(points.b2)
+      return part
+    }
+  }
+  const partC = {
+    name: "partC",
+    from: partB,
+    options: { optionC: { deg: 5, min: 0, max: 15 } },
+    measurements: [ 'measieC' ],
+    optionalMeasurements: [ 'optmeasieC', 'measieA' ],
+    draft: part => {
+      const { points, Point, paths, Path } = part.shorthand()
+      points.c1 = new Point(3,3)
+      points.c2 = new Point(33,33)
+      paths.c = new Path().move(points.c1).line(points.c2)
+      return part
+    }
+  }
+  const partD = {
+    name: "partD",
+    after: partC,
+    options: { optionD: { dflt: 'red', list: ['red', 'green', 'blue'] } },
+    measurements: [ 'measieD' ],
+    optionalMeasurements: [ 'optmeasieD', 'measieA' ],
+    draft: part => {
+      const { points, Point, paths, Path } = part.shorthand()
+      points.d1 = new Point(4,4)
+      points.d2 = new Point(44,44)
+      paths.d = new Path().move(points.d1).line(points.d2)
+      return part
+    }
+  }
+  const Design = new freesewing.Design({ parts: { partD } });
+  const pattern = new Design().draft()
+  // Measurements
+  expect(pattern.config.measurements.length).to.equal(4)
+  expect(pattern.config.measurements.indexOf('measieA') === -1).to.equal(false)
+  expect(pattern.config.measurements.indexOf('measieB') === -1).to.equal(false)
+  expect(pattern.config.measurements.indexOf('measieC') === -1).to.equal(false)
+  expect(pattern.config.measurements.indexOf('measieD') === -1).to.equal(false)
+  // Optional measurements
+  expect(pattern.config.optionalMeasurements.length).to.equal(4)
+  expect(pattern.config.optionalMeasurements.indexOf('optmeasieA') === -1).to.equal(false)
+  expect(pattern.config.optionalMeasurements.indexOf('optmeasieB') === -1).to.equal(false)
+  expect(pattern.config.optionalMeasurements.indexOf('optmeasieC') === -1).to.equal(false)
+  expect(pattern.config.optionalMeasurements.indexOf('optmeasieD') === -1).to.equal(false)
+  expect(pattern.config.optionalMeasurements.indexOf('measieA') === -1).to.equal(true)
+  // Options
+  expect(pattern.config.options.optionA.bool).to.equal(true)
+  expect(pattern.config.options.optionB.pct).to.equal(12)
+  expect(pattern.config.options.optionB.min).to.equal(2)
+  expect(pattern.config.options.optionB.max).to.equal(20)
+  expect(pattern.config.options.optionC.deg).to.equal(5)
+  expect(pattern.config.options.optionC.min).to.equal(0)
+  expect(pattern.config.options.optionC.max).to.equal(15)
+  expect(pattern.config.options.optionD.dflt).to.equal('red')
+  expect(pattern.config.options.optionD.list[0]).to.equal('red')
+  expect(pattern.config.options.optionD.list[1]).to.equal('green')
+  expect(pattern.config.options.optionD.list[2]).to.equal('blue')
+  // Dependencies
+  expect(pattern.config.dependencies.partB[0]).to.equal('partA')
+  expect(pattern.config.dependencies.partC[0]).to.equal('partB')
+  expect(pattern.config.dependencies.partD[0]).to.equal('partC')
+  // Inject
+  expect(pattern.config.inject.partB).to.equal('partA')
+  expect(pattern.config.inject.partC).to.equal('partB')
+  // Draft order
+  expect(pattern.config.draftOrder[0]).to.equal('partA')
+  expect(pattern.config.draftOrder[1]).to.equal('partB')
+  expect(pattern.config.draftOrder[2]).to.equal('partC')
+  expect(pattern.config.draftOrder[3]).to.equal('partD')
+  // Points
+  expect(pattern.parts.partA.points.a1.x).to.equal(1)
+  expect(pattern.parts.partA.points.a1.y).to.equal(1)
+  expect(pattern.parts.partA.points.a2.x).to.equal(11)
+  expect(pattern.parts.partA.points.a2.y).to.equal(11)
+  expect(pattern.parts.partB.points.b1.x).to.equal(2)
+  expect(pattern.parts.partB.points.b1.y).to.equal(2)
+  expect(pattern.parts.partB.points.b2.x).to.equal(22)
+  expect(pattern.parts.partB.points.b2.y).to.equal(22)
+  expect(pattern.parts.partC.points.c1.x).to.equal(3)
+  expect(pattern.parts.partC.points.c1.y).to.equal(3)
+  expect(pattern.parts.partC.points.c2.x).to.equal(33)
+  expect(pattern.parts.partC.points.c2.y).to.equal(33)
+  expect(pattern.parts.partD.points.d1.x).to.equal(4)
+  expect(pattern.parts.partD.points.d1.y).to.equal(4)
+  expect(pattern.parts.partD.points.d2.x).to.equal(44)
+  expect(pattern.parts.partD.points.d2.y).to.equal(44)
+  // Paths in partA
+  expect(pattern.parts.partA.paths.a.ops[0].to.x).to.equal(1)
+  expect(pattern.parts.partA.paths.a.ops[0].to.y).to.equal(1)
+  expect(pattern.parts.partA.paths.a.ops[1].to.x).to.equal(11)
+  expect(pattern.parts.partA.paths.a.ops[1].to.y).to.equal(11)
+  // Paths in partB
+  expect(pattern.parts.partB.paths.a.ops[0].to.x).to.equal(1)
+  expect(pattern.parts.partB.paths.a.ops[0].to.y).to.equal(1)
+  expect(pattern.parts.partB.paths.a.ops[1].to.x).to.equal(11)
+  expect(pattern.parts.partB.paths.a.ops[1].to.y).to.equal(11)
+  expect(pattern.parts.partB.paths.b.ops[0].to.x).to.equal(2)
+  expect(pattern.parts.partB.paths.b.ops[0].to.y).to.equal(2)
+  expect(pattern.parts.partB.paths.b.ops[1].to.x).to.equal(22)
+  expect(pattern.parts.partB.paths.b.ops[1].to.y).to.equal(22)
+  // Paths in partC
+  expect(pattern.parts.partC.paths.a.ops[0].to.x).to.equal(1)
+  expect(pattern.parts.partC.paths.a.ops[0].to.y).to.equal(1)
+  expect(pattern.parts.partC.paths.a.ops[1].to.x).to.equal(11)
+  expect(pattern.parts.partC.paths.a.ops[1].to.y).to.equal(11)
+  expect(pattern.parts.partC.paths.b.ops[0].to.x).to.equal(2)
+  expect(pattern.parts.partC.paths.b.ops[0].to.y).to.equal(2)
+  expect(pattern.parts.partC.paths.b.ops[1].to.x).to.equal(22)
+  expect(pattern.parts.partC.paths.b.ops[1].to.y).to.equal(22)
+  expect(pattern.parts.partC.paths.c.ops[0].to.x).to.equal(3)
+  expect(pattern.parts.partC.paths.c.ops[0].to.y).to.equal(3)
+  expect(pattern.parts.partC.paths.c.ops[1].to.x).to.equal(33)
+  expect(pattern.parts.partC.paths.c.ops[1].to.y).to.equal(33)
+  // Paths in partR
+  expect(pattern.parts.partD.paths.d.ops[0].to.x).to.equal(4)
+  expect(pattern.parts.partD.paths.d.ops[0].to.y).to.equal(4)
+  expect(pattern.parts.partD.paths.d.ops[1].to.x).to.equal(44)
+  expect(pattern.parts.partD.paths.d.ops[1].to.y).to.equal(44)
 })


### PR DESCRIPTION
This is a work in progress to explore some of the ideas from #2538 in code.
I don't actually expect this to be merged, or at least not without some squashing/cherry picking later.
Please see this more as me trying to see what works and what doesn't. I'm just doing it in the open coz that's how we do.

**Progress**
- [x] ac9b616b99368b8b42087cc3db3a574382cc43a1 implements polymorphism in the `Design` constructor to accept the `legacy` way as well as the `2022` way of initializing a new Design. The `2022` way means that you pass only one object that holds all the data to create a new design. It also adds a new `warnings` key on the config that will be populated in case anything is amiss. This will allow us to raise these issues to the attention of the developer (in the development environment). For these early stage issues, we can't rely on the `Pattern.raise` methods since there is no instantiated pattern yet
- [x] 70bd946bdc82ced1815b645e0ed2da801d7d1d1f Adds the the ability to extend a part by importing only that part and then just saying you want a part `from` the imported one. The imported part comes with all options, it does not currently come with all measurements. This also *follows* dependencies. 
- [x] a1a3e1c1942a56175e00fc3c1a49b286ad92fe09 has some fixes for backwards compatibility
- [x] 6c3208768e767ba9b2eb00657445fa32a770df45 Adds support for pulling in part-level measurements and optional measurements
- [x] 689f908f68778f57d09ced1691637b021f7bd179 Adds support for adding parts at run-time