### PR TITLE
fix: Broken/misleading links to designs' source code

### DIFF
--- a/designs/unice/example/netlify.toml
+++ b/designs/unice/example/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  base = "packages/unice/example"
+  base = "designs/unice/example"
   publish = "build"
   command = "npm run build"
 

--- a/markdown/dev/guides/markdown/custom-components/en.md
+++ b/markdown/dev/guides/markdown/custom-components/en.md
@@ -110,7 +110,7 @@ You can use the `i18n:` prefix followed by the translation key. For example
 
 Use **Example** to embed an example (a part of our `examples` pattern) that is used to
 illustrate the core API documentation. Check [the examples
-source code](https://github.com/freesewing/freesewing/blob/develop/packages/examples/src/index.js) for
+source code](https://github.com/freesewing/freesewing/blob/develop/designs/examples/src/index.js) for
 a full list of all available parts/examples.
 
 ```markdown

--- a/markdown/dev/howtos/code/adding-instructions/en.md
+++ b/markdown/dev/howtos/code/adding-instructions/en.md
@@ -8,7 +8,7 @@ about: While documentation is good, sometimes you want to add some instructions 
 
 ##### See this example in our source code
 
-- [packages/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/38d101b0415a4cbf3f9f86e006bd8cb7c43c703b/packages/jaeger/src/front.js#L411)
+- [designs/aaron/src/back.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/aaron/src/back.js#L66)
 
 </Note>
 
@@ -18,27 +18,19 @@ The tricky part is to make sure your text can be translated.
 Below is a rather involved example from Aaron:
 
 ```js
-points.bindinAnchor = new Point(points.armhole.x / 4, points.armhole.y)
+points.bindingAnchor = new Point(points.armhole.x / 4, points.armhole.y)
   .attr('data-text', 'cutTwoStripsToFinishTheArmholes')
   .attr('data-text', ':\n')
-  .attr('data-text', 'width')
-  .attr('data-text', ':')
-  .attr('data-text', units(sa * 6 || 60))
-  .attr('data-text', '\n')
-  .attr('data-text', 'length')
-  .attr('data-text', ':')
-  .attr('data-text', units(armholeLength * 0.95 + 2 * sa))
-  .attr('data-text', '\n&#160;\n')
+  .attr('data-text', `2x: ${units(sa * 6 || 60)} x ${units(armholeLength * 0.95 + 2 * sa)}`)
+  .attr('data-text', '\n \n')
   .attr('data-text', 'cutOneStripToFinishTheNeckOpening')
   .attr('data-text', ':\n')
   .attr('data-text', 'width')
   .attr('data-text', ':')
-  .attr('data-text', units(sa * 6))
-  .attr('data-text', '\n')
-  .attr('data-text', 'length')
-  .attr('data-text', ':')
-  .attr('data-text', units(neckOpeningLength * 2 * 0.95 + 2 * sa))
-  .attr('data-text-lineheight', 6)
+  .attr(
+    'data-text',
+    `${units((sa || 10) * 6)} x ${units(neckOpeningLength * 2 * 0.95 + 2 * sa)}`
+  )
 ```
 
 If you want to add text along a path, you can do that too:

--- a/markdown/dev/howtos/code/extend-pattern/en.md
+++ b/markdown/dev/howtos/code/extend-pattern/en.md
@@ -6,9 +6,9 @@ title: Create a new design based on an existing design
 
 ##### See this example in our source code
 
-- [packages/aaron/config/index.js](https://github.com/freesewing/freesewing/blob/72f34101792bda4d8e553c3479daa63cb461f3c5/packages/aaron/config/index.js#L34)
-- [packages/aaron/src/index.js](https://github.com/freesewing/freesewing/blob/72f34101792bda4d8e553c3479daa63cb461f3c5/packages/aaron/src/index.js#L2)
-- [packages/carlita/src/index.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/carlita/src/index.js#L25)
+- [designs/aaron/config/index.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/aaron/config/index.js#L36)
+- [designs/aaron/src/index.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/aaron/src/index.js#L2)
+- [designs/carlita/src/index.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/carlita/src/index.js#L25)
 
 </Note>
 

--- a/markdown/dev/howtos/code/hide-paths/en.md
+++ b/markdown/dev/howtos/code/hide-paths/en.md
@@ -8,7 +8,7 @@ about: When you inherit a part, it comes with a bunch of paths. Here'show to hid
 
 ##### See this example in our source code
 
-- [packages/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/develop/packages/aaron/src/front.js#L22)
+- [designs/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/aaron/src/front.js#L22)
 
 </Note>
 

--- a/markdown/dev/howtos/code/remove-paths/en.md
+++ b/markdown/dev/howtos/code/remove-paths/en.md
@@ -8,10 +8,12 @@ about: When you inherit a part, it comes with a bunch of paths. Here'show to rem
 
 ##### See this example in our source code
 
-- [packages/carlton/src/back.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/carlton/src/back.js#L62)
+- [designs/carlton/src/back.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/carlton/src/back.js#L62)
 
 </Note>
 
 ```js
-  for (let i in paths) delete paths[i]
+  for (let i in paths) {
+    if (['backArmhole', 'backCollar'].indexOf(i) === -1) delete paths[i]
+  }
 ```

--- a/markdown/dev/howtos/code/shared-dimensions/en.md
+++ b/markdown/dev/howtos/code/shared-dimensions/en.md
@@ -8,8 +8,8 @@ about: Shows how to share dimensions between similar pattern parts
 
 ##### See this example in our source code
 
-- [packages/aaron/src/shared.js](https://github.com/freesewing/freesewing/blob/develop/packages/aaron/src/shared.js)
-- [packages/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/72f34101792bda4d8e553c3479daa63cb461f3c5/packages/aaron/src/front.js#L160)
+- [designs/aaron/src/shared.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/aaron/src/shared.js)
+- [designs/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/aaron/src/front.js#L160)
 
 </Note>
 

--- a/markdown/dev/howtos/code/storing-path-length/en.md
+++ b/markdown/dev/howtos/code/storing-path-length/en.md
@@ -8,7 +8,7 @@ about: Shows how to store a seam length so you can true the seam of another part
 
 ##### See this example in our source code
 
-- [packages/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/develop/packages/aaron/src/front.js#L103)
+- [designs/aaron/src/front.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/aaron/src/front.js#L103)
 
 </Note>
 

--- a/markdown/dev/howtos/design/fit-sleeve/en.md
+++ b/markdown/dev/howtos/design/fit-sleeve/en.md
@@ -8,7 +8,7 @@ about: Shows how to adapt the length of the sleevecap to fit your armhole
 
 ##### See this example in our source code
 
-- [packages/bent/src/sleeve.js](https://github.com/freesewing/freesewing/blob/develop/packages/bent/src/sleeve.js)
+- [designs/bent/src/sleeve.js](https://github.com/freesewing/freesewing/blob/develop/designs/bent/src/sleeve.js)
 
 </Note>
 

--- a/markdown/dev/howtos/design/seam-allowance/en.md
+++ b/markdown/dev/howtos/design/seam-allowance/en.md
@@ -8,7 +8,7 @@ about: Adding seam allowance or hem allowance is easy to do
 
 ##### See this example in our source code
 
-- [packages/bruce/src/inset.js](https://github.com/freesewing/freesewing/blob/develop/packages/bruce/src/inset.js#L34)
+- [designs/bruce/src/inset.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/bruce/src/inset.js#L32)
 
 </Note>
 

--- a/markdown/dev/howtos/design/slash-spread/en.md
+++ b/markdown/dev/howtos/design/slash-spread/en.md
@@ -8,7 +8,7 @@ about: Slash and spread is easy enough on paper, here's how to do it in code
 
 ##### See this example in our source code
 
-- [packages/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/jaeger/src/front.js#L64)
+- [designs/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/jaeger/src/front.js#L64)
 
 </Note>
 

--- a/markdown/dev/howtos/design/sprinkle-snippets/en.md
+++ b/markdown/dev/howtos/design/sprinkle-snippets/en.md
@@ -8,7 +8,7 @@ about: Adding multiple snippets doesn't need to be a chore with this handy macro
 
 ##### See this example in our source code
 
-- [packages/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/8474477911daed3c383700ab29c9565883f16d66/packages/jaeger/src/front.js#L381)
+- [designs/jaeger/src/front.js](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/jaeger/src/front.js#L381)
 
 </Note>
 

--- a/markdown/dev/reference/api/config/en.md
+++ b/markdown/dev/reference/api/config/en.md
@@ -35,4 +35,4 @@ const config = {
 }
 ```
 
-[aaron]: https://github.com/freesewing/freesewing/blob/develop/packages/aaron/config/index.js
+[aaron]: https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/aaron/config/index.js

--- a/markdown/dev/reference/api/path/trim/en.md
+++ b/markdown/dev/reference/api/path/trim/en.md
@@ -24,7 +24,7 @@ To limit the impact of path.trim(), follow this approach:
 - now join it to the rest of your path
 
 You can see an example of this
-[in the front part of the Bruce pattern](https://github.com/freesewing/freesewing/blob/develop/packages/bruce/src/front.js#L195).
+[in the front part of the Bruce pattern](https://github.com/freesewing/freesewing/blob/3ca5d0edfe54c7ac20aaf3af2f3544aee72f9b99/designs/bruce/src/front.js#L158).
 
 </Warning>
 

--- a/markdown/dev/reference/plugins/bust/en.md
+++ b/markdown/dev/reference/plugins/bust/en.md
@@ -77,8 +77,8 @@ import config from "../config";
 const Pattern = new freesewing.Design(config, bust);
 ```
 
-[1]: https://github.com/freesewing/freesewing/blob/develop/packages/carlita/src/index.js#L12
+[1]: https://github.com/freesewing/freesewing/blob/develop/designs/carlita/src/index.js#L12
 
-[2]: https://github.com/freesewing/freesewing/blob/develop/packages/carlton
+[2]: https://github.com/freesewing/freesewing/blob/develop/designs/carlton
 
-[3]: https://github.com/freesewing/freesewing/blob/develop/packages/teagan/src/index.js
+[3]: https://github.com/freesewing/freesewing/blob/develop/designs/teagan/src/index.js


### PR DESCRIPTION
Some of these links were actually broken, since they expect to find designs under the `packages/` directory in the current `develop` branch. Other links were technically okay, since they link to old commits, but updating those links may still help to reduce confusion.

Also fix a reference to `packages/unice` in a `netlify.toml` file. (Untested, but I don't think this is an actual Netlify configuration.)