### PR TITLE
feat: Stack based layouts in core

### DIFF
--- a/packages/core/src/index.mjs
+++ b/packages/core/src/index.mjs
@@ -32,7 +32,7 @@ import {
   rad2deg,
   pctBasedOn,
   Bezier,
-  generatePartTransform,
+  generateStackTransform,
   macroName,
 } from './utils.mjs'
 import { version } from '../data.mjs'
@@ -71,7 +71,7 @@ export {
   deg2rad,
   rad2deg,
   pctBasedOn,
-  generatePartTransform,
+  generateStackTransform,
   macroName,
   isCoord,
   version,

--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -336,15 +336,6 @@ Part.prototype.shorthand = function () {
   return shorthand
 }
 
-Part.prototype.generateTransform = function (transforms) {
-  const { move, rotate, flipX, flipY } = transforms
-  const generated = utils.generatePartTransform(move.x, move.y, rotate, flipX, flipY, this)
-
-  for (var t in generated) {
-    this.attr(t, generated[t], true)
-  }
-}
-
 Part.prototype.isEmpty = function () {
   if (Object.keys(this.snippets).length > 0) return false
 

--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -26,6 +26,7 @@ export function Part() {
   this.points = {}
   this.paths = {}
   this.snippets = {}
+  this.name = null
 
   return this
 }
@@ -121,8 +122,8 @@ Part.prototype.boundary = function () {
   return this
 }
 
-/** Stacks part so that its top left corner is in (0,0) */
-Part.prototype.stack = function () {
+/** Homes part so that its top left corner is in (0,0) */
+Part.prototype.home = function () {
   if (this.topLeft !== false) return this
   else this.boundary()
   if (this.topLeft.x == 0 && this.topLeft.y == 0) return this

--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -111,27 +111,11 @@ Part.prototype.boundary = function () {
   if (topLeft.y === Infinity) topLeft.y = 0
   if (bottomRight.x === -Infinity) bottomRight.x = 0
   if (bottomRight.y === -Infinity) bottomRight.y = 0
-  // Add margin
-  let margin = this.context.settings.margin
-  if (this.context.settings.paperless && margin < 10) margin = 10
-  this.topLeft = new Point(topLeft.x - margin, topLeft.y - margin)
-  this.bottomRight = new Point(bottomRight.x + margin, bottomRight.y + margin)
+
+  this.topLeft = topLeft
+  this.bottomRight = bottomRight
   this.width = this.bottomRight.x - this.topLeft.x
   this.height = this.bottomRight.y - this.topLeft.y
-
-  return this
-}
-
-/** Homes part so that its top left corner is in (0,0) */
-Part.prototype.home = function () {
-  if (this.topLeft !== false) return this
-  else this.boundary()
-  if (this.topLeft.x == 0 && this.topLeft.y == 0) return this
-  else {
-    this.attr('transform', `translate(${this.topLeft.x * -1}, ${this.topLeft.y * -1})`)
-    this.layout.move.x = this.topLeft.x * -1
-    this.layout.move.y = this.topLeft.y * -1
-  }
 
   return this
 }

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -561,9 +561,12 @@ Pattern.prototype.pack = function () {
   // First, create all stacks
   this.stacks = {}
   for (const [name, part] of Object.entries(this.parts)) {
-    if (typeof this.stacks[part.stack] === 'undefined')
-      this.stacks[part.stack] = this.__createStackWithContext(part.stack)
-    this.stacks[part.stack].addPart(part)
+    const stackName = (typeof part.stack === 'function')
+      ? part.stack(this.settings, name)
+      : part.stack
+    if (typeof this.stacks[stackName] === 'undefined')
+      this.stacks[stackName] = this.__createStackWithContext(stackName)
+    this.stacks[stackName].addPart(part)
   }
 
   let bins = []

--- a/packages/core/src/stack.mjs
+++ b/packages/core/src/stack.mjs
@@ -5,16 +5,16 @@ import * as utils from './utils.mjs'
 export function Stack(name = null) {
   // Non-enumerable properties
   utils.addNonEnumProp(this, 'freeId', 0)
-  utils.addNonEnumProp(this, 'topLeft', false)
-  utils.addNonEnumProp(this, 'bottomRight', false)
-  utils.addNonEnumProp(this, 'width', false)
-  utils.addNonEnumProp(this, 'height', false)
   utils.addNonEnumProp(this, 'layout', { move: { x: 0, y: 0 } })
 
   // Enumerable properties
   this.attributes = new Attributes()
   this.parts = new Set()
   this.name = name
+  this.topLeft = false
+  this.bottomRight = false
+  this.width = false
+  this.height = false
 
   return this
 }
@@ -37,24 +37,24 @@ Stack.prototype.getPartNames = function (part) {
 }
 
 /** Homes the stack so that its top left corner is in (0,0) */
-Stack.prototype.home = function () {
-  const parts = this.getPartList()
-  if (parts.length < 1) return this
-  for (const part of this.getPartList()) {
-    part.home()
-  }
-
-  if (parts.length === 1) {
-    this.topLeft = part.topLeft
-    this.bottomRigth = part.bottomRight
-    this.width = part.width
-    this.height = part.height
-
-    return this
-  }
-
-  return this.boundary()
-}
+//Stack.prototype.home = function () {
+//  const parts = this.getPartList()
+//  if (parts.length < 1) return this
+//  for (const part of this.getPartList()) {
+//    part.home()
+//  }
+//
+//  if (parts.length === 1) {
+//    this.topLeft = part.topLeft
+//    this.bottomRigth = part.bottomRight
+//    this.width = part.width
+//    this.height = part.height
+//
+//    return this
+//  }
+//
+//  return this.boundary()
+//}
 
 /** Calculates the stack's bounding box and sets it */
 Stack.prototype.home = function () {
@@ -102,7 +102,7 @@ Stack.prototype.home = function () {
   return this
 }
 
-/** Finds the anchor to aling parts in this stack */
+/** Finds the anchor to align parts in this stack */
 Stack.prototype.getAnchor = function() {
   let anchorPoint = true
   let gridAnchorPoint = true
@@ -125,5 +125,16 @@ Stack.prototype.attr = function (name, value, overwrite = false) {
 
   return this
 }
+
+/** Generates the transform for a stack */
+Stack.prototype.generateTransform = function (transforms) {
+  const { move, rotate, flipX, flipY } = transforms
+  const generated = utils.generateStackTransform(move.x, move.y, rotate, flipX, flipY, this)
+
+  for (var t in generated) {
+    this.attr(t, generated[t], true)
+  }
+}
+
 
 export default Stack

--- a/packages/core/src/stack.mjs
+++ b/packages/core/src/stack.mjs
@@ -1,0 +1,82 @@
+import { Attributes } from './attributes.mjs'
+import { Point } from './point.mjs'
+import * as utils from './utils.mjs'
+
+export function Stack(name=null) {
+  // Non-enumerable properties
+  utils.addNonEnumProp(this, 'freeId', 0)
+  utils.addNonEnumProp(this, 'topLeft', false)
+  utils.addNonEnumProp(this, 'bottomRight', false)
+  utils.addNonEnumProp(this, 'width', false)
+  utils.addNonEnumProp(this, 'height', false)
+  utils.addNonEnumProp(this, 'layout', { move: { x: 0, y: 0 } })
+
+  // Enumerable properties
+  this.attributes = new Attributes()
+  this.parts = new Set()
+  this.name = name
+
+  return this
+}
+
+/* Adds a part to the stack */
+Stack.prototype.addPart = function(part) {
+  if (part) this.parts.add(part)
+
+  return this
+}
+
+/* Returns a list of parts in this stack */
+Stack.prototype.getPartList = function(part) {
+  return [...this.parts]
+}
+
+/* Returns a list of names of parts in this stack */
+Stack.prototype.getPartNames = function(part) {
+  return [...this.parts].map(p => p.name)
+}
+
+/** Homes the stack so that its top left corner is in (0,0) */
+Stack.prototype.home = function () {
+  const parts = this.getPartList()
+  if (parts.length < 1) return this
+  for (const part of this.getPartList()) {
+    part.home()
+  }
+
+  if (parts.length === 1) {
+    this.topLeft = part.topLeft
+    this.bottomRigth = part.bottomRight
+    this.width = part.width
+    this.height = part.height
+
+    return this
+  }
+
+  return this.boundary()
+}
+
+/** Calculates the stack's bounding box and sets it */
+Stack.prototype.home = function () {
+  this.topLeft = new Point(Infinity, Infinity)
+  this.bottomRight = new Point(-Infinity, -Infinity)
+  for (const part of this.getPartList()) {
+    if (part.topLeft.x < this.topLeft.x) this.topLeft.x = part.topLeft.x
+    if (part.topLeft.y < this.topLeft.y) this.topLeft.y = part.topLeft.y
+    if (part.bottomRight.x > this.bottomRight.x) this.bottomRight.x = part.bottomRight.x
+    if (part.bottomRight.y > this.bottomRight.y) this.bottomRight.y = part.bottomRight.y
+  }
+
+  // Fix infinity if it's not overwritten
+  if (this.topLeft.x === Infinity) this.topLeft.x = 0
+  if (this.topLeft.y === Infinity) this.topLeft.y = 0
+  if (this.bottomRight.x === -Infinity) this.bottomRight.x = 0
+  if (this.bottomRight.y === -Infinity) this.bottomRight.y = 0
+
+  this.width = this.bottomRight.x - this.topLeft.x
+  this.height = this.bottomRight.y - this.topLeft.y
+
+  return this
+}
+
+export default Stack

--- a/packages/core/src/store.mjs
+++ b/packages/core/src/store.mjs
@@ -5,12 +5,6 @@ import get from 'lodash.get'
 const avoid = ['set', 'setIfUnset', 'push', 'unset', 'get', 'extend']
 
 export function Store(methods = []) {
-  for (const method of methods) {
-    if (avoid.indexOf(method[0]) !== -1) {
-      console.log(`WARNING: You can't squat ${method[0]}in the store`)
-    } else set(this, ...method)
-  }
-
   /*
    * Default logging methods
    * You can override these with a plugin
@@ -36,6 +30,12 @@ export function Store(methods = []) {
     },
   }
   this.logs = logs
+
+  for (const method of methods) {
+    if (avoid.indexOf(method[0]) !== -1) {
+      this.logs.warning(`You cannot squat ${method[0]} in the store`)
+    } else set(this, ...method)
+  }
 
   return this
 }

--- a/packages/core/src/utils.mjs
+++ b/packages/core/src/utils.mjs
@@ -361,8 +361,8 @@ export function pctBasedOn(measurement) {
   }
 }
 
-/** Generates the transform attributes needed for a given part */
-export const generatePartTransform = (x, y, rotate, flipX, flipY, part) => {
+/** Generates the transform attributes needed for a given stack */
+export const generateStackTransform = (x, y, rotate, flipX, flipY, part) => {
   const transforms = []
   let xTotal = x || 0
   let yTotal = y || 0

--- a/packages/core/tests/part.test.mjs
+++ b/packages/core/tests/part.test.mjs
@@ -195,7 +195,7 @@ describe('Part', () => {
     const design = new Design({ parts: [ part ]})
     const pattern = new design({ paperless: true })
     pattern.draft()
-    pattern.parts.test.stack()
+    pattern.parts.test.home()
     console.log(pattern.parts.test.attributes)
     expect(part.attributes.get('transform')).to.equal('translate(-17, -74)')
   })
@@ -208,9 +208,9 @@ describe('Part', () => {
     part.points.from = new short.Point(2, 2)
     part.points.to = new short.Point(19, 76)
     part.paths.test = new short.Path().move(part.points.from).line(part.points.to)
-    part.stack()
+    part.home()
     expect(part.attributes.get('transform')).to.equal(false)
-    part.stack()
+    part.home()
     expect(part.attributes.get('transform')).to.equal(false)
   })
 */
@@ -252,7 +252,7 @@ describe('Part', () => {
     part.points.from = new short.Point(2, 2)
     part.points.to = new short.Point(19, 76)
     part.paths.test = new short.Path().move(part.points.from).line(part.points.to)
-    part.stack()
+    part.home()
     part.generateTransform({
       move: {
         x: 10,

--- a/packages/core/tests/part.test.mjs
+++ b/packages/core/tests/part.test.mjs
@@ -124,7 +124,7 @@ describe('Part', () => {
     )
   })
 
-  it('Should calculate the part boundary with default margin', () => {
+  it('Should calculate the part boundary', () => {
     const design = new Design()
     const pattern = new design()
     const part = pattern.__createPartWithContext()
@@ -134,52 +134,15 @@ describe('Part', () => {
     part.points.to = new short.Point(19, 76)
     part.paths.test = new short.Path().move(part.points.from).line(part.points.to)
     let boundary = part.boundary()
-    expect(boundary.topLeft.x).to.equal(17)
-    expect(boundary.topLeft.y).to.equal(74)
-    expect(boundary.bottomRight.x).to.equal(125)
-    expect(boundary.bottomRight.y).to.equal(458)
+    expect(boundary.topLeft.x).to.equal(19)
+    expect(boundary.topLeft.y).to.equal(76)
+    expect(boundary.bottomRight.x).to.equal(123)
+    expect(boundary.bottomRight.y).to.equal(456)
     boundary = part.boundary()
-    expect(boundary.width).to.equal(108)
-    expect(boundary.height).to.equal(384)
+    expect(boundary.width).to.equal(104)
+    expect(boundary.height).to.equal(380)
   })
 
-  it('Should calculate the part boundary with custom margin', () => {
-    const design = new Design()
-    const pattern = new design({ margin: 5 })
-    const part = pattern.__createPartWithContext()
-    pattern.init()
-    const short = part.shorthand()
-    part.points.from = new short.Point(123, 456)
-    part.points.to = new short.Point(19, 76)
-    part.paths.test = new short.Path().move(part.points.from).line(part.points.to)
-    let boundary = part.boundary()
-    expect(boundary.topLeft.x).to.equal(14)
-    expect(boundary.topLeft.y).to.equal(71)
-    expect(boundary.bottomRight.x).to.equal(128)
-    expect(boundary.bottomRight.y).to.equal(461)
-    boundary = part.boundary()
-    expect(boundary.width).to.equal(114)
-    expect(boundary.height).to.equal(390)
-  })
-
-  it('Should calculate the part boundary for paperless', () => {
-    const design = new Design()
-    const pattern = new design({ paperless: true })
-    const part = pattern.__createPartWithContext()
-    pattern.init()
-    const short = part.shorthand()
-    part.points.from = new short.Point(123, 456)
-    part.points.to = new short.Point(19, 76)
-    part.paths.test = new short.Path().move(part.points.from).line(part.points.to)
-    let boundary = part.boundary()
-    expect(boundary.topLeft.x).to.equal(9)
-    expect(boundary.topLeft.y).to.equal(66)
-    expect(boundary.bottomRight.x).to.equal(133)
-    expect(boundary.bottomRight.y).to.equal(466)
-    boundary = part.boundary()
-    expect(boundary.width).to.equal(124)
-    expect(boundary.height).to.equal(400)
-  })
   /*
   it('Should stack a part', () => {
     const part = {
@@ -243,25 +206,6 @@ describe('Part', () => {
     )
   })
 
-  it('Should generate the part transforms', () => {
-    const design = new Design()
-    const pattern = new design({ margin: 5 })
-    const part = pattern.__createPartWithContext()
-    pattern.init()
-    let short = part.shorthand()
-    part.points.from = new short.Point(2, 2)
-    part.points.to = new short.Point(19, 76)
-    part.paths.test = new short.Path().move(part.points.from).line(part.points.to)
-    part.home()
-    part.generateTransform({
-      move: {
-        x: 10,
-        y: 20,
-      },
-    })
-    expect(part.attributes.list.transform.length).to.equal(1)
-    expect(part.attributes.list.transform[0]).to.equal('translate(10 20)')
-  })
   describe('isEmpty', () => {
     it('Should return true if the part has no paths or snippets', () => {
       const design = new Design()

--- a/packages/core/tests/pattern-init.test.mjs
+++ b/packages/core/tests/pattern-init.test.mjs
@@ -18,7 +18,7 @@ describe('Pattern', () => {
       expect(typeof pattern.config).to.equal('object')
       expect(typeof pattern.parts).to.equal('object')
       expect(typeof pattern.store).to.equal('object')
-      expect(Object.keys(pattern).length).to.equal(4)
+      expect(Object.keys(pattern).length).to.equal(5)
     })
 
     it('Pattern constructor should add non-enumerable properties', () => {

--- a/packages/core/tests/stacks.test.mjs
+++ b/packages/core/tests/stacks.test.mjs
@@ -68,10 +68,8 @@ describe('Stacks', () => {
       },
     })
     pattern.draft()
-    console.log(pattern.store.logs)
     //console.log(pattern.parts)
     //pattern.render()
-    console.log(pattern.render())
 
     it('Pattern.init() should resolve dependencies', () => {
       expect(typeof pattern.config.resolvedDependencies).to.equal('object')
@@ -89,5 +87,92 @@ describe('Stacks', () => {
         pattern.config.resolvedDependencies['test.partC'].indexOf('test.partB') !== -1
       ).to.equal(true)
     })
+
+
+  it('Should calculate the part boundary', () => {
+    const part = {
+      name: 'test',
+      draft: ({points, Point, paths, Path, part }) => {
+        points.from = new Point(123, 456)
+        points.to = new Point(19, 76)
+        paths.test = new Path().move(points.from).line(points.to)
+
+        return part
+      }
+    }
+    const design = new Design({ parts: [ part ]})
+    const pattern = new design()
+    pattern.draft().render()
+    expect(pattern.stacks.test.topLeft.x).to.equal(17)
+    expect(pattern.stacks.test.topLeft.y).to.equal(74)
+    expect(pattern.stacks.test.bottomRight.x).to.equal(125)
+    expect(pattern.stacks.test.bottomRight.y).to.equal(458)
+    expect(pattern.stacks.test.width).to.equal(108)
+    expect(pattern.stacks.test.height).to.equal(384)
+  })
+
+  it('Should calculate the part boundary with custom margin', () => {
+    const part = {
+      name: 'test',
+      draft: ({points, Point, paths, Path, part }) => {
+        points.from = new Point(123, 456)
+        points.to = new Point(19, 76)
+        paths.test = new Path().move(points.from).line(points.to)
+
+        return part
+      }
+    }
+    const design = new Design({ parts: [ part ]})
+    const pattern = new design({ margin: 5 })
+    pattern.draft().render()
+    expect(pattern.stacks.test.topLeft.x).to.equal(14)
+    expect(pattern.stacks.test.topLeft.y).to.equal(71)
+    expect(pattern.stacks.test.bottomRight.x).to.equal(128)
+    expect(pattern.stacks.test.bottomRight.y).to.equal(461)
+    expect(pattern.stacks.test.width).to.equal(114)
+    expect(pattern.stacks.test.height).to.equal(390)
+  })
+
+  it('Should calculate the part boundary for paperless', () => {
+    const part = {
+      name: 'test',
+      draft: ({points, Point, paths, Path, part }) => {
+        points.from = new Point(123, 456)
+        points.to = new Point(19, 76)
+        paths.test = new Path().move(points.from).line(points.to)
+
+        return part
+      }
+    }
+    const design = new Design({ parts: [ part ]})
+    const pattern = new design({ paperless: true })
+    pattern.draft().render()
+    expect(pattern.stacks.test.topLeft.x).to.equal(9)
+    expect(pattern.stacks.test.topLeft.y).to.equal(66)
+  })
+  it('Should generate the part transforms', () => {
+    const part = {
+      name: 'test',
+      draft: ({points, Point, paths, Path, part }) => {
+        points.from = new Point(2, 2)
+        points.to = new Point(19, 76)
+        paths.test = new Path().move(points.from).line(points.to)
+
+        return part
+      }
+    }
+    const design = new Design({ parts: [ part ] })
+    const pattern = new design()
+    pattern.draft().render()
+    pattern.stacks.test.generateTransform({
+      move: {
+        x: 10,
+        y: 20,
+      },
+    })
+    expect(pattern.stacks.test.attributes.list.transform.length).to.equal(1)
+    expect(pattern.stacks.test.attributes.list.transform[0]).to.equal('translate(10 20)')
+  })
+
   })
 })

--- a/packages/core/tests/stacks.test.mjs
+++ b/packages/core/tests/stacks.test.mjs
@@ -4,7 +4,6 @@ import { round, Design, Point, pctBasedOn } from '../src/index.mjs'
 const expect = chai.expect
 
 describe('Stacks', () => {
-
   describe('Pattern.init()', () => {
     const partA = {
       name: 'test.partA',
@@ -12,9 +11,9 @@ describe('Stacks', () => {
       options: {
         size: { pct: 40, min: 20, max: 80 },
       },
-      draft: ({ points, Point, paths, Path, part, store, measurements, options}) => {
+      draft: ({ points, Point, paths, Path, part, store, measurements, options }) => {
         store.set('size', measurements.head * options.size)
-        points.from = new Point(0,0)
+        points.from = new Point(0, 0)
         points.to = new Point(0, store.get('size'))
         paths.line = new Path().move(points.from).line(points.to)
         return part
@@ -25,8 +24,8 @@ describe('Stacks', () => {
       name: 'test.partB',
       measurements: ['head'],
       after: partA,
-      draft: ({ points, Point, paths, Path, part, store}) => {
-        points.from = new Point(0,store.get('size'))
+      draft: ({ points, Point, paths, Path, part, store }) => {
+        points.from = new Point(0, store.get('size'))
         points.to = new Point(store.get('size'), store.get('size'))
         paths.line = new Path().move(points.from).line(points.to)
         return part
@@ -36,7 +35,7 @@ describe('Stacks', () => {
     const partC = {
       name: 'test.partC',
       after: partB,
-      draft: ({ points, Point, paths, Path, part, store}) => {
+      draft: ({ points, Point, paths, Path, part, store }) => {
         points.from = new Point(store.get('size'), store.get('size'))
         points.to = new Point(store.get('size'), 0)
         paths.line = new Path().move(points.from).line(points.to)
@@ -47,13 +46,13 @@ describe('Stacks', () => {
     const partD = {
       name: 'test.partD',
       after: partC,
-      draft: ({ points, Point, paths, Path, part, store}) => {
+      draft: ({ points, Point, paths, Path, part, store }) => {
         points.from = new Point(store.get('size'), 0)
         points.to = new Point(0, 0)
         paths.line = new Path().move(points.from).line(points.to)
         return part
       },
-    //  stack: 'box',
+      //  stack: 'box',
     }
 
     const Pattern = new Design({
@@ -65,8 +64,8 @@ describe('Stacks', () => {
     })
     const pattern = new Pattern({
       measurements: {
-        head: 400
-      }
+        head: 400,
+      },
     })
     pattern.draft()
     console.log(pattern.store.logs)
@@ -90,6 +89,5 @@ describe('Stacks', () => {
         pattern.config.resolvedDependencies['test.partC'].indexOf('test.partB') !== -1
       ).to.equal(true)
     })
-
   })
 })

--- a/packages/core/tests/stacks.test.mjs
+++ b/packages/core/tests/stacks.test.mjs
@@ -1,0 +1,95 @@
+import chai from 'chai'
+import { round, Design, Point, pctBasedOn } from '../src/index.mjs'
+
+const expect = chai.expect
+
+describe('Stacks', () => {
+
+  describe('Pattern.init()', () => {
+    const partA = {
+      name: 'test.partA',
+      measurements: ['head'],
+      options: {
+        size: { pct: 40, min: 20, max: 80 },
+      },
+      draft: ({ points, Point, paths, Path, part, store, measurements, options}) => {
+        store.set('size', measurements.head * options.size)
+        points.from = new Point(0,0)
+        points.to = new Point(0, store.get('size'))
+        paths.line = new Path().move(points.from).line(points.to)
+        return part
+      },
+      stack: 'box',
+    }
+    const partB = {
+      name: 'test.partB',
+      measurements: ['head'],
+      after: partA,
+      draft: ({ points, Point, paths, Path, part, store}) => {
+        points.from = new Point(0,store.get('size'))
+        points.to = new Point(store.get('size'), store.get('size'))
+        paths.line = new Path().move(points.from).line(points.to)
+        return part
+      },
+      stack: 'box',
+    }
+    const partC = {
+      name: 'test.partC',
+      after: partB,
+      draft: ({ points, Point, paths, Path, part, store}) => {
+        points.from = new Point(store.get('size'), store.get('size'))
+        points.to = new Point(store.get('size'), 0)
+        paths.line = new Path().move(points.from).line(points.to)
+        return part
+      },
+      stack: 'box',
+    }
+    const partD = {
+      name: 'test.partD',
+      after: partC,
+      draft: ({ points, Point, paths, Path, part, store}) => {
+        points.from = new Point(store.get('size'), 0)
+        points.to = new Point(0, 0)
+        paths.line = new Path().move(points.from).line(points.to)
+        return part
+      },
+    //  stack: 'box',
+    }
+
+    const Pattern = new Design({
+      data: {
+        name: 'test',
+        version: '1.2.3',
+      },
+      parts: [partD],
+    })
+    const pattern = new Pattern({
+      measurements: {
+        head: 400
+      }
+    })
+    pattern.draft()
+    console.log(pattern.store.logs)
+    //console.log(pattern.parts)
+    //pattern.render()
+    console.log(pattern.render())
+
+    it('Pattern.init() should resolve dependencies', () => {
+      expect(typeof pattern.config.resolvedDependencies).to.equal('object')
+      expect(Array.isArray(pattern.config.resolvedDependencies['test.partA'])).to.equal(true)
+      expect(pattern.config.resolvedDependencies['test.partA'].length).to.equal(0)
+      expect(Array.isArray(pattern.config.resolvedDependencies['test.partB'])).to.equal(true)
+      expect(pattern.config.resolvedDependencies['test.partB'].length).to.equal(1)
+      expect(pattern.config.resolvedDependencies['test.partB'][0]).to.equal('test.partA')
+      expect(Array.isArray(pattern.config.resolvedDependencies['test.partC'])).to.equal(true)
+      expect(pattern.config.resolvedDependencies['test.partC'].length).to.equal(2)
+      expect(
+        pattern.config.resolvedDependencies['test.partC'].indexOf('test.partA') !== -1
+      ).to.equal(true)
+      expect(
+        pattern.config.resolvedDependencies['test.partC'].indexOf('test.partB') !== -1
+      ).to.equal(true)
+    })
+
+  })
+})

--- a/packages/core/tests/utils.test.mjs
+++ b/packages/core/tests/utils.test.mjs
@@ -28,7 +28,7 @@ import {
   rad2deg,
   pctBasedOn,
   Bezier,
-  generatePartTransform,
+  generateStackTransform,
   macroName,
   Design,
 } from '../src/index.mjs'

--- a/sites/shared/components/workbench/draft/index.js
+++ b/sites/shared/components/workbench/draft/index.js
@@ -27,7 +27,7 @@ const LabDraft = props => {
 
   return (
     <>
-      {(!patternProps || patternProps.events?.error?.length > 0)
+      {(!patternProps || patternProps.logs?.error?.length > 0)
         ? <Error {...{ draft, patternProps, updateGist }} />
         : null
       }

--- a/sites/shared/components/workbench/draft/stack.js
+++ b/sites/shared/components/workbench/draft/stack.js
@@ -1,0 +1,20 @@
+import Part from './part'
+import { getProps } from './utils'
+
+const Stack = props => {
+  const { stackName, stack, patternProps, gist, app, updateGist, unsetGist, showInfo } = props
+
+  return (
+    <g {...getProps(stack)} id={`stack-${stackName}`}>
+      {[...stack.parts].map((part) => (
+        <Part {...{ app, gist, updateGist, unsetGist, showInfo }}
+          key={part.name}
+          partName={part.name}
+          part={part}
+        />
+      ))}
+    </g>
+  )
+}
+
+export default Stack

--- a/sites/shared/components/workbench/draft/svg-wrapper.js
+++ b/sites/shared/components/workbench/draft/svg-wrapper.js
@@ -2,7 +2,7 @@ import { SizeMe } from 'react-sizeme'
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch"
 import Svg from './svg'
 import Defs from './defs'
-import Part from './part'
+import Stack from './stack'
 
 /* What's with all the wrapping?
  *
@@ -40,11 +40,11 @@ const SvgWrapper = props => {
             <Defs {...patternProps} />
             <style>{`:root { --pattern-scale: ${gist.scale || 1}} ${patternProps.svg.style}`}</style>
             <g>
-              {Object.keys(patternProps.parts).map((name) => (
-                <Part {...{ app, gist, updateGist, unsetGist, showInfo }}
-                  key={name}
-                  partName={name}
-                  part={patternProps.parts[name]}
+              {Object.keys(patternProps.stacks).map((stackName) => (
+                <Stack {...{ app, gist, updateGist, unsetGist, showInfo, patternProps }}
+                  key={stackName}
+                  stackName={stackName}
+                  stack={patternProps.stacks[stackName]}
                 />
               ))}
             </g>


### PR DESCRIPTION
This moves from `part` to `stack` as the basic building block for layouts. A `stack` will typically contain just 1 part and thus be a mere wrapper. But a `stack` can contain multiple parts that will be anchored relatively to each other (aka use the same coordinate space) yet from a layout perspective, they will be one block.

In practical terms, things like `width`, `height`, `topLeft`, and `bottomRight` will be set on the `stack`, not the `part`.
The relevant methods have also been renamed so `utils.generateStackTransforms` instead of `utils.generatePartTransforms`.