### PR TITLE
Add json type assertions for import statements.

### DIFF
--- a/config/templates/design/config.js
+++ b/config/templates/design/config.js
@@ -1,4 +1,4 @@
-import { version } from './package.json'
+import { version } from './package.json' assert { type: 'json' }
 
 export default {
   name: '{{name}}',

--- a/packages/core/src/pattern.js
+++ b/packages/core/src/pattern.js
@@ -8,7 +8,7 @@ import pack from 'bin-pack'
 import Store from './store'
 import Hooks from './hooks'
 import Attributes from './attributes'
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default function Pattern(config = { options: {} }) {
   // Default settings

--- a/packages/core/src/svg.js
+++ b/packages/core/src/svg.js
@@ -1,6 +1,6 @@
 import Attributes from './attributes'
 import { round } from './utils'
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 function Svg(pattern) {
   this.openGroups = []

--- a/packages/new-design/templates/from-bella/design/config.js
+++ b/packages/new-design/templates/from-bella/design/config.js
@@ -1,4 +1,4 @@
-import { version } from '../package.json'
+import { version } from '../package.json' assert { type: 'json' }
 import { config as bellaConfig } from '@freesewing/bella'
 
 export default {

--- a/packages/new-design/templates/from-bent/design/config.js
+++ b/packages/new-design/templates/from-bent/design/config.js
@@ -1,4 +1,4 @@
-import { version } from '../package.json'
+import { version } from '../package.json' assert { type: 'json' }
 import { config as bentConfig } from '@freesewing/bent'
 
 export default {

--- a/packages/new-design/templates/from-breanna/design/config.js
+++ b/packages/new-design/templates/from-breanna/design/config.js
@@ -1,4 +1,4 @@
-import { version } from '../package.json'
+import { version } from '../package.json' assert { type: 'json' }
 import { config as breannaConfig } from '@freesewing/breanna'
 
 export default {

--- a/packages/new-design/templates/from-brian/design/config.js
+++ b/packages/new-design/templates/from-brian/design/config.js
@@ -1,4 +1,4 @@
-import { version } from '../package.json'
+import { version } from '../package.json' assert { type: 'json' }
 import { config as brianConfig } from '@freesewing/brian'
 
 export default {

--- a/packages/new-design/templates/from-scratch/design/config.js
+++ b/packages/new-design/templates/from-scratch/design/config.js
@@ -1,4 +1,4 @@
-import { version } from '../package.json'
+import { version } from '../package.json' assert { type: 'json' }
 
 export default {
   name: '{{name}}',

--- a/packages/new-design/templates/from-titan/design/config.js
+++ b/packages/new-design/templates/from-titan/design/config.js
@@ -1,4 +1,4 @@
-import { version } from '../package.json'
+import { version } from '../package.json' assert { type: 'json' }
 import { config as titanConfig } from '@freesewing/titan'
 
 export default {

--- a/plugins/plugin-banner/src/index.js
+++ b/plugins/plugin-banner/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-bartack/src/index.js
+++ b/plugins/plugin-bartack/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 import bartack from './bartack'
 
 export default {

--- a/plugins/plugin-bundle/src/index.js
+++ b/plugins/plugin-bundle/src/index.js
@@ -13,7 +13,7 @@ import scalebox from '@freesewing/plugin-scalebox'
 import round from '@freesewing/plugin-round'
 import sprinkle from '@freesewing/plugin-sprinkle'
 import measurements from '@freesewing/plugin-measurements'
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 const bundledPlugins = [
   banner,

--- a/plugins/plugin-bust/src/index.js
+++ b/plugins/plugin-bust/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-buttons/src/index.js
+++ b/plugins/plugin-buttons/src/index.js
@@ -1,7 +1,7 @@
 import button from './button'
 import buttonhole from './buttonhole'
 import snaps from './snaps'
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-cutonfold/src/index.js
+++ b/plugins/plugin-cutonfold/src/index.js
@@ -1,5 +1,5 @@
 import markers from './lib/markers'
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-dimension/src/index.js
+++ b/plugins/plugin-dimension/src/index.js
@@ -1,5 +1,5 @@
 import markers from './lib/markers'
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 const prefix = '__paperless'
 

--- a/plugins/plugin-flip/src/index.js
+++ b/plugins/plugin-flip/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-gore/src/index.js
+++ b/plugins/plugin-gore/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-grainline/src/index.js
+++ b/plugins/plugin-grainline/src/index.js
@@ -1,5 +1,5 @@
 import markers from './markers'
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 const dflts = {
   text: 'grainline',

--- a/plugins/plugin-i18n/src/index.js
+++ b/plugins/plugin-i18n/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-logo/src/index.js
+++ b/plugins/plugin-logo/src/index.js
@@ -1,5 +1,5 @@
 import logo from './logo'
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export {logo}
 

--- a/plugins/plugin-measurements/src/index.js
+++ b/plugins/plugin-measurements/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-mirror/src/index.js
+++ b/plugins/plugin-mirror/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 const lineValues = (start, end) => {
   const { x: x1, y: y1 } = start

--- a/plugins/plugin-notches/src/index.js
+++ b/plugins/plugin-notches/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 const notches =
   '<g id="notch"><circle cy="0" cx="0" r="1.4" class="fill-note" /><circle cy="0" cx="0" r="2.8" class="note" /></g><g id="bnotch"><path d="M -1.1 -1.1 L 1.1 1.1 M 1.1 -1.1 L -1.1 1.1" class="note" /><circle cy="0" cx="0" r="2.8" class="note" /></g>'

--- a/plugins/plugin-round/src/index.js
+++ b/plugins/plugin-round/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-scalebox/src/index.js
+++ b/plugins/plugin-scalebox/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 import scalebox from './scalebox'
 import miniscale from './miniscale'
 

--- a/plugins/plugin-sprinkle/src/index.js
+++ b/plugins/plugin-sprinkle/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-svgattr/src/index.js
+++ b/plugins/plugin-svgattr/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/plugins/plugin-theme/src/index.js
+++ b/plugins/plugin-theme/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 import gridMetric from './defs/grid-metric'
 import gridImperial from './defs/grid-imperial'
 import draft from './lib/draft'

--- a/plugins/plugin-title/src/index.js
+++ b/plugins/plugin-title/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 const style = `
 text.title-nr {

--- a/plugins/plugin-versionfree-svg/src/index.js
+++ b/plugins/plugin-versionfree-svg/src/index.js
@@ -1,4 +1,4 @@
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 
 export default {
   name: pkg.name,

--- a/scripts/add-software.mjs
+++ b/scripts/add-software.mjs
@@ -6,7 +6,7 @@ import { banner } from './banner.mjs'
 import mustache from 'mustache'
 import { execSync } from 'child_process'
 // Software
-import designs from '../config/software/designs.json'
+import designs from '../config/software/designs.json' assert { type: 'json' }
 
 const type = process.argv[2]
 

--- a/sites/lab/components/version-picker.js
+++ b/sites/lab/components/version-picker.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import VersionsIcon from 'shared/components/icons/versions.js'
 import { useTranslation } from 'next-i18next'
-import versions from 'site/versions.json'
+import versions from 'site/versions.json' assert { type: 'json' }
 import useVersion from 'site/hooks/useVersion.js'
 import {Picker, PickerLink} from 'shared/components/picker'
 

--- a/sites/lab/page-templates/design-list.js
+++ b/sites/lab/page-templates/design-list.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'next-i18next'
 import { formatVersionTitle } from 'site/components/version-picker.js'
 import Layout from 'site/components/layouts/bare'
 import { PageTitle } from 'shared/components/layouts/default'
-import availableVersions from 'site/available-versions.json'
+import availableVersions from 'site/available-versions.json' assert { type: 'json' }
 
 const DesignLinks = ({ list, prefix='', version=false }) => {
   const { t } = useTranslation(['patterns'])

--- a/sites/lab/pages/v/index.js
+++ b/sites/lab/pages/v/index.js
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { formatVersionTitle } from 'site/components/version-picker.js'
 import Layout from 'site/components/layouts/bare'
 import { PageTitle } from 'shared/components/layouts/default'
-import availableVersions from 'site/available-versions.json'
+import availableVersions from 'site/available-versions.json' assert { type: 'json' }
 
 const DesignLinks = ({ list, prefix='', version=false }) => (
   <ul className="flex flex-row flex-wrap ml-8">

--- a/sites/org/pages/designs/index.js
+++ b/sites/org/pages/designs/index.js
@@ -3,7 +3,7 @@ import useApp from 'site/hooks/useApp.js'
 import PageLink from 'shared/components/page-link'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
-import designs from 'shared/config/designs.json'
+import designs from 'shared/config/designs.json' assert { type: 'json' }
 import Design from 'site/components/design.js'
 
 // Don't bother with utilities

--- a/sites/org/pages/showcase/designs/[design].js
+++ b/sites/org/pages/showcase/designs/[design].js
@@ -4,7 +4,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { strapiHost } from 'shared/config/freesewing.mjs'
 import { strapiImage } from 'shared/utils.js'
 import { useTranslation } from 'next-i18next'
-import designs from 'shared/config/designs.json'
+import designs from 'shared/config/designs.json' assert { type: 'json' }
 import { PreviewTile } from '../index.js'
 
 const DesignIndexPage = (props) => {


### PR DESCRIPTION
This PR appends `assert { type: 'json' }` to every "import from .json" statement that did not already have it.