### PR TITLE
Move bee and bella plugin config to part-level. Use new data property.

### DIFF
--- a/designs/bee/src/index.mjs
+++ b/designs/bee/src/index.mjs
@@ -1,15 +1,12 @@
 import { Design } from '@freesewing/core'
-import { pluginBundle } from '@freesewing/plugin-bundle'
-import { name, version } from '../pkg.mjs'
+import { data } from '../data.mjs'
 import { cup } from './cup.mjs'
 import { neckTie } from './neck-tie.mjs'
 import { bandTie } from './band-tie.mjs'
 
 const Bee = new Design({
-  name,
-  version,
+  data,
   parts: [ cup, neckTie, bandTie ],
-  plugins: pluginBundle,
 })
 
 export { cup, neckTie, bandTie, Bee }

--- a/designs/bee/src/neck-tie.mjs
+++ b/designs/bee/src/neck-tie.mjs
@@ -1,4 +1,5 @@
 import { pctBasedOn } from '@freesewing/core'
+import { pluginBundle } from '@freesewing/plugin-bundle'
 
 export const neckTie = {
   name: 'bee.neckTie',
@@ -22,6 +23,7 @@ export const neckTie = {
     neckTieEnds: { dflt: 'straight', list: ['straight', 'pointed'], menu: 'style' },
     neckTieColours: { dflt: 'one', list: ['one', 'two'], menu: 'style' },
   },
+  plugins: [ pluginBundle ],
   draft: part => {
     const {
       store,

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -1,3 +1,5 @@
+import { pluginBundle } from '@freesewing/plugin-bundle'
+
 export const back = {
   name: 'bella.back',
   measurements: [
@@ -47,6 +49,7 @@ export const back = {
     frontShoulderWidth: { pct: 95, max: 98, min: 92, menu: 'advanced' },
     highBustWidth: { pct: 86, max: 92, min: 80, menu: 'advanced' },
   },
+  plugins: [ pluginBundle ],
   draft: part => {
     const {
       store,

--- a/designs/bella/src/index.mjs
+++ b/designs/bella/src/index.mjs
@@ -1,14 +1,11 @@
 import { Design } from '@freesewing/core'
-import { pluginBundle } from '@freesewing/plugin-bundle'
-import { name, version } from '../pkg.mjs'
+import { data } from '../data.mjs'
 import { back } from './back.mjs'
 import { frontSideDart } from './front-side-dart.mjs'
 
 const Bella = new Design({
-  name,
-  version,
+  data,
   parts: [ back, frontSideDart ],
-  plugins: pluginBundle,
 })
 
 export { back, frontSideDart, Bella }


### PR DESCRIPTION
PR into v3 branch.

There is an issue with bee where the imported bella front and back parts are incorrectly not hidden, and these two parts are appearing by default in the lab. 