### PR TITLE
Fix Simon notch typos

### DIFF
--- a/markdown/org/docs/patterns/simon/instructions/en.md
+++ b/markdown/org/docs/patterns/simon/instructions/en.md
@@ -85,7 +85,7 @@ You can now put your cuffs aside, we'll attach them later.
 
 ![Sew collar and undercollar together](3a.png)
 
-Place both collar parts with the good sides together, and sew them together at the standard seam allowance.
+Place both collar parts with the _good sides together_, and sew them together at the standard seam allowance.
 
 #### Trim seam allowance
 

--- a/markdown/org/docs/patterns/simon/instructions/en.md
+++ b/markdown/org/docs/patterns/simon/instructions/en.md
@@ -85,7 +85,7 @@ You can now put your cuffs aside, we'll attach them later.
 
 ![Sew collar and undercollar together](3a.png)
 
-Place both collar parts together with the good sides, and sew them together at the standard seam allowance.
+Place both collar parts with the good sides together, and sew them together at the standard seam allowance.
 
 #### Trim seam allowance
 
@@ -461,9 +461,9 @@ Spread your shirt open so that both fronts and back lie flat with their good sid
 
 Now place your sleeve on top with the good side down, matching the top of the sleeve with the shoulder seam.
 
-> Be careful, your sleeve is not symmetric, so be sure to have the double notch (and cuff guard) on the back side, and the single notch on the front side.
+> Be careful, your sleeve is not symmetric, so be sure to have the ⊗ notch (and cuff guard) on the back side, and the ⊙ notch on the front side.
 >
-> Also note that the double notch on the back of your sleeve does not have a corresponding notch on the back. That's because it should match up with the seam where your yoke joins the back.
+> Also note that the ⊗ notch on the back of your sleeve does not have a corresponding notch on the back of the shirt. That's because it should match up with the seam where your yoke joins the back.
 
 You now need to pin the sleeve to the armhole. To do so, make sure to:
 
@@ -513,7 +513,7 @@ You can use pins to hold this in place, but it's simpler to just press it.
 
 Now, from the bad side of the fabric, sew the seam allowance down just at the edge where it folds under the other seam allowance.
 
-Important here is to keep an even distance from the seam of your sleeve. If you have a felling foot for your sewing machine, it will help you with that. But if not, just be careful.
+Here it is important to keep an even distance from the seam of your sleeve. If you have a felling foot for your sewing machine, it will help you with that. But if not, just be careful.
 
 > It is more important to keep and even distance from the sleeve seam than to sew exactly at the edge of the fold. Ideally, the fold sits at an even distance anyhow, but if it doesn't, just make sure to sew parallel to the sleeve seam. Even if that means you deviate a bit from the folded edge.
 

--- a/markdown/org/docs/patterns/simon/instructions/en.md
+++ b/markdown/org/docs/patterns/simon/instructions/en.md
@@ -461,9 +461,9 @@ Spread your shirt open so that both fronts and back lie flat with their good sid
 
 Now place your sleeve on top with the good side down, matching the top of the sleeve with the shoulder seam.
 
-> Be careful, your sleeve is not symmetric, so be sure to have the ⊗ notch (and cuff guard) on the back side, and the ⊙ notch on the front side.
+> Be careful, your sleeve is not symmetric, so be sure to have the back notch (⊗) and cuff guard on the back side, and the front notch (⊙) on the front side.
 >
-> Also note that the ⊗ notch on the back of your sleeve does not have a corresponding notch on the back of the shirt. That's because it should match up with the seam where your yoke joins the back.
+> Also note that the back notch (⊗) on the sleeve does not have a corresponding notch on the back of the shirt. That's because it should match up with the seam where your yoke joins the back.
 
 You now need to pin the sleeve to the armhole. To do so, make sure to:
 


### PR DESCRIPTION
I replaced "single" and "double" notch with the symbols for these notches (to reflect the with the pattern notation guide https://freesewing.org/docs/various/notation/notches/ ).
I also tweaked the word order of a couple of sentences for clarity.