### PR TITLE
Titan Notches for #2558

### DIFF
--- a/designs/charlie/config/index.js
+++ b/designs/charlie/config/index.js
@@ -91,6 +91,7 @@ export default {
     fitCrossSeam: true,
     fitCrossSeamFront: true,
     fitCrossSeamBack: true,
+    fitGuides: false,
     // Lock titan options
     fitKnee: true,
 

--- a/designs/paco/config/index.js
+++ b/designs/paco/config/index.js
@@ -76,6 +76,7 @@ export default {
     fitCrossSeam: true,
     fitCrossSeamFront: true,
     fitCrossSeamBack: true,
+    fitGuides: false,
     kneeEase: 0.06,
     fitKnee: false,
     frontPocketHeelRatio: 0.4,

--- a/designs/titan/config/index.js
+++ b/designs/titan/config/index.js
@@ -49,6 +49,7 @@ export default {
     fitCrossSeam: true,
     fitCrossSeamFront: true,
     fitCrossSeamBack: true,
+    fitGuides: true,
 
     // Fit
     waistEase: { pct: 2, min: 0, max: 10 },

--- a/designs/titan/config/index.js
+++ b/designs/titan/config/index.js
@@ -71,6 +71,6 @@ export default {
     crotchSeamCurveAngle: { deg: 25, min: 0, max: 35 },
     waistBalance: { pct: 60, min: 30, max: 90 },
     grainlinePosition: { pct: 45, min: 30, max: 60 },
-    waistbandWidth: { pct: 3, min: 1, max: 6, snap: elastics, ...pctBasedOn('waistToFloor') },
+    waistbandWidth: { pct: 3, min: 0, max: 6, snap: elastics, ...pctBasedOn('waistToFloor') },
   },
 }

--- a/designs/titan/config/index.js
+++ b/designs/titan/config/index.js
@@ -72,6 +72,6 @@ export default {
     crotchSeamCurveAngle: { deg: 25, min: 0, max: 35 },
     waistBalance: { pct: 60, min: 30, max: 90 },
     grainlinePosition: { pct: 45, min: 30, max: 60 },
-    waistbandWidth: { pct: 3, min: 0, max: 6, snap: elastics, ...pctBasedOn('waistToFloor') },
+    waistbandWidth: { pct: 3, min: 1, max: 6, snap: elastics, ...pctBasedOn('waistToFloor') },
   },
 }

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -221,7 +221,7 @@ export default (part) => {
       to: points.grainlineBottom,
     })
     macro('scalebox', { at: points.knee })
-    points.logoAnchor = new Point(points.crossSeamCurveStart.x / 2, points.crossSeamCurveStart.y)
+    points.logoAnchor = new Point(points.crossSeamCurveStart.x / 2, points.fork.y)
     snippets.logo = new Snippet('logo', points.logoAnchor)
     points.titleAnchor = points.logoAnchor.shift(-90, 60)
     macro('title', {

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -271,7 +271,7 @@ export default (part) => {
 	}
 	macro('sprinkle', {
 	snippet: 'notch',
-	on: ['kneeInNotch', 'kneeOutNotch', 'seatOutNotch']
+	on: ['seatOutNotch', 'kneeInNotch', 'kneeOutNotch']
 	})
 	macro('sprinkle', {
 	snippet: 'bnotch',

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -231,68 +231,68 @@ export default (part) => {
     })
 	//notches
   if (options.fitGuides) {
-	points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
-	points.seatMid = points.waistMid.shiftTowards(points.waistIn, measurements.waistToSeat).rotate(90, points.waistMid)
-	points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
-	points.seatOutTarget = points.seatMid.shiftTowards(points.seatOut, measurements.seat / 4)
-	points.hipsInTarget	 = points.waistIn.shiftTowards(points.waistOut, measurements.waistToHips).rotate(-90, points.waistIn)
-	points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(90, points.waistOut)
-	points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crossSeamCurveStart)
-	points.crossSeamCurveStartMid = utils.beamsIntersect(points.crossSeamCurveStart, points.crossSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1), points.waistMid, points.seatMid)
+  	points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
+	  points.seatMid = points.waistMid.shiftTowards(points.waistIn, measurements.waistToSeat).rotate(90, points.waistMid)
+	  points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
+	  points.seatOutTarget = points.seatMid.shiftTowards(points.seatOut, measurements.seat / 4)
+	  points.hipsInTarget	 = points.waistIn.shiftTowards(points.waistOut, measurements.waistToHips).rotate(-90, points.waistIn)
+	  points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(90, points.waistOut)
+	  points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crossSeamCurveStart)
+	  points.crossSeamCurveStartMid = utils.beamsIntersect(points.crossSeamCurveStart, points.crossSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1), points.waistMid, points.seatMid)
 	if (points.seatMid.y > points.crossSeamCurveStartMid.y){
-	points.seatIn = utils.lineIntersectsCurve(points.seatMid, points.seatInTarget, points.crossSeamCurveStart, points.crossSeamCurveCp1, points.crossSeamCurveCp2, points.fork)
+	  points.seatIn = utils.lineIntersectsCurve(points.seatMid, points.seatInTarget, points.crossSeamCurveStart, points.crossSeamCurveCp1, points.crossSeamCurveCp2, points.fork)
 	}
 	else {
-	points.seatIn = utils.beamsIntersect(points.seatMid, points.seatInTarget, points.waistIn, points.crossSeamCurveStart)
+	  points.seatIn = utils.beamsIntersect(points.seatMid, points.seatInTarget, points.waistIn, points.crossSeamCurveStart)
 	}
 	if (options.fitKnee) {
 	if (points.waistOut.x > points.seatOut.x) {
-	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.kneeOut, points.kneeOutCp2, points.seatOut, points.waistOut)
-	points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.kneeOut, points.kneeOutCp2, points.seatOut, points.waistOut)
+	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.kneeOut, points.kneeOutCp2, points.seatOut, points.waistOut)
+	  points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.kneeOut, points.kneeOutCp2, points.seatOut, points.waistOut)
 	}
 	else {
-	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.seatOut, points.seatOutCp2, points.waistOut, points.waistOut)
-	points.seatOutNotch = points.seatOut
+	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.seatOut, points.seatOutCp2, points.waistOut, points.waistOut)
+	  points.seatOutNotch = points.seatOut
 	}
