### PR TITLE
fix(boring-cyborg): Fix typo in boring-cyborg.yml

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -98,7 +98,7 @@ labelPRBasedOnFilePath:
   ":shirt: titan": [ designs/titan/* ]
   ":shirt: trayvon": [ designs/trayvon/* ]
   ":shirt: tutorial": [ designs/tutorial/* ]
-  ":shirt: unice": [ designs/unice/* ] // New
+  ":shirt: unice": [ designs/unice/* ]
   ":shirt: ursula": [ designs/ursula/* ]
   ":shirt: wahid": [ designs/wahid/* ]
   ":shirt: walburga": [ designs/walburga/* ]


### PR DESCRIPTION
In #2619 / 501db1d1d8e3e6f79de084130c25839c261e4a54 I was trying to make `boring-cyborg` work better than before, but I accidentally made things worse. I'm sorry! I've tested this fix by configuring the bot in a personal repo.