### PR TITLE
Fix typos in documentation and update cutting instruction for Jaeger

### DIFF
--- a/markdown/org/docs/patterns/diana/fabric/en.md
+++ b/markdown/org/docs/patterns/diana/fabric/en.md
@@ -4,5 +4,5 @@ title: "Diana draped top: Fabric Options"
 
 This top works best in one of these two scenarios:
 
-- Use a stretch fabric, and chose minimal ease
+- Use a stretch fabric, and choose minimal ease
 - Or use a non-stretch fabric with good _drape_, in which case you'll want to add more ease. Flowy fabrics can be cut on the bias for a body-hugging effect

--- a/markdown/org/docs/patterns/diana/needs/en.md
+++ b/markdown/org/docs/patterns/diana/needs/en.md
@@ -5,7 +5,7 @@ title: "Diana draped top: What You Need"
 To make Diana, you will need the following:
 
 - [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
-- About 1.5 meters (1.7 yards) (or half of that if it's wide enough to fit the sleeves next tot he body) of a suitable fabric ([see Fabric options](/docs/patterns/diana/fabric))
+- About 1.5 meters (1.7 yards) (or half of that if it's wide enough to fit the sleeves next to the body) of a suitable fabric ([see Fabric options](/docs/patterns/diana/fabric))
 
 <Note>
 

--- a/markdown/org/docs/patterns/jaeger/cutting/en.md
+++ b/markdown/org/docs/patterns/jaeger/cutting/en.md
@@ -27,7 +27,7 @@ title: "Jaeger jacket: Cutting Instructions"
   - Cut **2 fronts** on bias (part 1) Note: Don't include seam allowance
   - Cut **2 chest pieces** on bias. Look for the indication on the front part. Note: Don't include seam allowance
 - **Undercollar fabric**
-  - Cut **1 undercollar** (part 7)
+  - Cut **2 undercollars** (part 7)
 
 <Note>
 

--- a/markdown/org/docs/patterns/jaeger/cutting/en.md
+++ b/markdown/org/docs/patterns/jaeger/cutting/en.md
@@ -20,7 +20,7 @@ title: "Jaeger jacket: Cutting Instructions"
   - Cut **2 sides** (part 3)
   - Cut **2 topsleeves** (part 4) Note: Some people like to use different lining for the sleeves
   - Cut **2 undersleeves** (part 5) Note: Some people like to use different lining for the sleeves
-  - Cut **2 chest pocket bags** )(part 11)
+  - Cut **2 chest pocket bags** (part 11)
   - Cut **2 inner pocket welts**
   - Cut **2 inner pocket bags** (part 13)
 - **Canvas**
@@ -46,7 +46,7 @@ When you cut them individually, remember that they need to be mirror images of e
 
 - The chest piece is marked on the front.
 - Don't include seam allowance when cutting out canvas, and cut it on bias.
-- The front facing and lining is marked on the front piece. They split the front part in two along the boundary line. You can cut the front part along that line after cutting out the front from the main fabric. The inner pocket extension for the facing is printed separately, and you can tape it back in its place after cutting the patern piece. **Do not forget to add seam allowance to both the facing and the lining for this boundary seam**.
+- The front facing and lining is marked on the front piece. They split the front part in two along the boundary line. You can cut the front part along that line after cutting out the front from the main fabric. The inner pocket extension for the facing is printed separately, and you can tape it back in its place after cutting the pattern piece. **Do not forget to add seam allowance to both the facing and the lining for this boundary seam**.
 
 ![Trace the front facing and lining from the front part](cuttingCaveat.svg)
 

--- a/markdown/org/docs/patterns/jaeger/instructions/en.md
+++ b/markdown/org/docs/patterns/jaeger/instructions/en.md
@@ -146,7 +146,7 @@ Cut out the chest canvas piece. Align it along the roll line, and baste it in pl
 
 Now baste the front canvas and chest piece to your front. Keep in mind that the canvas has no seam allowance.
 
-> Base it a bit inwards from the seam line so you can fold it away when sewing these seams later.  
+> Baste it a bit inwards from the seam line so you can fold it away when sewing these seams later.  
 > You don't want your canvas to get caught in the seams.
 
 #### Pad-stitch your lapels

--- a/markdown/org/docs/patterns/jaeger/needs/en.md
+++ b/markdown/org/docs/patterns/jaeger/needs/en.md
@@ -30,7 +30,7 @@ If you know where to get them, great. If not, you can get a **Jacket trim pack**
 It's a shop for professionals (they're not even open on Saturdays) but they don't require you to be a business
 to place an order.
 
-I have no afiliation with these guys, but it's the only place I know of that will sell you a kit of
+I have no affiliation with these guys, but it's the only place I know of that will sell you a kit of
 professional trimmings to make a jacket.
 
 If you know of any other place that carries this stuff, please let us know.

--- a/markdown/org/docs/patterns/jaeger/needs/en.md
+++ b/markdown/org/docs/patterns/jaeger/needs/en.md
@@ -17,7 +17,7 @@ To make Jaeger, you will need the following:
 
 <Note>
 
-\####### Where to get all this stuff
+###### Where to get all this stuff
 
 Making Jaeger is a fun and rewarning project, but getting all the required bits and pieces can be challenging.
 


### PR DESCRIPTION
Fixes multiple minor typos, one markdown issue for a heading and updates the cutting instruction for Jaeger to cut *two* undercollars, not one.