-	points.kneeOutNotch = points.kneeOut
-	points.kneeInNotch = points.kneeIn
+	  points.kneeOutNotch = points.kneeOut
+	  points.kneeInNotch = points.kneeIn
 	}
 	else {
 	if (points.waistOut.x > points.seatOut.x) {
-	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
-	points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
-	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
+	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
+	  points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
+	  points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
 	}
 	else {
-	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.seatOut, points.seatOutCp2, points.waistOut, points.waistOut)
-	points.seatOutNotch = points.seatOut
-	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.floorOut, points.kneeOutCp2, points.seatOutCp1, points.seatOut)
+	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.seatOut, points.seatOutCp2, points.waistOut, points.waistOut)
+	  points.seatOutNotch = points.seatOut
+	  points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.floorOut, points.kneeOutCp2, points.seatOutCp1, points.seatOut)
 	}
-	points.kneeInNotch = utils.lineIntersectsCurve(points.kneeIn, points.kneeOut.rotate(180, points.kneeIn), points.fork, points.forkCp2, points.kneeInCp1, points.floorIn)
+	  points.kneeInNotch = utils.lineIntersectsCurve(points.kneeIn, points.kneeOut.rotate(180, points.kneeIn), points.fork, points.forkCp2, points.kneeInCp1, points.floorIn)
 	}
-	macro('sprinkle', {
-	snippet: 'notch',
-	on: ['seatOutNotch', 'kneeInNotch', 'kneeOutNotch']
-	})
-	macro('sprinkle', {
-	snippet: 'bnotch',
-	on: ['crossSeamCurveStart', 'seatIn']
-	})
-	paths.seatline = new Path()
-	.move(points.seatIn)
-	.line(points.seatOutNotch)
-	.attr('class', 'fabric help')
-	.attr('data-text', 'Seat Line')
-	.attr('data-text-class', 'center')
+	  macro('sprinkle', {
+	  snippet: 'notch',
+	  on: ['seatOutNotch', 'kneeInNotch', 'kneeOutNotch']
+	  })
+	  macro('sprinkle', {
+  	snippet: 'bnotch',
+	  on: ['crossSeamCurveStart', 'seatIn']
+	  })
+	  paths.seatline = new Path()
+	  .move(points.seatIn)
+	  .line(points.seatOutNotch)
+	  .attr('class', 'fabric help')
+	  .attr('data-text', 'Seat Line')
+	  .attr('data-text-class', 'center')
 	if (measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth < measurements.waistToHips){
-	snippets.hipsIn = new Snippet('bnotch', points.hipsIn)
-	snippets.hipsOut = new Snippet('notch', points.hipsOut)
-	paths.hipline = new Path()
-	.move(points.hipsIn)
-	.line(points.hipsOut)
-	.attr('class', 'fabric help')
-	.attr('data-text', 'Hip Line')
-	.attr('data-text-class', 'center')
+	  snippets.hipsIn = new Snippet('bnotch', points.hipsIn)
+	  snippets.hipsOut = new Snippet('notch', points.hipsOut)
+	  paths.hipline = new Path()
+	  .move(points.hipsIn)
+	  .line(points.hipsOut)
+	  .attr('class', 'fabric help')
+	  .attr('data-text', 'Hip Line')
+	  .attr('data-text-class', 'center')
 	}
 }
     if (sa) {

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -230,6 +230,7 @@ export default (part) => {
       at: points.titleAnchor,
     })
 	//notches
