### PR TITLE
Move snapseries to cibuild_step1.

### DIFF
--- a/packages/snapseries/package.json
+++ b/packages/snapseries/package.json
@@ -31,7 +31,7 @@
     "vbuild": "VERBOSE=1 node build.mjs",
     "lab": "cd ../../sites/lab && yarn start",
     "tips": "node ../../scripts/help.mjs",
-    "cibuild_step6": "node build.mjs"
+    "cibuild_step1": "node build.mjs"
   },
   "peerDependencies": {},
   "dependencies": {},


### PR DESCRIPTION
This PR changes the `snapseries` package from cibuild_step6 to cibuild_step1.

We are doing this because Titan depends on `snapseries` during step 3, and the 'yarn cleanall; yarn build` sequence currently fails due to the dependency.
```
lerna ERR! yarn run cibuild_step3 exited 1 in '@freesewing/titan'
...
 ✘ [ERROR] Could not resolve "@freesewing/snapseries"
```

