### PR TITLE
chore(v2): Run the test and CodeQL workflows on `v2`, not just on `develop`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,20 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop ]
+    branches:
+    - develop
+    - v2
+    paths:
+    - '**'
+    - '!**/*.md'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop ]
+    branches:
+    - develop
+    - v2
+    paths:
+    - '**'
+    - '!**/*.md'
   schedule:
     - cron: '45 1 * * 6'
 

--- a/.github/workflows/tests.all.yml
+++ b/.github/workflows/tests.all.yml
@@ -4,15 +4,17 @@ on:
   push:
     branches:
       - develop
+      - v2
     paths:
       - '**'
-      - '!**/README.md'
+      - '!**/*.md'
   pull_request:
     branches:
       - develop
+      - v2
     paths:
       - '**'
-      - '!**/README.md'
+      - '!**/*.md'
 
 jobs:
   test:


### PR DESCRIPTION
I assume we want some form of CI on the `v2` branch; currently there's none configured in .github/workflows, either on `v2` or on `develop`. This change would be made in both branches.

Technically, we could bifurcate the workflow configuration files such that configs in the `v2` branch target `v2` and configs in the `develop` branch target `develop`; but I think it's safer to have complete configuration files that can be synced from one branch to another.