+  if (options.fitGuides) {
 	points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
 	points.seatMid = points.waistMid.shiftTowards(points.waistIn, measurements.waistToSeat).rotate(90, points.waistMid)
 	points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
@@ -293,6 +294,7 @@ export default (part) => {
 	.attr('data-text', 'Hip Line')
 	.attr('data-text-class', 'center')
 	}
+}
     if (sa) {
       paths.saBase = drawOutseam()
         .join(

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -238,7 +238,7 @@ export default (part) => {
 	points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(90, points.waistOut)
 	points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crossSeamCurveStart)
 	points.crossSeamCurveStartMid = utils.beamsIntersect(points.crossSeamCurveStart, points.crossSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1), points.waistMid, points.seatMid)
-	if (points.seatMid.y < points.crossSeamCurveStartMid){
+	if (points.seatMid.y > points.crossSeamCurveStartMid.y){
 	points.seatIn = utils.lineIntersectsCurve(points.seatMid, points.seatInTarget, points.crossSeamCurveStart, points.crossSeamCurveCp1, points.crossSeamCurveCp2, points.fork)
 	}
 	else {

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -279,7 +279,7 @@ export default (part) => {
 	})
 	paths.seatline = new Path()
 	.move(points.seatIn)
-	.line(points.seatOut)
+	.line(points.seatOutNotch)
 	.attr('class', 'fabric help')
 	.attr('data-text', 'Seat Line')
 	.attr('data-text-class', 'center')

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -229,7 +229,49 @@ export default (part) => {
       title: 'back',
       at: points.titleAnchor,
     })
-
+	//notches
+	points.hipsInTarget	 = points.waistIn.shiftTowards(points.waistOut, measurements.waistToHips).rotate(-90, points.waistIn)
+	points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(90, points.waistOut)
+	points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crossSeamCurveStart)
+	if (options.fitKnee) {
+	if (points.waistOut.x > points.seatOut.x) {
+	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.kneeOut, points.kneeOutCp2, points.seatOut, points.waistOut)
+	}
+	else {
+	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.seatOut, points.seatOutCp2, points.waistOut, points.waistOut)
+	}
+	points.kneeOutNotch = points.kneeOut
+	points.kneeInNotch = points.kneeIn
+	}
+	else {
+	if (points.waistOut.x > points.seatOut.x) {
+	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
+	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
+	}
+	else {
+	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.seatOut, points.seatOutCp2, points.waistOut, points.waistOut)
+	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.floorOut, points.kneeOutCp2, points.seatOutCp1, points.seatOut)
+	}
+	points.kneeInNotch = utils.lineIntersectsCurve(points.kneeIn, points.kneeOut.rotate(180, points.kneeIn), points.fork, points.forkCp2, points.kneeInCp1, points.floorIn)
+	}
+	macro('sprinkle', {
+	snippet: 'notch',
+	on: ['kneeInNotch', 'kneeOutNotch']
+	})
+	macro('sprinkle', {
+	snippet: 'bnotch',
+	on: ['crossSeamCurveStart',]
+	})
+	if (measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth < measurements.waistToHips){
+	snippets.hipsIn = new Snippet('bnotch', points.hipsIn)
+	snippets.hipsOut = new Snippet('notch', points.hipsOut)
+	paths.hipline = new Path()
+	.move(points.hipsIn)
+	.line(points.hipsOut)
+	.attr('class', 'fabric help')
+	.attr('data-text', 'Hip Line')
+	.attr('data-text-class', 'center')
+	}
     if (sa) {
       paths.saBase = drawOutseam()
         .join(

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -229,72 +229,162 @@ export default (part) => {
       title: 'back',
       at: points.titleAnchor,
     })
-	//notches
-  if (options.fitGuides) {
-  	points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
-	  points.seatMid = points.waistMid.shiftTowards(points.waistIn, measurements.waistToSeat).rotate(90, points.waistMid)
-	  points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
-	  points.seatOutTarget = points.seatMid.shiftTowards(points.seatOut, measurements.seat / 4)
-	  points.hipsInTarget	 = points.waistIn.shiftTowards(points.waistOut, measurements.waistToHips).rotate(-90, points.waistIn)
-	  points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(90, points.waistOut)
-	  points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crossSeamCurveStart)
-	  points.crossSeamCurveStartMid = utils.beamsIntersect(points.crossSeamCurveStart, points.crossSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1), points.waistMid, points.seatMid)
-	if (points.seatMid.y > points.crossSeamCurveStartMid.y){
-	  points.seatIn = utils.lineIntersectsCurve(points.seatMid, points.seatInTarget, points.crossSeamCurveStart, points.crossSeamCurveCp1, points.crossSeamCurveCp2, points.fork)
-	}
-	else {
-	  points.seatIn = utils.beamsIntersect(points.seatMid, points.seatInTarget, points.waistIn, points.crossSeamCurveStart)
-	}
-	if (options.fitKnee) {
-	if (points.waistOut.x > points.seatOut.x) {
-	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.kneeOut, points.kneeOutCp2, points.seatOut, points.waistOut)
-	  points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.kneeOut, points.kneeOutCp2, points.seatOut, points.waistOut)
-	}
-	else {
-	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.seatOut, points.seatOutCp2, points.waistOut, points.waistOut)
-	  points.seatOutNotch = points.seatOut
-	}
-	  points.kneeOutNotch = points.kneeOut
-	  points.kneeInNotch = points.kneeIn
-	}
-	else {
-	if (points.waistOut.x > points.seatOut.x) {
-	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
-	  points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
-	  points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.floorOut, points.kneeOutCp2, points.seatOut, points.waistOut)
-	}
-	else {
-	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.seatOut, points.seatOutCp2, points.waistOut, points.waistOut)
-	  points.seatOutNotch = points.seatOut
-	  points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.floorOut, points.kneeOutCp2, points.seatOutCp1, points.seatOut)
-	}
-	  points.kneeInNotch = utils.lineIntersectsCurve(points.kneeIn, points.kneeOut.rotate(180, points.kneeIn), points.fork, points.forkCp2, points.kneeInCp1, points.floorIn)
-	}
-	  macro('sprinkle', {
-	  snippet: 'notch',
-	  on: ['seatOutNotch', 'kneeInNotch', 'kneeOutNotch']
-	  })
-	  macro('sprinkle', {
-  	snippet: 'bnotch',
-	  on: ['crossSeamCurveStart', 'seatIn']
-	  })
-	  paths.seatline = new Path()
-	  .move(points.seatIn)
-	  .line(points.seatOutNotch)
-	  .attr('class', 'fabric help')
-	  .attr('data-text', 'Seat Line')
-	  .attr('data-text-class', 'center')
-	if (measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth < measurements.waistToHips){
-	  snippets.hipsIn = new Snippet('bnotch', points.hipsIn)
-	  snippets.hipsOut = new Snippet('notch', points.hipsOut)
-	  paths.hipline = new Path()
-	  .move(points.hipsIn)
-	  .line(points.hipsOut)
-	  .attr('class', 'fabric help')
-	  .attr('data-text', 'Hip Line')
-	  .attr('data-text-class', 'center')
-	}
-}
+    //notches
+    if (options.fitGuides) {
+      points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
+      points.seatMid = points.waistMid
+        .shiftTowards(points.waistIn, measurements.waistToSeat)
+        .rotate(90, points.waistMid)
+      points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
+      points.seatOutTarget = points.seatMid.shiftTowards(points.seatOut, measurements.seat / 4)
+      points.hipsInTarget = points.waistIn
+        .shiftTowards(points.waistOut, measurements.waistToHips)
+        .rotate(-90, points.waistIn)
+      points.hipsOutTarget = points.waistOut
+        .shiftTowards(points.waistIn, measurements.waistToHips)
+        .rotate(90, points.waistOut)
+      points.hipsIn = utils.beamsIntersect(
+        points.hipsOutTarget,
+        points.hipsInTarget,
+        points.waistIn,
+        points.crossSeamCurveStart
+      )
+      points.crossSeamCurveStartMid = utils.beamsIntersect(
+        points.crossSeamCurveStart,
+        points.crossSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1),
+        points.waistMid,
+        points.seatMid
+      )
+      if (points.seatMid.y > points.crossSeamCurveStartMid.y) {
+        points.seatIn = utils.lineIntersectsCurve(
+          points.seatMid,
+          points.seatInTarget,
+          points.crossSeamCurveStart,
+          points.crossSeamCurveCp1,
+          points.crossSeamCurveCp2,
+          points.fork
+        )
+      } else {
+        points.seatIn = utils.beamsIntersect(
+          points.seatMid,
+          points.seatInTarget,
+          points.waistIn,
+          points.crossSeamCurveStart
+        )
+      }
+      if (options.fitKnee) {
+        if (points.waistOut.x > points.seatOut.x) {
+          points.hipsOut = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.kneeOut,
+            points.kneeOutCp2,
+            points.seatOut,
+            points.waistOut
+          )
+          points.seatOutNotch = utils.lineIntersectsCurve(
+            points.seatMid,
+            points.seatOutTarget,
+            points.kneeOut,
+            points.kneeOutCp2,
+            points.seatOut,
+            points.waistOut
+          )
+        } else {
+          points.hipsOut = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.seatOut,
+            points.seatOutCp2,
+            points.waistOut,
+            points.waistOut
+          )
+          points.seatOutNotch = points.seatOut
+        }
+        points.kneeOutNotch = points.kneeOut
+        points.kneeInNotch = points.kneeIn
+      } else {
+        if (points.waistOut.x > points.seatOut.x) {
+          points.hipsOut = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.floorOut,
+            points.kneeOutCp2,
+            points.seatOut,
+            points.waistOut
+          )
+          points.seatOutNotch = utils.lineIntersectsCurve(
+            points.seatMid,
+            points.seatOutTarget,
+            points.floorOut,
+            points.kneeOutCp2,
+            points.seatOut,
+            points.waistOut
+          )
+          points.kneeOutNotch = utils.lineIntersectsCurve(
+            points.kneeOut,
+            points.kneeIn.rotate(180, points.kneeOut),
+            points.floorOut,
+            points.kneeOutCp2,
+            points.seatOut,
+            points.waistOut
+          )
+        } else {
+          points.hipsOut = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.seatOut,
+            points.seatOutCp2,
+            points.waistOut,
+            points.waistOut
+          )
+          points.seatOutNotch = points.seatOut
+          points.kneeOutNotch = utils.lineIntersectsCurve(
+            points.kneeOut,
+            points.kneeIn.rotate(180, points.kneeOut),
+            points.floorOut,
+            points.kneeOutCp2,
+            points.seatOutCp1,
+            points.seatOut
+          )
+        }
+        points.kneeInNotch = utils.lineIntersectsCurve(
+          points.kneeIn,
+          points.kneeOut.rotate(180, points.kneeIn),
+          points.fork,
+          points.forkCp2,
+          points.kneeInCp1,
+          points.floorIn
+        )
+      }
+      macro('sprinkle', {
+        snippet: 'notch',
+        on: ['seatOutNotch', 'kneeInNotch', 'kneeOutNotch'],
+      })
+      macro('sprinkle', {
+        snippet: 'bnotch',
+        on: ['crossSeamCurveStart', 'seatIn'],
+      })
+      paths.seatline = new Path()
+        .move(points.seatIn)
+        .line(points.seatOutNotch)
+        .attr('class', 'fabric help')
+        .attr('data-text', 'Seat Line')
+        .attr('data-text-class', 'center')
+      if (
+        measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth <
+        measurements.waistToHips
+      ) {
+        snippets.hipsIn = new Snippet('bnotch', points.hipsIn)
+        snippets.hipsOut = new Snippet('notch', points.hipsOut)
+        paths.hipline = new Path()
+          .move(points.hipsIn)
+          .line(points.hipsOut)
+          .attr('class', 'fabric help')
+          .attr('data-text', 'Hip Line')
+          .attr('data-text-class', 'center')
+      }
+    }
     if (sa) {
       paths.saBase = drawOutseam()
         .join(

--- a/designs/titan/src/front.js
+++ b/designs/titan/src/front.js
@@ -348,7 +348,7 @@ export default (part) => {
 	on: ['crotchSeamCurveStart', 'seatIn', 'seatOutNotch', 'kneeInNotch', 'kneeOutNotch']
 	})
 	paths.seatline = new Path()
-	.move(points.seatOut)
+	.move(points.seatOutNotch)
 	.line(points.seatIn)
 	.attr('class', 'fabric help')
 	.attr('data-text', 'Seat Line')

--- a/designs/titan/src/front.js
+++ b/designs/titan/src/front.js
@@ -303,16 +303,29 @@ export default (part) => {
       title: 'front',
       at: points.titleAnchor,
     })
