### PR TITLE
Complete porting albert to v3.

### DIFF
--- a/designs/albert/src/front.mjs
+++ b/designs/albert/src/front.mjs
@@ -1,21 +1,14 @@
 import { pluginBundle } from '@freesewing/plugin-bundle'
 import { crossBox } from './index.mjs'
 
-export const bibLength = { pct: 75, min: 0, max: 90, menu: 'style' }
-export const lengthBonus = { pct: 0, min: -20, max: 25, menu: 'style' }
-export const backOpening = { pct: 10, min: 0, max: 25, menu: 'fit' }
-export const bibWidth = { pct: 100, min: 50, max: 125, menu: 'style' }
-export const strapWidth = { pct: 60, min: 20, max: 100, menu: 'style' }
-
 export const front = {
   name: 'albert.front',
-  measurements: [ 'chest', 'hpsToWaistBack', 'waist', 'waistToKnee' ],
+  measurements: [ 'chest', 'hpsToWaistBack', 'waist', 'waistToKnee', 'hips' ],
   options: {
-    backOpening,
-    bibWidth,
-    strapWidth,
-    bibLength,
-    lengthBonus,
+    backOpening: { pct: 10, min: 0, max: 25, menu: 'fit' },
+    bibWidth: { pct: 100, min: 50, max: 125, menu: 'style' },
+    bibLength: { pct: 75, min: 0, max: 90, menu: 'style' },
+    lengthBonus: { pct: 0, min: -20, max: 25, menu: 'style' },
   },
 //  plugins: [ pluginBundle, crossBox ],
   plugins: [ pluginBundle ],

--- a/designs/albert/src/front.mjs
+++ b/designs/albert/src/front.mjs
@@ -1,3 +1,6 @@
+import { pluginBundle } from '@freesewing/plugin-bundle'
+import { crossBox } from './index.mjs'
+
 export const bibLength = { pct: 75, min: 0, max: 90, menu: 'style' }
 export const lengthBonus = { pct: 0, min: -20, max: 25, menu: 'style' }
 export const backOpening = { pct: 10, min: 0, max: 25, menu: 'fit' }
@@ -14,6 +17,8 @@ export const front = {
     bibLength,
     lengthBonus,
   },
+//  plugins: [ pluginBundle, crossBox ],
+  plugins: [ pluginBundle ],
   draft: part => {
     const {
       options,

--- a/designs/albert/src/index.mjs
+++ b/designs/albert/src/index.mjs
@@ -1,12 +1,11 @@
 import { Design } from '@freesewing/core'
-import { pluginBundle } from '@freesewing/plugin-bundle'
 import { name, version } from '../pkg.mjs'
 import { front } from './front.mjs'
 import { pocket } from './pocket.mjs'
 import { strap } from './strap.mjs'
 
 // crossBox macro
-const crossBox = {
+export const crossBox = {
   name: 'crossbox',
   version,
   macros: {
@@ -69,7 +68,6 @@ const Albert = new Design({
   name,
   version,
   parts: [ front, pocket, strap ],
-  plugins: [ pluginBundle, crossBox ]
 })
 
 // Named exports

--- a/designs/albert/src/index.mjs
+++ b/designs/albert/src/index.mjs
@@ -1,5 +1,5 @@
 import { Design } from '@freesewing/core'
-import { name, version } from '../pkg.mjs'
+import { data } from '../data.mjs'
 import { front } from './front.mjs'
 import { pocket } from './pocket.mjs'
 import { strap } from './strap.mjs'
@@ -7,7 +7,7 @@ import { strap } from './strap.mjs'
 // crossBox macro
 export const crossBox = {
   name: 'crossbox',
-  version,
+  version: data.version,
   macros: {
     crossBox: function (so) {
       let id = this.getId()
@@ -65,8 +65,7 @@ export const crossBox = {
 
 // Setup our new design
 const Albert = new Design({
-  name,
-  version,
+  data,
   parts: [ front, pocket, strap ],
 })
 

--- a/designs/albert/src/pocket.mjs
+++ b/designs/albert/src/pocket.mjs
@@ -1,9 +1,8 @@
-import { bibLength, lengthBonus } from './front.mjs'
+import { front } from './front.mjs'
 
 export const pocket = {
   name: 'albert.pocket',
-  measurements: [ 'hpsToWaistBack', 'waistToKnee' ],
-  options: { bibLength, lengthBonus },
+  after: front,
   draft: part => {
     const {
       options,

--- a/designs/albert/src/strap.mjs
+++ b/designs/albert/src/strap.mjs
@@ -1,14 +1,11 @@
-import { backOpening, bibWidth, bibLength, strapWidth } from './front.mjs'
+import { front } from './front.mjs'
 
 export const strap = {
   name: 'albert.strap',
-  measurements: [ 'chest', 'waist', 'hips', 'hpsToWaistBack' ],
+  after: front,
   options: {
-    backOpening,
-    bibWidth,
-    bibLength,
-    strapWidth,
     chestDepth: { pct: 22, min: 15, max: 90, menu: 'fit' },
+    strapWidth: { pct: 60, min: 20, max: 100, menu: 'style' },
   },
   draft: part => {
     const {


### PR DESCRIPTION
I was not able to get albert's `crossBox` local plugin to not get `ReferenceError: Cannot access 'crossBox' before initialization` errors. I even tried moving the plugin to a separate file outside of `index.mjs`, but that did not work. For now, the `crossBox` plugin is commented out in `front.mjs`.