### PR TITLE
[fix] Octoplushy Instructions incorrect format

### DIFF
--- a/markdown/org/docs/patterns/octoplushy/instructions/en.md
+++ b/markdown/org/docs/patterns/octoplushy/instructions/en.md
@@ -40,7 +40,7 @@ There are a couple of ways to make eyes for the Octoplushy version.
 Before sewing the eyebrows in half, you can stuff the eyebrows to create a more dramatic looking eyebrow.
 
 </Note>
-  
+
 - **Squid**
   - With _good sides together_ sew four head parts together, from notch B to the tip of the head part A creating a semi-sphere like shape.
   - Repeat with the remaining four head parts to create a second half.


### PR DESCRIPTION
One of those classics of github being fancy and not strict. 
There was a accidental line break that breaks the formatting of the bullet points on the website. 
This simply removes it to hopefully fix the formatting otherwise something deeper is going on. 