### PR TITLE
Move snapseries to earlier build order.

### DIFF
--- a/config/build-order.mjs
+++ b/config/build-order.mjs
@@ -6,7 +6,7 @@ import { designs, plugins, packages  } from './software/index.mjs'
  * order. This file takes care of that
  */
 
-const first = [ 'core', 'config-helpers', 'remark-jargon']
+const first = [ 'core', 'config-helpers', 'remark-jargon', 'snapseries' ]
 const blocks = [ 'brian', 'titan', 'bella', 'breanna' ]
 const extended = [ 'bent', 'simon', 'carlton', 'ursula' ]
 const last = ['i18n']


### PR DESCRIPTION
This PR just changes `config/build-order.mjs`. It does not contain any `yarn reconfigure` changes. We'll pick up the rest of the build order changes the next time v3 gets reconfigured and put back.

(But, if you think I should include the workspace reconfigure changes in this PR, please let me know and I will add them.)