-	//notches
+  //notches
+	points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
+	points.seatMid = points.waistMid.shiftTowards(points.waistOut, measurements.waistToSeat).rotate(90, points.waistMid)
+	points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
+	points.seatOutTarget = points.seatMid.shiftTowards(points.seatOut, measurements.seat / 4)
 	points.hipsInTarget	 = points.waistIn.shiftTowards(points.waistOut, measurements.waistToHips).rotate(90, points.waistIn)
 	points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(-90, points.waistOut)
 	points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crotchSeamCurveStart)
+	points.crotchSeamCurveStartMid = utils.beamsIntersect(points.crotchSeamCurveStart, points.crotchSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1), points.waistMid, points.seatMid)
+	if (points.seatMid.y > points.crotchSeamCurveStartMid.y){
+	points.seatIn = utils.lineIntersectsCurve(points.seatMid, points.seatInTarget, points.fork, points.crotchSeamCurveCp1, points.crotchSeamCurveCp2, points.crotchSeamCurveStart)
+	}
+	else {
+	points.seatIn = utils.beamsIntersect(points.seatMid, points.seatInTarget, points.crotchSeamCurveStart, points.waistIn)
+	}
 	if (options.fitKnee) {
 	if (points.waistOut.x < points.seatOut.x) {
 	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
+	points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
 	}
 	else {
 	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
+	points.seatOutNotch = points.seatOut
 	}
 	points.kneeOutNotch = points.kneeOut
 	points.kneeInNotch = points.kneeIn
@@ -320,18 +333,26 @@ export default (part) => {
 	else {
 	if (points.waistOut.x < points.seatOut.x) {
 	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
+	points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
 	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
 	}
 	else {
 	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
+	points.seatOutNotch = points.seatOut
 	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.seatOut, points.seatOutCp2, points.kneeOutCp1, points.floorOut)
 	}
 	points.kneeInNotch = utils.lineIntersectsCurve(points.kneeIn, points.kneeOut.rotate(180, points.kneeIn), points.floorIn, points.kneeInCp2, points.forkCp1, points.fork)
 	}
 	macro('sprinkle', {
 	snippet: 'notch',
-	on: ['crotchSeamCurveStart', 'kneeInNotch', 'kneeOutNotch']
+	on: ['crotchSeamCurveStart', 'seatIn', 'seatOutNotch', 'kneeInNotch', 'kneeOutNotch']
 	})
+	paths.seatline = new Path()
+	.move(points.seatOut)
+	.line(points.seatIn)
+	.attr('class', 'fabric help')
+	.attr('data-text', 'Seat Line')
+	.attr('data-text-class', 'center')
 	if (measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth < measurements.waistToHips){
 	macro('sprinkle', {
 	snippet: 'notch',

--- a/designs/titan/src/front.js
+++ b/designs/titan/src/front.js
@@ -305,66 +305,66 @@ export default (part) => {
     })
   //notches
   if (options.fitGuides) {
-	points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
-	points.seatMid = points.waistMid.shiftTowards(points.waistOut, measurements.waistToSeat).rotate(90, points.waistMid)
-	points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
-	points.seatOutTarget = points.seatMid.shiftTowards(points.seatOut, measurements.seat / 4)
-	points.hipsInTarget	 = points.waistIn.shiftTowards(points.waistOut, measurements.waistToHips).rotate(90, points.waistIn)
-	points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(-90, points.waistOut)
-	points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crotchSeamCurveStart)
-	points.crotchSeamCurveStartMid = utils.beamsIntersect(points.crotchSeamCurveStart, points.crotchSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1), points.waistMid, points.seatMid)
+  	points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
+  	points.seatMid = points.waistMid.shiftTowards(points.waistOut, measurements.waistToSeat).rotate(90, points.waistMid)
+  	points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
+  	points.seatOutTarget = points.seatMid.shiftTowards(points.seatOut, measurements.seat / 4)
+  	points.hipsInTarget	 = points.waistIn.shiftTowards(points.waistOut, measurements.waistToHips).rotate(90, points.waistIn)
+  	points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(-90, points.waistOut)
+  	points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crotchSeamCurveStart)
+  	points.crotchSeamCurveStartMid = utils.beamsIntersect(points.crotchSeamCurveStart, points.crotchSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1), points.waistMid, points.seatMid)
 	if (points.seatMid.y > points.crotchSeamCurveStartMid.y){
-	points.seatIn = utils.lineIntersectsCurve(points.seatMid, points.seatInTarget, points.fork, points.crotchSeamCurveCp1, points.crotchSeamCurveCp2, points.crotchSeamCurveStart)
+  	points.seatIn = utils.lineIntersectsCurve(points.seatMid, points.seatInTarget, points.fork, points.crotchSeamCurveCp1, points.crotchSeamCurveCp2, points.crotchSeamCurveStart)
 	}
 	else {
-	points.seatIn = utils.beamsIntersect(points.seatMid, points.seatInTarget, points.crotchSeamCurveStart, points.waistIn)
+  	points.seatIn = utils.beamsIntersect(points.seatMid, points.seatInTarget, points.crotchSeamCurveStart, points.waistIn)
 	}
 	if (options.fitKnee) {
 	if (points.waistOut.x < points.seatOut.x) {
-	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
-	points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
+  	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
+  	points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
 	}
 	else {
-	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
-	points.seatOutNotch = points.seatOut
+	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
+  	points.seatOutNotch = points.seatOut
 	}
-	points.kneeOutNotch = points.kneeOut
-	points.kneeInNotch = points.kneeIn
+	  points.kneeOutNotch = points.kneeOut
+	  points.kneeInNotch = points.kneeIn
 	}
 	else {
 	if (points.waistOut.x < points.seatOut.x) {
-	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
-	points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
-	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
+	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
+	  points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
+	  points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
 	}
 	else {
-	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
-	points.seatOutNotch = points.seatOut
-	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.seatOut, points.seatOutCp2, points.kneeOutCp1, points.floorOut)
+	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
+	  points.seatOutNotch = points.seatOut
+	  points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.seatOut, points.seatOutCp2, points.kneeOutCp1, points.floorOut)
 	}
