### PR TITLE
Fix v3 ForPrinting and ForCutting layouts to use design shortname.

### DIFF
--- a/sites/shared/components/workbench/layout/cut/index.js
+++ b/sites/shared/components/workbench/layout/cut/index.js
@@ -4,11 +4,13 @@ import Settings from './settings'
 const CutLayout = props => {
   const { t } = useTranslation(['workbench'])
 
+  let name = props.design.config.data.name
+  name = name.replace('@freesewing/', '')
   return (
     <div>
       <h2 className="capitalize">
         {
-          t('layoutThing', { thing: props.design.config.data.name })
+          t('layoutThing', { thing: name })
           + ': '
           + t('forCutting')
         }

--- a/sites/shared/components/workbench/layout/print/index.js
+++ b/sites/shared/components/workbench/layout/print/index.js
@@ -44,11 +44,13 @@ const PrintLayout = props => {
     handleExport('pdf', props.gist, props.design, t, props.app, (e) => setError(false), (e) => setError(true))
   }
 
+  let name = props.design.config.data.name
+  name = name.replace('@freesewing/', '')
   return (
     <div>
       <h2 className="capitalize">
         {
-          t('layoutThing', { thing: props.design.config.data.name })
+          t('layoutThing', { thing: name })
           + ': '
           + t('forPrinting')
         }


### PR DESCRIPTION
Before the fix:
![Screen Shot 2022-09-01 at 10 46 56 PM](https://user-images.githubusercontent.com/109869956/188068965-39181b7a-f6f1-4b9d-98c8-44e69da7ee26.png)

After the fix:
![Screen Shot 2022-09-01 at 10 56 33 PM](https://user-images.githubusercontent.com/109869956/188069001-8dfbed3c-3bce-4403-ba48-dea4f4dc3861.png)
