### PR TITLE
[wip]: Draft changes for Breanna, Bruce, and Titan

### DIFF
--- a/designs/breanna/src/dart-utils.js
+++ b/designs/breanna/src/dart-utils.js
@@ -84,27 +84,37 @@ export const getDartLocationsAsNumbers = (options) => {
   else return [loc1, loc2]
 }
 
-export const getDartPaths = (Path, points) => [
-  new Path()
-    .line(points.primaryBustDart1)
-    .line(points.primaryBustDartTip)
-    .line(points.primaryBustDart2),
-  new Path()
-    .line(points.secondaryBustDart1)
-    .line(points.secondaryBustDartTip)
-    .line(points.secondaryBustDart2),
-]
+export const getDartPaths = (Path, points) => {
+  let dart_paths = [
+    new Path()
+      .line(points.primaryBustDart1)
+      .line(points.primaryBustDartTip)
+      .line(points.primaryBustDart2),
+  ]
+  if ('secondaryBustDart1' in points)
+    dart_paths.push(new Path()
+      .line(points.secondaryBustDart1)
+      .line(points.secondaryBustDartTip)
+      .line(points.secondaryBustDart2)
+    )
+  return dart_paths
+}
 
-export const getSaDartPaths = (Path, points) => [
-  new Path()
-    .line(points.primaryBustDart1)
-    .line(points.primaryBustDartEdge)
-    .line(points.primaryBustDart2),
-  new Path()
-    .line(points.secondaryBustDart1)
-    .line(points.secondaryBustDartEdge)
-    .line(points.secondaryBustDart2),
-]
+export const getSaDartPaths = (Path, points) => {
+  let dart_paths = [
+    new Path()
+      .line(points.primaryBustDart1)
+     .line(points.primaryBustDartEdge)
+     .line(points.primaryBustDart2),
+  ]
+  if ('secondaryBustDart1' in points)
+    dart_paths.push(new Path()
+      .line(points.secondaryBustDart1)
+      .line(points.secondaryBustDartEdge)
+      .line(points.secondaryBustDart2)
+    )
+  return dart_paths
+}
 
 /*
  * Once the front is constructed with the theorethical bust darts, we

--- a/designs/bruce/src/front.js
+++ b/designs/bruce/src/front.js
@@ -71,35 +71,39 @@ export default function (part) {
 
   // Adjust tusk length to fit inset curve
   let delta = tuskDelta(part)
-  let original_delta = delta
-  let rotation = ['rightTuskRight', 'rightTuskLeft', 'curveRightCpBottom']
+  let previous_delta = delta
+  const points_to_save = ['rightTuskRight', 'rightTuskLeft',
+    'curveRightCpBottom']
   let saved = []
   let stop = false
   if (Math.abs(delta) <= 1) {
-    // We are already below 1mm. No adjustment needed.
+    // We started below the 1mm threshold. No adjustment needed.
     stop = true
   }
   let count = 0
   while (!stop) {
-    original_delta = delta
-    for (const i of rotation) {
+    for (const i of points_to_save) {
       saved[i] = points[i]
     }
+    previous_delta = delta
     tweakTusk(delta, part)
     delta = tuskDelta(part)
     count++
     if (Math.abs(delta) <= 1) {
-      // Below 1mm is good enough
+      // Below 1mm threshold is good enough.
       stop = true
-    } else if (Math.abs(delta) > Math.abs(original_delta) || count >= 150) {
-      raise.warning("Unable to adjust the front tusk length to fit the given measurements, after " + count  + " iterations.")
-      adjustment_warning = true
-      stop = true
-      if (Math.abs(delta) > Math.abs(original_delta)) {
-        for (const i of rotation) {
+    } else if (Math.abs(delta) > Math.abs(previous_delta) ||
+      count >= 150) {
+      if (Math.abs(delta) > Math.abs(previous_delta)) {
+        // The shifts have started to produce worse results.
+        // Revert back to the previous set of points.
+        for (const i of points_to_save) {
           points[i] = saved[i]
         }
       }
+      raise.warning("Unable to adjust the front tusk length to fit the given measurements, after " + count  + " iterations.")
+      adjustment_warning = true
+      stop = true
     }
   }
 

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -195,18 +195,20 @@ export default (part) => {
       delta = crossSeamDelta()
       // Uncomment the line beloe this to see all iterations
       // paths[`try${run}`] = drawPath().attr('class', 'dotted')
-    } while (Math.abs(delta) > 1
-        && run < 15
-        && (Math.abs(delta) < Math.abs(previous_delta)))
+    } while (Math.abs(delta) > 1 &&
+        run < 15 &&
+        Math.abs(delta) < Math.abs(previous_delta)))
     if (Math.abs(delta) > Math.abs(previous_delta)) {
+      // The rotations have started to produce worse results.
+      // Revert back to the previous rotation.
       for (const i of rotate) {
         points[i] = saved[i]
       }
       points.fork = saved.fork
       points.forkCp2 = saved.forkCp2
     }
-    if (Math.abs(delta) > 1
-      || Math.abs(delta) > Math.abs(previous_delta)) {
+    if (Math.abs(delta) > 1 ||
+       Math.abs(delta) > Math.abs(previous_delta)) {
       raise.warning("Unable to adjust the back crotch seam to fit the given measurements.")
       adjustment_warning = true
     }
@@ -346,7 +348,7 @@ export default (part) => {
             points.seatOut,
             points.waistOut
           )
-          let proposed_kneeOutNotch = utils.lineIntersectsCurve(
+          const seamline_outside_knee = utils.lineIntersectsCurve(
             points.kneeOut,
             points.kneeIn.rotate(180, points.kneeOut),
             points.floorOut,
@@ -354,17 +356,18 @@ export default (part) => {
             points.seatOut,
             points.waistOut
           )
-          if (proposed_kneeOutNotch) {
-            points.kneeOutNotch = proposed_kneeOutNotch
+          const seamline_inside_knee = utils.lineIntersectsCurve(
+            points.kneeOut,
+            points.kneeIn,
+            points.floorOut,
+            points.kneeOutCp2,
+            points.seatOut,
+            points.waistOut
+          )
+          if (seamline_outside_knee) {
+            points.kneeOutNotch = seamline_outside_knee
           } else {
-            points.kneeOutNotch = utils.lineIntersectsCurve(
-              points.kneeOut,
-              points.kneeIn,
-              points.floorOut,
-              points.kneeOutCp2,
-              points.seatOut,
-              points.waistOut
-            )
+            points.kneeOutNotch = seamline_inside_knee
             raise.warning("Unable to draw seamline outside the back outside knee point.")
             adjustment_warning = true
           }
@@ -378,7 +381,7 @@ export default (part) => {
             points.waistOut
           )
           points.seatOutNotch = points.seatOut
-          let proposed_kneeOutNotch = utils.lineIntersectsCurve(
+          const seamline_outside_knee = utils.lineIntersectsCurve(
             points.kneeOut,
             points.kneeIn.rotate(180, points.kneeOut),
             points.floorOut,
@@ -386,22 +389,23 @@ export default (part) => {
             points.seatOutCp1,
             points.seatOut
           )
-          if (proposed_kneeOutNotch) {
-            points.kneeOutNotch = proposed_kneeOutNotch
+          const seamline_inside_knee = utils.lineIntersectsCurve(
+            points.kneeOut,
+            points.kneeIn,
+            points.floorOut,
+            points.kneeOutCp2,
+            points.seatOutCp1,
+            points.seatOut
+          )
+          if (seamline_outside_knee {
+            points.kneeOutNotch = seamline_outisde_knee
           } else {
-            points.kneeOutNotch = utils.lineIntersectsCurve(
-              points.kneeOut,
-              points.kneeIn,
-              points.floorOut,
-              points.kneeOutCp2,
-              points.seatOutCp1,
-              points.seatOut
-            )
+            points.kneeOutNotch = seamline_inside_knee
             raise.warning("Unable to draw seamline outside the back outside knee point.")
             adjustment_warning = true
           }
         }
-        let proposed_kneeInNotch = utils.lineIntersectsCurve(
+        const seamline_outisde_knee = utils.lineIntersectsCurve(
           points.kneeIn,
           points.kneeOut.rotate(180, points.kneeIn),
           points.fork,
@@ -409,25 +413,23 @@ export default (part) => {
           points.kneeInCp1,
           points.floorIn
         )
-        if (proposed_kneeInNotch) {
-          points.kneeInNotch = proposed_kneeInNotch
+        const seamline_inside_knee = utils.lineIntersectsCurve(
+          points.kneeIn,
+          points.kneeOut,
+          points.fork,
+          points.forkCp2,
+          points.kneeInCp1,
+          points.floorIn
+        )
+        if (seamline_outside_knee) {
+          points.kneeInNotch = seamline_outside_knee
+        } else if (seamline_inside_knee) {
+          points_knee_InNotch = seamline_inside_knee
+          raise.warning("Unable to draw seamline outside the back inside knee point.")
+          adjustment_warning = true
         } else {
-          proposed_kneeInNotch = utils.lineIntersectsCurve(
-            points.kneeIn,
-            points.kneeOut,
-            points.fork,
-            points.forkCp2,
-            points.kneeInCp1,
-            points.floorIn
-          )
-          if (proposed_kneeInNotch) {
-            points_knee_InNotch = proposed_kneeInNotch
-            raise.warning("Unable to draw seamline outside the back inside knee point.")
-            adjustment_warning = true
-          } else {
-            raise.warning("Unable to determine proper kneeInNotch location.")
-            adjustment_warning = true
-          }
+          raise.warning("Unable to determine proper kneeInNotch location.")
+          adjustment_warning = true
         }
       }
       macro('sprinkle', {

--- a/designs/titan/src/back.js
+++ b/designs/titan/src/back.js
@@ -197,7 +197,7 @@ export default (part) => {
       // paths[`try${run}`] = drawPath().attr('class', 'dotted')
     } while (Math.abs(delta) > 1 &&
         run < 15 &&
-        Math.abs(delta) < Math.abs(previous_delta)))
+        Math.abs(delta) < Math.abs(previous_delta))
     if (Math.abs(delta) > Math.abs(previous_delta)) {
       // The rotations have started to produce worse results.
       // Revert back to the previous rotation.
@@ -397,7 +397,7 @@ export default (part) => {
             points.seatOutCp1,
             points.seatOut
           )
-          if (seamline_outside_knee {
+          if (seamline_outside_knee) {
             points.kneeOutNotch = seamline_outisde_knee
           } else {
             points.kneeOutNotch = seamline_inside_knee

--- a/designs/titan/src/front.js
+++ b/designs/titan/src/front.js
@@ -257,18 +257,20 @@ export default (part) => {
       delta = crotchSeamDelta()
       // Uncomment the line below this to see all iterations
       // paths[`try${run}`] = drawPath().attr('class', 'dotted')
-    } while (Math.abs(delta) > 1
-        && run < 15
-        && (Math.abs(delta) < Math.abs(previous_delta)))
+    } while (Math.abs(delta) > 1 &&
+        run < 15 &&
+        (Math.abs(delta) < Math.abs(previous_delta)))
     if (Math.abs(delta) > Math.abs(previous_delta)) {
+      // The rotations have started to produce worse results.
+      // Revert back to the previous rotation.
       for (const i of rotate) {
         points[i] = saved[i]
       }
       points.fork = saved.fork
     }
-    if (Math.abs(delta) > 1
-      || Math.abs(delta) > Math.abs(previous_delta)) {
-      raise.warning("Unable to adjust the front crotch seam to fit the given measurements.")
+    if (Math.abs(delta) > 1 ||
+      Math.abs(delta) > Math.abs(previous_delta)) {
+      raise.warning("Unable to adjust the front crotch seam to fit the given measurements, after " + run + " iterations.")
       adjustment_warning = true
     }
   }
@@ -304,9 +306,11 @@ export default (part) => {
       points.waistIn,
       points.crotchSeamCurveStart
     )
+    // If the waist is moved too low, the top of the crotch seam
+    // needs to be lowered to match.
     if (points.styleWaistIn.y > points.crotchSeamCurveStart.y) {
       points.crotchSeamCurveStart = points.styleWaistIn.clone()
-      raise.warning("Forced to shorten front crotch length to accommodate waistband height.")
+      raise.warning("Forced to shorten front crotch length to accommodate waist height.")
       adjustment_warning = true
     }
   } else {
@@ -376,7 +380,7 @@ export default (part) => {
       }
       if (options.fitKnee) {
         if (points.waistOut.x < points.seatOut.x) {
-          let proposed_hipsOut = utils.lineIntersectsCurve(
+          const seamline_outside_hips = utils.lineIntersectsCurve(
             points.hipsOutTarget,
             points.hipsIn.rotate(180, points.hipsOutTarget),
             points.waistOut,
@@ -384,17 +388,18 @@ export default (part) => {
             points.kneeOutCp1,
             points.kneeOut
           )
-          if (proposed_hipsOut) {
-            points.hipsOut = proposed_hipsOut
+          const seamline_inside_hips = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn,
+            points.waistOut,
+            points.seatOut,
+            points.kneeOutCp1,
+            points.kneeOut
+          )
+          if (seamline_outside_hips) {
+            points.hipsOut = seamline_outside_hips
           } else {
-            points.hipsOut = utils.lineIntersectsCurve(
-              points.hipsOutTarget,
-              points.hipsIn,
-              points.waistOut,
-              points.seatOut,
-              points.kneeOutCp1,
-              points.kneeOut
-            )
+            points.hipsOut = seamline_inside_hips
             raise.warning("Unable to draw seamline outside the front outside hip point.")
             adjustment_warning = true
           }
@@ -407,7 +412,7 @@ export default (part) => {
             points.kneeOut
           )
         } else {
-          let proposed_hipsOut = utils.lineIntersectsCurve(
+          const seamline_outside_hips = utils.lineIntersectsCurve(
             points.hipsOutTarget,
             points.hipsIn.rotate(180, points.hipsOutTarget),
             points.waistOut,
@@ -415,17 +420,18 @@ export default (part) => {
             points.seatOutCp1,
             points.seatOut
           )
-          if (proposed_hipsOut) {
-            points.hipsOut = proposed_hipsOut
+          const seamline_inside_hips = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn,
+            points.waistOut,
+            points.waistOut,
+            points.seatOutCp1,
+            points.seatOut
+          )
+          if (seamline_outside_hips) {
+            points.hipsOut = seamline_outside_hips
           } else {
-            points.hipsOut = utils.lineIntersectsCurve(
-              points.hipsOutTarget,
-              points.hipsIn,
-              points.waistOut,
-              points.waistOut,
-              points.seatOutCp1,
-              points.seatOut
-            )
+            points.hipsOut = seamline_inside_hips
             raise.warning("Unable to draw seamline outside the front outside hip point.")
             adjustment_warning = true
           }
@@ -435,7 +441,7 @@ export default (part) => {
         points.kneeInNotch = points.kneeIn
       } else {
         if (points.waistOut.x < points.seatOut.x) {
-          let proposed_hipsOut = utils.lineIntersectsCurve(
+          const seamline_outside_hips = utils.lineIntersectsCurve(
             points.hipsOutTarget,
             points.hipsIn.rotate(180, points.hipsOutTarget),
             points.waistOut,
@@ -443,17 +449,18 @@ export default (part) => {
             points.kneeOutCp1,
             points.floorOut
           )
-          if (proposed_hipsOut) {
-            points.hipsOut = proposed_hipsOut
+          const seamline_inside_hips = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn,
+            points.waistOut,
+            points.seatOut,
+            points.kneeOutCp1,
+            points.floorOut
+          )
+          if (seamline_outside_hips) {
+            points.hipsOut = seamline_outside_hips
           } else {
-            points.hipsOut = utils.lineIntersectsCurve(
-              points.hipsOutTarget,
-              points.hipsIn,
-              points.waistOut,
-              points.seatOut,
-              points.kneeOutCp1,
-              points.floorOut
-            )
+            points.hipsOut = seamline_inside_hips
             raise.warning("Unable to draw seamline outside the front outside hip point.")
             adjustment_warning = true
           }
@@ -474,7 +481,7 @@ export default (part) => {
             points.floorOut
           )
         } else {
-          let proposed_hipsOut = utils.lineIntersectsCurve(
+          const seamline_outside_hips = utils.lineIntersectsCurve(
             points.hipsOutTarget,
             points.hipsIn.rotate(180, points.hipsOutTarget),
             points.waistOut,
@@ -482,17 +489,18 @@ export default (part) => {
             points.seatOutCp1,
             points.seatOut
           )
-          if (proposed_hipsOut) {
-            points.hipsOut = proposed_hipsOut
+          const seamline_inside_hips = utils.lineIntersectsCurve(
+            points.hipsOutTarget,
+            points.hipsIn,
+            points.waistOut,
+            points.waistOut,
+            points.seatOutCp1,
+            points.seatOut
+          )
+          if (seamline_outside_hips) {
+            points.hipsOut = seamline_outside_hips
           } else {
-            points.hipsOut = utils.lineIntersectsCurve(
-              points.hipsOutTarget,
-              points.hipsIn,
-              points.waistOut,
-              points.waistOut,
-              points.seatOutCp1,
-              points.seatOut
-            )
+            points.hipsOut = seamline_inside_hips
             raise.warning("Unable to draw seamline outside the front outside hip point.")
             adjustment_warning = true
           }
@@ -506,7 +514,7 @@ export default (part) => {
             points.floorOut
           )
         }
-        let proposed_kneeInNotch = utils.lineIntersectsCurve(
+        const seamline_outside_knee = utils.lineIntersectsCurve(
           points.kneeIn,
           points.kneeOut.rotate(180, points.kneeIn),
           points.floorIn,
@@ -514,10 +522,7 @@ export default (part) => {
           points.forkCp1,
           points.fork
         )
-        if (proposed_kneeInNotch) {
-          points.kneeInNotch = proposed_kneeInNotch
-        } else {
-          proposed_kneeInNotch = utils.lineIntersectsCurve(
+        const seamline_inside_knee = utils.lineIntersectsCurve(
             points.kneeIn,
             points.kneeOut,
             points.floorIn,
@@ -525,14 +530,15 @@ export default (part) => {
             points.forkCp1,
             points.fork
           )
-          if (proposed_kneeInNotch) {
-            points.kneeInNotch = proposed_kneeInNotch
-            raise.warning("Unable to draw seamline outside the front inside knee point.")
-            adjustment_warning = true
-          } else {
-            raise.warning("Unable to determine proper kneeInNotch location.")
-            adjustment_warning = true
-          }
+        if (seamline_outside_knee) {
+          points.kneeInNotch = seamline_outside_knee
+        } else if (seamline_inside_knee) {
+          points.kneeInNotch = seamline_inside_knee
+          raise.warning("Unable to draw seamline outside the front inside knee point.")
+          adjustment_warning = true
+        } else {
+          raise.warning("Unable to determine proper kneeInNotch location.")
+          adjustment_warning = true
         }
       }
       macro('sprinkle', {


### PR DESCRIPTION
This is a draft PR with changes that I had been working on for Breanna, Bruce, and Titan. I do not wish to put back the changes or do further work until after the switchover to v3 is complete.

- For Breanna, the change prevents spurious Warning messages from being logged when there is no secondary bust dart.
- For Bruce and Titan, we are adding "runaway rotation/shift" protection. Iterative rotations/shifts theoretically make changes that keep getting closer and closer to the target state. However, sometimes they can stop getting closer to the target and instead start to get further and further away. This code change monitors and stops the process if it sees that it has stopped producing better results.
- For Bruce and Titan, new Warning messages have been added to alert the customer when it is known that a non-optimal pattern has been produced, telling them that _"Manual fitting/alteration of the Front pattern piece may be needed."_ and to _"Please recheck your measurements, make a test garment to check fit, and alter if necessary."_
- For Titan, code has been added to produce Warning messages if certain points fall on the other side of knee or hip points. Previously, these unexpected scenarios would cause the pattern to fail with an Error.