### PR TITLE
Update tutorial instructions to use Node 16.

### DIFF
--- a/markdown/dev/tutorials/getting-started-linux/installing-node/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/installing-node/en.md
@@ -6,14 +6,10 @@ order: 20
 Now we will use nvm to install Node JS. Run the following command:
 
 ```bash
-nvm install lts/fermium
+nvm install lts/gallium
 ```
 
-This will install the so-called LTS version of Node 14 on your system.
+This will install the so-called LTS version of Node 16 on your system.
 
 LTS versions -- short for Long Term Support -- are good node versions
 to use because they are stable and supported for a long time.
-
-<Note compact>
-Node 14 is required to use our monorepo [until we upgrade Strapi](https://github.com/freesewing/freesewing/issues/2351).
-</Note>

--- a/markdown/dev/tutorials/getting-started-linux/node-versions/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/node-versions/en.md
@@ -52,7 +52,3 @@ nvm use v10.22.1
 
 If you picked a version that is not installed, `nvm` will simply tell you
 and even suggest the command you should type to install it. Handy!
-
-<Note compact>
-Node 14 is required to use our monorepo [until we upgrade Strapi](https://github.com/freesewing/freesewing/issues/2351).
-</Note>

--- a/markdown/dev/tutorials/getting-started-mac/installing-node/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/installing-node/en.md
@@ -6,14 +6,10 @@ order: 20
 Now we will use nvm to install Node JS. Run the following command:
 
 ```bash
-nvm install lts/fermium
+nvm install lts/gallium
 ```
 
-This will install the so-called LTS version of Node 14 on your system.
+This will install the so-called LTS version of Node 16 on your system.
 
 LTS versions -- short for Long Term Support -- are good node versions
 to use because they are stable and supported for a long time.
-
-<Note compact>
-Node 14 is required to use our monorepo [until we upgrade Strapi](https://github.com/freesewing/freesewing/issues/2351).
-</Note>

--- a/markdown/dev/tutorials/getting-started-windows/en.md
+++ b/markdown/dev/tutorials/getting-started-windows/en.md
@@ -57,7 +57,7 @@ the screen or opening a new terminal.
 
 Now that you have NVM installed, you can install node. The latest version can be
 installed using `nvm install default`. You can also install a specific version
-using `nvm install v12.16.1`. For the purposes of debugging it can be useful to
+using `nvm install v16.17.0`. For the purposes of debugging it can be useful to
 have the same version of node installed as the main project uses, which you can
 then activate using `nvm use <version>`. You can determine what version the
 FreeSewing project uses by checking
@@ -65,7 +65,7 @@ FreeSewing project uses by checking
 
 <Warning> At the time this guide was written the latest version of node/npm has
 a bug in the dependency resolution process which causes the freesewing project
-to fail to build. Use the latest LTS version (currently 14.15.4) or the specific
+to fail to build. Use the latest LTS version (currently 16.17.0) or the specific
 version used by the main project to avoid this issue.  </Warning>
 
 Node comes with the Node Package Manager (npm) by default which can be used to
@@ -139,7 +139,7 @@ rest of this process.
 Open a Powershell terminal or command prompt. Run `nvm ls available` to show
 versions that can be installed. Choose the appropriate version (you should use
 the same version as the freesewing project or latest LTS version) then run `nvm
-install 14.15.4` and `nvm use 14.15.4` (where `14.15.4` is the full version
+install 16.17.0` and `nvm use 16.17.0` (where `16.17.0` is the full version
 string of the version you wish to use) to activate the newly installed version.
 You will receive a prompt for elevated permissions and will need to accept it in
 order to activate the new version of node.
@@ -147,7 +147,7 @@ order to activate the new version of node.
 <Warning> 
 At the time this guide was written the latest version of node/npm has
 a bug in the dependency resolution process which causes the freesewing project
-to fail to build. Use the latest LTS version (currently 14.15.4) or the specific
+to fail to build. Use the latest LTS version (currently 16.17.0) or the specific
 version used by the main project to avoid this issue.  
 </Warning>
 


### PR DESCRIPTION
(I do not know if the Node.js "bug in the dependency resolution process" mentioned in the Windows tutorial still exists, but I left that wording intact and updated the suggested Node version to "16.17.0".)