### PR TITLE
v2 - fix(holmes) Holmes adds stores.

### DIFF
--- a/designs/holmes/config/index.js
+++ b/designs/holmes/config/index.js
@@ -24,10 +24,13 @@ export default {
     advanced: ['visorLength'],
   },
   measurements: ['head'],
-  dependencies: {},
+  dependencies: {
+    ear: 'gore',
+    visor: 'gore',
+  },
   inject: {},
   hide: [],
-  parts: ['gore', 'visor', 'ear'],
+  parts: ['gore'],
   options: {
     headEase: {
       pct: 3,

--- a/designs/holmes/src/ear.js
+++ b/designs/holmes/src/ear.js
@@ -17,9 +17,9 @@ export default function (part) {
   } = part.shorthand()
 
   // Design pattern here
-  let headCircumference = store.get('headCircumference')
+  let circumference = store.get('circumference')
   let earFlapLength = store.get('goreLength') * options.earLength
-  let earFlapWidth = (headCircumference / 12) * options.earWidth
+  let earFlapWidth = (circumference / 12) * options.earWidth
   points.top = new Point(0, 0)
   points.bottom = new Point(earFlapWidth, earFlapLength)
   points.topC = points.top.shift(0, points.bottom.x)
@@ -43,7 +43,7 @@ export default function (part) {
     macro('title', { at: points.title, nr: 3, title: 'ear flap', scale: 0.5 })
     macro('miniscale', { at: new Point(0, points.bottom.y * 0.3) })
     if (options.buttonhole) {
-      let buttonholeDistance = (options.lengthRatio * headCircumference) / 2
+      let buttonholeDistance = (options.lengthRatio * circumference) / 2
       points.buttonhole = new Point(points.top.x, points.bottom.y - buttonholeDistance)
       snippets.buttonhole = new Snippet('buttonhole-start', points.buttonhole).attr('data-scale', 2)
     }

--- a/designs/holmes/src/ear.js
+++ b/designs/holmes/src/ear.js
@@ -43,7 +43,7 @@ export default function (part) {
     macro('title', { at: points.title, nr: 3, title: 'ear flap', scale: 0.5 })
     macro('miniscale', { at: new Point(0, points.bottom.y * 0.3) })
     if (options.buttonhole) {
-      let buttonholeDistance = (options.lengthRatio * circumference) / 2
+      let buttonholeDistance = store.get('goreLength')
       points.buttonhole = new Point(points.top.x, points.bottom.y - buttonholeDistance)
       snippets.buttonhole = new Snippet('buttonhole-start', points.buttonhole).attr('data-scale', 2)
     }

--- a/designs/holmes/src/ear.js
+++ b/designs/holmes/src/ear.js
@@ -45,7 +45,7 @@ export default function (part) {
     if (options.buttonhole) {
       let buttonholeDistance = store.get('goreLength')
       points.buttonhole = new Point(points.top.x, points.bottom.y - buttonholeDistance)
-      snippets.buttonhole = new Snippet('buttonhole-start', points.buttonhole).attr('data-scale', 2)
+      snippets.buttonhole = new Snippet('buttonhole', points.buttonhole).attr('data-scale', 2)
     }
     if (sa) {
       paths.sa = paths.saBase

--- a/designs/holmes/src/ear.js
+++ b/designs/holmes/src/ear.js
@@ -4,7 +4,6 @@ export default function (part) {
     points,
     Path,
     paths,
-    measurements,
     options,
     complete,
     sa,
@@ -12,7 +11,6 @@ export default function (part) {
     Snippet,
     paperless,
     macro,
-    absoluteOptions,
     store,
   } = part.shorthand()
 

--- a/designs/holmes/src/ear.js
+++ b/designs/holmes/src/ear.js
@@ -13,11 +13,12 @@ export default function (part) {
     paperless,
     macro,
     absoluteOptions,
+    store,
   } = part.shorthand()
 
   // Design pattern here
-  let headCircumference = measurements.head + absoluteOptions.headEase
-  let earFlapLength = ((options.lengthRatio * headCircumference) / 2) * options.earLength
+  let headCircumference = store.get('headCircumference')
+  let earFlapLength = store.get('goreLength') * options.earLength
   let earFlapWidth = (headCircumference / 12) * options.earWidth
   points.top = new Point(0, 0)
   points.bottom = new Point(earFlapWidth, earFlapLength)
@@ -30,9 +31,8 @@ export default function (part) {
     .move(points.bottom)
     .curve(points.bottomC, points.topC, points.top)
     .curve(points.topCFlipped, points.bottomCFlipped, points.bottomFlipped)
-	.setRender(false)
-  paths.hemBase = new Path().move(points.bottomFlipped).line(points.bottom)
-  .setRender(false)
+    .setRender(false)
+  paths.hemBase = new Path().move(points.bottomFlipped).line(points.bottom).setRender(false)
   paths.seam = paths.saBase.join(paths.hemBase).close()
   // Complete?
   if (complete) {

--- a/designs/holmes/src/gore.js
+++ b/designs/holmes/src/gore.js
@@ -11,6 +11,7 @@ export default function (part) {
     sa,
     paperless,
     absoluteOptions,
+    store,
   } = part.shorthand()
 
   // Design pattern here
@@ -32,6 +33,9 @@ export default function (part) {
 
   // Complete?
   if (complete) {
+    store.set('headCircumference', points.gore_p3.dist(points.p0) * 2 * options.gores)
+    store.set('goreLength', points.p0.dist(points.gore_p1))
+
     points.title = new Point(points.gore_p1.x / 10, points.gore_p2.y / 1.8)
     macro('title', { at: points.title, nr: 1, title: 'crown', scale: 0.5 })
 

--- a/designs/holmes/src/gore.js
+++ b/designs/holmes/src/gore.js
@@ -33,7 +33,7 @@ export default function (part) {
 
   // Complete?
   if (complete) {
-    store.set('headCircumference', points.gore_p3.dist(points.p0) * 2 * options.gores)
+    store.set('circumference', points.gore_p3.dist(points.p0) * 2 * options.gores)
     store.set('goreLength', points.p0.dist(points.gore_p1))
 
     points.title = new Point(points.gore_p1.x / 10, points.gore_p2.y / 1.8)

--- a/designs/holmes/src/gore.js
+++ b/designs/holmes/src/gore.js
@@ -30,12 +30,11 @@ export default function (part) {
     prefix: 'gore_',
     render: true,
   })
-
-  // Complete?
-  if (complete) {
+  
     store.set('circumference', points.gore_p3.dist(points.p0) * 2 * options.gores)
     store.set('goreLength', points.p0.dist(points.gore_p1))
-
+  // Complete?
+  if (complete) {
     points.title = new Point(points.gore_p1.x / 10, points.gore_p2.y / 1.8)
     macro('title', { at: points.title, nr: 1, title: 'crown', scale: 0.5 })
 

--- a/designs/holmes/src/visor.js
+++ b/designs/holmes/src/visor.js
@@ -4,7 +4,6 @@ export default function (part) {
     points,
     Path,
     paths,
-    measurements,
     options,
     complete,
     sa,

--- a/designs/holmes/src/visor.js
+++ b/designs/holmes/src/visor.js
@@ -29,9 +29,9 @@ export default function (part) {
     2 * visorRadius * Math.sin(visorSectorAngle / 2)
   )
   //test circle
-  //points.circleCentre = points.in1.shift(90,headRadius)
-  //.attr("data-circle",headRadius)
-  //points.circle60 = points.circleCentre.shift(-30,headRadius)
+  //points.circleCentre = points.in1.shift(90, radius)
+  //.attr("data-circle", radius)
+  //points.circle60 = points.circleCentre.shift(-30, radius)
   //
   points.in1C = points.in1.shift(0, cpDistance)
   points.in2C = points.in2.shift(180 + (180 / Math.PI) * visorSectorAngle, cpDistance)

--- a/designs/holmes/src/visor.js
+++ b/designs/holmes/src/visor.js
@@ -14,11 +14,11 @@ export default function (part) {
     store,
   } = part.shorthand()
 
-  let headCircumference = store.get('headCircumference')
-  let headRadius = headCircumference / 2 / Math.PI
-  let visorRadius = headRadius / Math.sin((options.visorAngle * Math.PI) / 180)
+  let circumference = store.get('circumference')
+  let radius = circumference / 2 / Math.PI
+  let visorRadius = radius / Math.sin((options.visorAngle * Math.PI) / 180)
   let sectorAngle = (Math.PI / 3) * options.visorLength
-  let visorSectorAngle = (sectorAngle * headRadius) / visorRadius
+  let visorSectorAngle = (sectorAngle * radius) / visorRadius
   let cpDistance =
     ((4 / 3) * visorRadius * (1 - Math.cos(visorSectorAngle / 2))) / Math.sin(visorSectorAngle / 2)
 

--- a/designs/holmes/src/visor.js
+++ b/designs/holmes/src/visor.js
@@ -11,9 +11,10 @@ export default function (part) {
     paperless,
     macro,
     absoluteOptions,
+    store,
   } = part.shorthand()
 
-  let headCircumference = measurements.head + absoluteOptions.headEase
+  let headCircumference = store.get('headCircumference')
   let headRadius = headCircumference / 2 / Math.PI
   let visorRadius = headRadius / Math.sin((options.visorAngle * Math.PI) / 180)
   let sectorAngle = (Math.PI / 3) * options.visorLength
@@ -46,34 +47,35 @@ export default function (part) {
   )
   points.ex1CFlipped = points.ex1C.flipX()
   points.ex2CFlipped = points.ex2C.flipX()
-  
-paths.saInner = new Path ()
-.move(points.in2)
-.curve(points.in2C, points.in1C, points.in1)
-.curve(points.in1CFlipped, points.in2CFlipped, points.in2Flipped)
-.setRender(false)
-  
-paths.saOuter = new Path()
-.move(points.in2Flipped)
-.curve(points.ex2CFlipped, points.ex1CFlipped, points.ex1)
-.curve(points.ex1C, points.ex2C, points.in2)
-.setRender(false)
-  
-paths.seam = paths.saOuter.join(paths.saInner).close()
+
+  paths.saInner = new Path()
+    .move(points.in2)
+    .curve(points.in2C, points.in1C, points.in1)
+    .curve(points.in1CFlipped, points.in2CFlipped, points.in2Flipped)
+    .setRender(false)
+
+  paths.saOuter = new Path()
+    .move(points.in2Flipped)
+    .curve(points.ex2CFlipped, points.ex1CFlipped, points.ex1)
+    .curve(points.ex1C, points.ex2C, points.in2)
+    .setRender(false)
+
+  paths.seam = paths.saOuter.join(paths.saInner).close()
   // Complete?
   if (complete) {
     macro('grainline', { from: points.in1, to: points.ex1 })
     macro('title', { at: points.ex1.shift(45, 20), nr: 2, title: 'visor', scale: 0.4 })
 
     if (sa) {
-	points.sa1 = new Point(points.in2.x + sa, paths.saInner.offset(sa*2).start().y)
-	points.sa2 = points.sa1.flipX(points.in1)
-	paths.sa = paths.saOuter.offset(sa)
-	.line(points.sa1)
-	.join(paths	.saInner.offset(sa * 2))
-	.line(points.sa2)
-	.close()
-	.attr('class', 'fabric sa')
+      points.sa1 = new Point(points.in2.x + sa, paths.saInner.offset(sa * 2).start().y)
+      points.sa2 = points.sa1.flipX(points.in1)
+      paths.sa = paths.saOuter
+        .offset(sa)
+        .line(points.sa1)
+        .join(paths.saInner.offset(sa * 2))
+        .line(points.sa2)
+        .close()
+        .attr('class', 'fabric sa')
     }
 
     // Paperless?


### PR DESCRIPTION
Problem:
gore Plugin reduces the circumference of the hat when below 50% meaning that the headCircumference used for the ear flaps and  visor are inaccuarate to the circumference of the crown. This also applies to the length of the ear flaps.

Solution:
Store the measures needed for the ear flaps and visor.

Additions
- added `store.set('circumference')` to holmes/gores.js
- added `store.set('goreLength')` to holmes/gores.js

Changes
- changed 'headCircumference' to 'circumference' and `store.get('circumference')` for holmes/ears.js
- changed 'earFlapLength' value to use `store.get('goreLength')` for holmes/ears.js
- changed 'buttonholeDistance' value to use `store.get('goreLength')` for holmes/ears.js
- changed 'headCircumference' to 'circumference' and `store.get('circumference')` for holmes/visor.js
- changed 'headRadius' to 'radius' for holmes/visor.js

I am sorry this is in v2 and not in v3. I am still having trouble grasping v3 atm but I thought If I could at least get the v2 fix on paper someone else can port this fix to v3.

Edit: Had to rollback a change and in doing so went one commit too far back, fixed now.