-	points.kneeInNotch = utils.lineIntersectsCurve(points.kneeIn, points.kneeOut.rotate(180, points.kneeIn), points.floorIn, points.kneeInCp2, points.forkCp1, points.fork)
+	  points.kneeInNotch = utils.lineIntersectsCurve(points.kneeIn, points.kneeOut.rotate(180, points.kneeIn), points.floorIn, points.kneeInCp2, points.forkCp1, points.fork)
 	}
-	macro('sprinkle', {
-	snippet: 'notch',
-	on: ['crotchSeamCurveStart', 'seatIn', 'seatOutNotch', 'kneeInNotch', 'kneeOutNotch']
-	})
-	paths.seatline = new Path()
-	.move(points.seatOutNotch)
-	.line(points.seatIn)
-	.attr('class', 'fabric help')
-	.attr('data-text', 'Seat Line')
-	.attr('data-text-class', 'center')
+	  macro('sprinkle', {
+	  snippet: 'notch',
+	  on: ['crotchSeamCurveStart', 'seatIn', 'seatOutNotch', 'kneeInNotch', 'kneeOutNotch']
+	  })
+	  paths.seatline = new Path()
+	  .move(points.seatOutNotch)
+	  .line(points.seatIn)
+	  .attr('class', 'fabric help')
+	  .attr('data-text', 'Seat Line')
+	  .attr('data-text-class', 'center')
 	if (measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth < measurements.waistToHips){
-	macro('sprinkle', {
-	snippet: 'notch',
-	on: ['hipsIn', 'hipsOut',]
-	})
-	paths.hipline = new Path()
-	.move(points.hipsOut)
-	.line(points.hipsIn)
-	.attr('class', 'fabric help')
-	.attr('data-text', 'Hip Line')
-	.attr('data-text-class', 'center')
+	  macro('sprinkle', {
+	  snippet: 'notch',
+	  on: ['hipsIn', 'hipsOut',]
+	  })
+	  paths.hipline = new Path()
+	  .move(points.hipsOut)
+	  .line(points.hipsIn)
+	  .attr('class', 'fabric help')
+	  .attr('data-text', 'Hip Line')
+	  .attr('data-text-class', 'center')
 	}
 }
     if (sa) {

--- a/designs/titan/src/front.js
+++ b/designs/titan/src/front.js
@@ -304,6 +304,7 @@ export default (part) => {
       at: points.titleAnchor,
     })
   //notches
