### PR TITLE
[Fix] Mix inline and class styling for buttons and buttonholes

### DIFF
--- a/plugins/plugin-buttons/src/button.js
+++ b/plugins/plugin-buttons/src/button.js
@@ -2,10 +2,11 @@ export default `
 <g id="button">
   <circle
     cx="0" cy="0" r="3.4"
+    style="stroke:var(--pattern-mark);fill:none;stroke-width:var(--pattern-stroke);"
     class="mark"
   />
-  <circle cx="-1" cy="-1" r="0.5" class="no-stroke fill-mark"/>
-  <circle cx="1"  cy="-1" r="0.5" class="no-stroke fill-mark" />
-  <circle cx="1"  cy="1"  r="0.5" class="no-stroke fill-mark" />
-  <circle cx="-1" cy="1"  r="0.5" class="no-stroke fill-mark" />
+  <circle cx="-1" cy="-1" r="0.5" class="no-stroke fill-mark" style="stroke:none;fill:var(--pattern-mark)"/>
+  <circle cx="1"  cy="-1" r="0.5" class="no-stroke fill-mark" style="stroke:none;fill:var(--pattern-mark)" />
+  <circle cx="1"  cy="1"  r="0.5" class="no-stroke fill-mark" style="stroke:none;fill:var(--pattern-mark)" />
+  <circle cx="-1" cy="1"  r="0.5" class="no-stroke fill-mark" style="stroke:none;fill:var(--pattern-mark)" />
 </g>`

--- a/plugins/plugin-buttons/src/buttonhole.js
+++ b/plugins/plugin-buttons/src/buttonhole.js
@@ -3,17 +3,20 @@ export default `
   <path
     class="mark"
     d="M -1,-5 L 1,-5 L 1,5 L -1,5 z"
+    style="fill:none;stroke:var(--pattern-mark);stroke-width:var(--pattern-stroke);"
   />
 </g>
 <g id="buttonhole-start">
   <path
     class="mark"
     d="M -1,-10 L 1,-10 L 1,0 L -1,0 z"
+    style="fill:none;stroke:var(--pattern-mark);stroke-width:var(--pattern-stroke);"
   />
 </g>
 <g id="buttonhole-end">
   <path
     class="mark"
     d="M -1,0 L 1,0 L 1,10 L -1,10 z"
+    style="fill:none;stroke:var(--pattern-mark);stroke-width:var(--pattern-stroke);"
   />
 </g>`

--- a/plugins/plugin-theme/src/lib/draft.js
+++ b/plugins/plugin-theme/src/lib/draft.js
@@ -13,12 +13,45 @@ const colors = {
   contrast: '#ec4899'
 }
 
+const vars = `svg.freesewing {
+  --pattern-fabric: ${colors.fabric};
+  --pattern-lining: ${colors.lining};
+  --pattern-interfacing: ${colors.interfacing};
+  --pattern-canvas: ${colors.canvas};
+  --pattern-various: ${colors.various};
+  --pattern-mark: ${colors.mark};
+  --pattern-contrast: ${colors.contrast};
+  --pattern-note: ${colors.note};
+  --pattern-text-xs: 0.2rem;
+  --pattern-text-sm: 0.3rem;
+  --pattern-text: 0.4rem;
+  --pattern-text-lg: 0.6rem;
+  --pattern-text-xl: 0.8rem;
+  --pattern-text-2xl: 1.5rem;
+  --pattern-text-3xl: 2rem;
+  --pattern-text-4xl: 3rem;
+  --pattern-scale: 1;
+  --pattern-stroke-xs: 0.2px;
+  --pattern-stroke-sm: 0.4px;
+  --pattern-stroke: 0.7px;
+  --pattern-stroke-lg: 1.3px;
+  --pattern-stroke-xl: 2px;
+  --pattern-stroke-2xl: 4px;
+  --pattern-stroke-3xl: 6px;
+  --pattern-stroke-4xl: 8px;
+  --pattern-stroke-5xl: 12px;
+  --pattern-stroke-6xl: 16px;
+  --pattern-stroke-7xl: 20px;
+}`
+
 /**
  * generate a stylesheet
  * scale: the scale of the markings
  * stripped: should nested declarations be stripped out? Necessary for svgToPdfkit
  * */
 export default (scale, stripped) => `
+  ${!stripped ? vars : ''}
+
   ${!stripped ? '/* Reset */' : ''}
   ${!stripped ? 'svg.freesewing ' : ''}path,
   ${!stripped ? 'svg.freesewing ' : ''}circle,


### PR DESCRIPTION
Fixes #2631 by leaving the inline styling in for svg rendering and using classes for pdf rendering. The svg to pdf parser won't use css vars, unfortunately. 

I think it's not ideal for maintenance to have to use both to accomplish the same outcomes in different places, but looking at our css, I'm kind of itching to use nesting to make it easier to read, navigate, and group, and I think that in that effort it'd be easier to put styling into the shadow dom in ways that don't require a ton of additional overhead.

In the mean time, this is backwards compatible for v2 and org, and it allows the snippets to render properly in pdf exports.