### PR TITLE
fix: wrong option name in octoplushy and typos in noble's options

### DIFF
--- a/packages/i18n/src/locales/en/options/noble.yml
+++ b/packages/i18n/src/locales/en/options/noble.yml
@@ -38,10 +38,10 @@ frontArmholeCurvature:
   title: Front armhole curvature
   description: Controls how deep the armhole is scooped out at the front bottom
 frontArmholePitchDepth:
-  description: Controls how deep the armhole curts into the front
+  description: Controls how deep the armhole cuts into the front
   title: Front armhole pitch depth
 backArmholePitchDepth:
-  description: Controls how deep the armhole curts into the back
+  description: Controls how deep the armhole cuts into the back
   title: Back armhole pitch depth
 backNeckCutout:
   description: Controls how deep the neck is cutout in the back
@@ -53,9 +53,9 @@ frontShoulderWidth:
   description: Controls how much width is added to the shoulder in the front
   title: Front shoulder width
 highBustWidth:
-  description: Controls the widht of the high bust
-  title: Hight bust width
+  description: Controls the width of the high bust
+  title: High bust width
 shoulderToShoulderEase:
-  description: Controls the amount of ease long the shoulder to shoulder measurement
+  description: Controls the amount of ease along the shoulder to shoulder measurement
   title: Shoulder to shoulder ease
 

--- a/packages/i18n/src/locales/en/options/octoplushy.yml
+++ b/packages/i18n/src/locales/en/options/octoplushy.yml
@@ -11,7 +11,7 @@ armWidth:
   description: Controls the width of the arms
 
 armLength:
-  title: Arm width
+  title: Arm length
   description: Controls the length of the arms
 
 neckWidth:


### PR DESCRIPTION
Fix wrong option name in `octoplushy` (was `length`, should be `width`) and typos in options of `noble`.