+  if (options.fitGuides) {
 	points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
 	points.seatMid = points.waistMid.shiftTowards(points.waistOut, measurements.waistToSeat).rotate(90, points.waistMid)
 	points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
@@ -365,6 +366,7 @@ export default (part) => {
 	.attr('data-text', 'Hip Line')
 	.attr('data-text-class', 'center')
 	}
+}
     if (sa) {
       paths.saBase = drawInseam()
         .join(

--- a/designs/titan/src/front.js
+++ b/designs/titan/src/front.js
@@ -308,7 +308,7 @@ export default (part) => {
 	points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(-90, points.waistOut)
 	points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crotchSeamCurveStart)
 	if (options.fitKnee) {
-	if (points.waistOut.x > points.seatOut.x) {
+	if (points.waistOut.x < points.seatOut.x) {
 	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
 	}
 	else {
@@ -318,7 +318,7 @@ export default (part) => {
 	points.kneeInNotch = points.kneeIn
 	}
 	else {
-	if (points.waistOut.x > points.seatOut.x) {
+	if (points.waistOut.x < points.seatOut.x) {
 	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
 	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
 	}

--- a/designs/titan/src/front.js
+++ b/designs/titan/src/front.js
@@ -295,7 +295,7 @@ export default (part) => {
       from: points.grainlineTop,
       to: points.grainlineBottom,
     })
-    points.logoAnchor = new Point(points.crotchSeamCurveStart.x / 2, points.crotchSeamCurveStart.y)
+    points.logoAnchor = new Point(points.crotchSeamCurveStart.x / 2, points.fork.y)
     snippets.logo = new Snippet('logo', points.logoAnchor)
     points.titleAnchor = points.logoAnchor.shift(-90, 60)
     macro('title', {

--- a/designs/titan/src/front.js
+++ b/designs/titan/src/front.js
@@ -303,70 +303,160 @@ export default (part) => {
       title: 'front',
       at: points.titleAnchor,
     })
-  //notches
-  if (options.fitGuides) {
-  	points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
-  	points.seatMid = points.waistMid.shiftTowards(points.waistOut, measurements.waistToSeat).rotate(90, points.waistMid)
-  	points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
-  	points.seatOutTarget = points.seatMid.shiftTowards(points.seatOut, measurements.seat / 4)
-  	points.hipsInTarget	 = points.waistIn.shiftTowards(points.waistOut, measurements.waistToHips).rotate(90, points.waistIn)
-  	points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(-90, points.waistOut)
-  	points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crotchSeamCurveStart)
-  	points.crotchSeamCurveStartMid = utils.beamsIntersect(points.crotchSeamCurveStart, points.crotchSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1), points.waistMid, points.seatMid)
-	if (points.seatMid.y > points.crotchSeamCurveStartMid.y){
-  	points.seatIn = utils.lineIntersectsCurve(points.seatMid, points.seatInTarget, points.fork, points.crotchSeamCurveCp1, points.crotchSeamCurveCp2, points.crotchSeamCurveStart)
-	}
-	else {
-  	points.seatIn = utils.beamsIntersect(points.seatMid, points.seatInTarget, points.crotchSeamCurveStart, points.waistIn)
-	}
-	if (options.fitKnee) {
-	if (points.waistOut.x < points.seatOut.x) {
-  	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
-  	points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
-	}
-	else {
-	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
-  	points.seatOutNotch = points.seatOut
-	}
-	  points.kneeOutNotch = points.kneeOut
-	  points.kneeInNotch = points.kneeIn
-	}
-	else {
-	if (points.waistOut.x < points.seatOut.x) {
-	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
-	  points.seatOutNotch = utils.lineIntersectsCurve(points.seatMid, points.seatOutTarget, points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
-	  points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
-	}
-	else {
-	  points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
-	  points.seatOutNotch = points.seatOut
-	  points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.seatOut, points.seatOutCp2, points.kneeOutCp1, points.floorOut)
-	}
-	  points.kneeInNotch = utils.lineIntersectsCurve(points.kneeIn, points.kneeOut.rotate(180, points.kneeIn), points.floorIn, points.kneeInCp2, points.forkCp1, points.fork)
-	}
-	  macro('sprinkle', {
-	  snippet: 'notch',
-	  on: ['crotchSeamCurveStart', 'seatIn', 'seatOutNotch', 'kneeInNotch', 'kneeOutNotch']
-	  })
-	  paths.seatline = new Path()
-	  .move(points.seatOutNotch)
-	  .line(points.seatIn)
-	  .attr('class', 'fabric help')
-	  .attr('data-text', 'Seat Line')
-	  .attr('data-text-class', 'center')
-	if (measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth < measurements.waistToHips){
-	  macro('sprinkle', {
-	  snippet: 'notch',
-	  on: ['hipsIn', 'hipsOut',]
-	  })
-	  paths.hipline = new Path()
-	  .move(points.hipsOut)
-	  .line(points.hipsIn)
-	  .attr('class', 'fabric help')
-	  .attr('data-text', 'Hip Line')
-	  .attr('data-text-class', 'center')
-	}
-}
+    //notches
+    if (options.fitGuides) {
+      points.waistMid = points.waistOut.shiftFractionTowards(points.waistIn, 0.5)
+      points.seatMid = points.waistMid
+        .shiftTowards(points.waistOut, measurements.waistToSeat)
+        .rotate(90, points.waistMid)
+      points.seatInTarget = points.seatOut.shiftOutwards(points.seatMid, measurements.seat / 4)
+      points.seatOutTarget = points.seatMid.shiftTowards(points.seatOut, measurements.seat / 4)
+      points.hipsInTarget = points.waistIn
+        .shiftTowards(points.waistOut, measurements.waistToHips)
+        .rotate(90, points.waistIn)
+      points.hipsOutTarget = points.waistOut
+        .shiftTowards(points.waistIn, measurements.waistToHips)
+        .rotate(-90, points.waistOut)
+      points.hipsIn = utils.beamsIntersect(
+        points.hipsOutTarget,
+        points.hipsInTarget,
+        points.waistIn,
+        points.crotchSeamCurveStart
+      )
+      points.crotchSeamCurveStartMid = utils.beamsIntersect(
+        points.crotchSeamCurveStart,
+        points.crotchSeamCurveStart.shift(points.waistIn.angle(points.waistOut), 1),
+        points.waistMid,
+        points.seatMid
+      )
+      if (points.seatMid.y > points.crotchSeamCurveStartMid.y) {
+        points.seatIn = utils.lineIntersectsCurve(
+          points.seatMid,
+          points.seatInTarget,
+          points.fork,
+          points.crotchSeamCurveCp1,
+          points.crotchSeamCurveCp2,
+          points.crotchSeamCurveStart
+        )
+      } else {
+        points.seatIn = utils.beamsIntersect(
+          points.seatMid,
+          points.seatInTarget,
+          points.crotchSeamCurveStart,
+          points.waistIn
+        )
+      }
+      if (options.fitKnee) {
+        if (points.waistOut.x < points.seatOut.x) {
+          points.hipsOut = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.waistOut,
+            points.seatOut,
+            points.kneeOutCp1,
+            points.kneeOut
+          )
+          points.seatOutNotch = utils.lineIntersectsCurve(
+            points.seatMid,
+            points.seatOutTarget,
+            points.waistOut,
+            points.seatOut,
+            points.kneeOutCp1,
+            points.kneeOut
+          )
+        } else {
+          points.hipsOut = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.waistOut,
+            points.waistOut,
+            points.seatOutCp1,
+            points.seatOut
+          )
+          points.seatOutNotch = points.seatOut
+        }
+        points.kneeOutNotch = points.kneeOut
+        points.kneeInNotch = points.kneeIn
+      } else {
+        if (points.waistOut.x < points.seatOut.x) {
+          points.hipsOut = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.waistOut,
+            points.seatOut,
+            points.kneeOutCp1,
+            points.floorOut
+          )
+          points.seatOutNotch = utils.lineIntersectsCurve(
+            points.seatMid,
+            points.seatOutTarget,
+            points.waistOut,
+            points.seatOut,
+            points.kneeOutCp1,
+            points.floorOut
+          )
+          points.kneeOutNotch = utils.lineIntersectsCurve(
+            points.kneeOut,
+            points.kneeIn.rotate(180, points.kneeOut),
+            points.waistOut,
+            points.seatOut,
+            points.kneeOutCp1,
+            points.floorOut
+          )
+        } else {
+          points.hipsOut = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.waistOut,
+            points.waistOut,
+            points.seatOutCp1,
+            points.seatOut
+          )
+          points.seatOutNotch = points.seatOut
+          points.kneeOutNotch = utils.lineIntersectsCurve(
+            points.kneeOut,
+            points.kneeIn.rotate(180, points.kneeOut),
+            points.seatOut,
+            points.seatOutCp2,
+            points.kneeOutCp1,
+            points.floorOut
+          )
+        }
+        points.kneeInNotch = utils.lineIntersectsCurve(
+          points.kneeIn,
+          points.kneeOut.rotate(180, points.kneeIn),
+          points.floorIn,
+          points.kneeInCp2,
+          points.forkCp1,
+          points.fork
+        )
+      }
+      macro('sprinkle', {
+        snippet: 'notch',
+        on: ['crotchSeamCurveStart', 'seatIn', 'seatOutNotch', 'kneeInNotch', 'kneeOutNotch'],
+      })
+      paths.seatline = new Path()
+        .move(points.seatOutNotch)
+        .line(points.seatIn)
+        .attr('class', 'fabric help')
+        .attr('data-text', 'Seat Line')
+        .attr('data-text-class', 'center')
+      if (
+        measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth <
+        measurements.waistToHips
+      ) {
+        macro('sprinkle', {
+          snippet: 'notch',
+          on: ['hipsIn', 'hipsOut'],
+        })
+        paths.hipline = new Path()
+          .move(points.hipsOut)
+          .line(points.hipsIn)
+          .attr('class', 'fabric help')
+          .attr('data-text', 'Hip Line')
+          .attr('data-text-class', 'center')
+      }
+    }
     if (sa) {
       paths.saBase = drawInseam()
         .join(

--- a/designs/titan/src/front.js
+++ b/designs/titan/src/front.js
@@ -303,7 +303,47 @@ export default (part) => {
       title: 'front',
       at: points.titleAnchor,
     })
-
+	//notches
+	points.hipsInTarget	 = points.waistIn.shiftTowards(points.waistOut, measurements.waistToHips).rotate(90, points.waistIn)
+	points.hipsOutTarget = points.waistOut.shiftTowards(points.waistIn, measurements.waistToHips).rotate(-90, points.waistOut)
+	points.hipsIn = utils.beamsIntersect(points.hipsOutTarget, points.hipsInTarget, points.waistIn, points.crotchSeamCurveStart)
+	if (options.fitKnee) {
+	if (points.waistOut.x > points.seatOut.x) {
+	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.kneeOut)
+	}
+	else {
+	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
+	}
+	points.kneeOutNotch = points.kneeOut
+	points.kneeInNotch = points.kneeIn
+	}
+	else {
+	if (points.waistOut.x > points.seatOut.x) {
+	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
+	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.waistOut, points.seatOut, points.kneeOutCp1, points.floorOut)
+	}
+	else {
+	points.hipsOut = utils.lineIntersectsCurve(points.hipsOutTarget, points.hipsIn.rotate(180, points.hipsOutTarget), points.waistOut, points.waistOut, points.seatOutCp1, points.seatOut)
+	points.kneeOutNotch = utils.lineIntersectsCurve(points.kneeOut, points.kneeIn.rotate(180, points.kneeOut), points.seatOut, points.seatOutCp2, points.kneeOutCp1, points.floorOut)
+	}
+	points.kneeInNotch = utils.lineIntersectsCurve(points.kneeIn, points.kneeOut.rotate(180, points.kneeIn), points.floorIn, points.kneeInCp2, points.forkCp1, points.fork)
+	}
+	macro('sprinkle', {
+	snippet: 'notch',
+	on: ['crotchSeamCurveStart', 'kneeInNotch', 'kneeOutNotch']
+	})
+	if (measurements.waistToHips * (1 - options.waistHeight) + absoluteOptions.waistbandWidth < measurements.waistToHips){
+	macro('sprinkle', {
+	snippet: 'notch',
+	on: ['hipsIn', 'hipsOut',]
+	})
+	paths.hipline = new Path()
+	.move(points.hipsOut)
+	.line(points.hipsIn)
+	.attr('class', 'fabric help')
+	.attr('data-text', 'Hip Line')
+	.attr('data-text-class', 'center')
+	}
     if (sa) {
       paths.saBase = drawInseam()
         .join(


### PR DESCRIPTION
As mentioned in #2558 this update adds the following notches.

- Cross and Crotch Seam notches
- Hip notches (when the rise is high enough)
- Seat Notches
- Knee notches

Changed logoAnchor.y to fork.y to minimise overlap of new paths.

Another thing I added was Hip Line and Seat Line paths to better identify where the hip line is with the notches.

I have also changed the waistbandWidth option to allow 0%, whilst the waistband being included is awesome for extending it is not the best for those who are using Titan as a physical block or for those who are testing Titan to check their measures.
Whilst not strictly necessary for extending Titan as some of these notches may be in a different place when extended, it will benefit those who are using Titan as it is described in its instructions. 

This has made me think about another possible addition to Titan which will benefit those extending it so may be another update soon. 

Added options.fitGuides so it does not display on Charlie and Paco.

Edit: Added seat notches.
Edit2: Added fitGuides