### PR TITLE
fix(noble): Add missing "raise" from shorthand.

### DIFF
--- a/designs/noble/src/backpoints.mjs
+++ b/designs/noble/src/backpoints.mjs
@@ -2,7 +2,7 @@ import { back as bellaBack } from '@freesewing/bella'
 import * as options from './options.mjs'
 
 function nobleBackPoints(part) {
-  const { points, Path, paths, options, snippets } = part.shorthand()
+  const { points, Path, paths, options, snippets, raise } = part.shorthand()
 
   // Hide Bella paths
   for (let key of Object.keys(paths)) paths[key].render = false

--- a/designs/noble/src/frontpoints.mjs
+++ b/designs/noble/src/frontpoints.mjs
@@ -2,7 +2,7 @@ import { frontSideDart as bellaFront } from '@freesewing/bella'
 import * as options from './options.mjs'
 
 function nobleFrontPoints(part) {
-  const { points, Path, paths, snippets, options, macro } = part.shorthand()
+  const { points, Path, paths, snippets, options, macro, raise } = part.shorthand()
 
   const bCircle = 0.552284749831
 


### PR DESCRIPTION
These two files use the `raise()` method later in the code, but they never pulled it out of shorthand.