### PR TITLE
fix(testci): Accept `alpha` and `beta` package versions

### DIFF
--- a/tests/patterns/config.mjs
+++ b/tests/patterns/config.mjs
@@ -35,7 +35,7 @@ export const testPatternConfig = (design, pattern, expect, models, patterns) => 
     const chunks = pattern.config.version.split('.')
     if (chunks.length > 3) {
       expect(pattern.config.version.split('.').length).to.equal(4)
-      expect(chunks[2]).to.contain('-rc')
+      expect(chunks[2]).to.contain.oneOf(['-alpha', '-beta', '-rc'])
     }
     else expect(pattern.config.version.split('.').length).to.equal(3)
   })

--- a/tests/plugins/shared.mjs
+++ b/tests/plugins/shared.mjs
@@ -21,7 +21,7 @@ export const sharedPluginTests = plugin => {
       const chunks = plugin.version.split('.')
       if (chunks.length > 3) {
         chai.expect(plugin.version.split('.').length).to.equal(4)
-        chai.expect(chunks[2]).to.contain('-rc')
+        chai.expect(chunks[2]).to.contain.oneOf(['-alpha', '-beta', '-rc'])
       }
       else chai.expect(plugin.version.split('.').length).to.equal(3)
     })


### PR DESCRIPTION
testci is currently failing now that package versions have been [bumped to `3.0.0-alpha.0`](https://github.com/freesewing/freesewing/commit/ae40299#diff-2d72bdead8afa0798d18995311992d684348a694c2d5e214e8e4d2b6153e4821). Alpha and beta version numbers have existed before, but only as recently as `v2.1.0-alpha.0` and `v2.7.0-beta.3` respectively, both of which preceded [the assertions in question](https://github.com/freesewing/freesewing/commit/7ddb023c8d13db4f7afa383378f295a53d38238d).

This PR updates those assertions to accept `alpha` or `beta` package versions, in addition to the already-supported `rc` and stable (non-suffixed) package versions.