### PR TITLE
chore: Bump .nvmrc up to Node 16 LTS

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+lts/gallium


### PR DESCRIPTION
See #2647.