### PR TITLE
Move aaron plugin config to part-level.

### DIFF
--- a/designs/aaron/src/index.mjs
+++ b/designs/aaron/src/index.mjs
@@ -1,6 +1,4 @@
 import { Design } from '@freesewing/core'
-import { pluginBundle } from '@freesewing/plugin-bundle'
-import { withCondition as bustPlugin } from '@freesewing/plugin-bust'
 import { name, version } from '../pkg.mjs'
 import { back } from './back.mjs'
 import { front } from './front.mjs'
@@ -10,8 +8,6 @@ const Aaron = new Design({
   name,
   version,
   parts: [ back, front ],
-  plugins: pluginBundle,
-  conditionalPlugins: bustPlugin
 })
 
 // Named exports


### PR DESCRIPTION
- This is a PR into the v3 branch.
- This PR removes the plugin info from `index.mjs` for aaron. 
- However, it does _not_ move the plugin info into any other file. 
 
This is because aaron's `front.mjs` imports `base` from brian, and that part already imports pluginBundle. As I understand it, plugins are configured only once in the first part that uses them, and they should not be re-configured again in other parts. If this is incorrect, please let me know.