### PR TITLE
move kickstart out of gitpod prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,8 +9,7 @@ tasks:
     before: |
       nvm install lts/fermium
       nvm use lts/fermium
-    init: yarn kickstart
-    command: yarn lab
+    command: yarn kickstart && yarn lab
 
 github:
   prebuilds:


### PR DESCRIPTION
This improves prebuild times for PRs, and it should also mean that we less frequently have to tell people "just shut down and re-open your workspace". As far as I can tell, it has no adverse effects.