### PR TITLE
[Fix] [Bug] Measurement Inputs Not Showing

### DIFF
--- a/sites/shared/components/workbench/measurements/index.js
+++ b/sites/shared/components/workbench/measurements/index.js
@@ -1,13 +1,12 @@
-import React, {useMemo, useEffect, useState} from 'react'
+import React, { useMemo, useEffect, useState } from 'react'
 import MeasurementInput from '../inputs/measurement.js'
 import { adult, doll, giant } from '@freesewing/models'
 import WomenswearIcon from 'shared/components/icons/womenswear.js'
 import MenswearIcon from 'shared/components/icons/menswear.js'
 import { useTranslation } from 'next-i18next'
-import Setting from '../menu/core-settings/setting';
-import {settings} from '../menu/core-settings/index';
+import Setting from '../menu/core-settings/setting'
+import { settings } from '../menu/core-settings/index'
 import { Tab, Tabs } from 'shared/components/mdx/tabs.js'
-
 
 const groups = { adult, doll, giant }
 
@@ -16,12 +15,11 @@ const icons = {
   cisMale: <MenswearIcon />,
 }
 
-
 const WorkbenchMeasurements = ({ app, design, gist, updateGist, gistReady }) => {
   const { t } = useTranslation(['app', 'cfp'])
 
   // Method to handle measurement updates
-  const updateMeasurements = (value, m=false) => {
+  const updateMeasurements = (value, m = false) => {
     if (m === false) {
       // Set all measurements
       updateGist('measurements', value)
@@ -34,11 +32,13 @@ const WorkbenchMeasurements = ({ app, design, gist, updateGist, gistReady }) => 
   const [firstInvalid, setFirstInvalid] = useState(undefined)
 
   useEffect(() => {
-    if (!gistReady) { return }
+    if (!gistReady) {
+      return
+    }
     for (const m of design.config?.measurements || []) {
       if (!gist?.measurements?.[m]) {
-        setFirstInvalid(m);
-        return;
+        setFirstInvalid(m)
+        return
       }
 
       setFirstInvalid(undefined)
@@ -52,15 +52,13 @@ const WorkbenchMeasurements = ({ app, design, gist, updateGist, gistReady }) => 
   return (
     <div className="m-auto max-w-2xl">
       <h1>
-        <span className='capitalize mr-4 opacity-70'>
-          {shortname}:
-        </span> {t('measurements')}
+        <span className="capitalize mr-4 opacity-70">{shortname}:</span> {t('measurements')}
       </h1>
       <h2>{t('cfp:preloadMeasurements')}</h2>
       <Tabs tabs="Adults, Dolls, Giants">
-        {Object.keys(groups).map(group => (
+        {Object.keys(groups).map((group) => (
           <Tab tabId={group} key={group}>
-            {Object.keys(icons).map(type => (
+            {Object.keys(icons).map((type) => (
               <React.Fragment key={type}>
                 <h4 className="mt-4">{t(type)}</h4>
                 <ul className="flex flex-row flex-wrap gap-2">
@@ -71,10 +69,7 @@ const WorkbenchMeasurements = ({ app, design, gist, updateGist, gistReady }) => 
                         onClick={() => updateMeasurements(groups[group][type][m], false)}
                       >
                         {icons[type]}
-                        { group === 'adult'
-                          ? `${t('size')} ${m}`
-                          : `${m}%`
-                        }
+                        {group === 'adult' ? `${t('size')} ${m}` : `${m}%`}
                       </button>
                     </li>
                   ))}
@@ -87,28 +82,32 @@ const WorkbenchMeasurements = ({ app, design, gist, updateGist, gistReady }) => 
 
       <h2 className="mt-8">{t('cfp:enterMeasurements')}</h2>
       <div className="my-2 border p-4 rounded-lg shadow bg-base-200">
-        <Setting key={'units'} setting={'units'} config={settings.units} updateGist={updateGist} {...inputProps} />
+        <Setting
+          key={'units'}
+          setting={'units'}
+          config={settings.units}
+          updateGist={updateGist}
+          {...inputProps}
+        />
       </div>
-        {design.config.measurements && (
-          <>
-            <h3>{t('requiredMeasurements')}</h3>
-            {design.config.measurements.map(m => (
-              <MeasurementInput key={m} m={m} focus={m == firstInvalid} {...inputProps} />
-            ))}
-          </>
-        )}
-        {design.config.optionalMeasurements && (
-          <>
-            <h3>{t('optionalMeasurements')}</h3>
-            {design.config.optionalMeasurements.map(m => (
-              <MeasurementInput key={m} m={m} {...inputProps} />
-            ))}
-          </>
-        )}
-
+      {design.config.measurements && (
+        <>
+          <h3>{t('requiredMeasurements')}</h3>
+          {design.config.measurements.map((m) => (
+            <MeasurementInput key={m} m={m} focus={m == firstInvalid} {...inputProps} />
+          ))}
+        </>
+      )}
+      {design.config.optionalMeasurements.length > 0 && (
+        <>
+          <h3>{t('optionalMeasurements')}</h3>
+          {design.config.optionalMeasurements.map((m) => (
+            <MeasurementInput key={m} m={m} {...inputProps} />
+          ))}
+        </>
+      )}
     </div>
   )
 }
 
 export default WorkbenchMeasurements
-

--- a/sites/shared/components/wrappers/workbench.js
+++ b/sites/shared/components/wrappers/workbench.js
@@ -130,6 +130,11 @@ const WorkbenchWrapper = ({ app, design, preload = false, from = false, layout =
       console.log('Failed to draft design', error)
       return <DraftError error={error} app={app} draft={draft} at={'draft'} />
     }
+  } else {
+    // for non-drafting views, we still need a properly populated config, so we initialize a pattern from the gist.
+    // Because pattern.config === design.config, this will allow calls for design.config to work
+    let pattern = new design(gist)
+    pattern.__init()
   }
 
   // Props to pass down


### PR DESCRIPTION
The issue: 

1. Measurement inputs don't show
2. The title for Optional Measurements always shows even if the pattern doesn't required any

Steps to reproduce:

1. Go to the measurements view on any pattern
2. If the measurement inputs are showing, refresh the page
3. measurement inputs will not show

The fix:
Because measurements are now in the part configs, `design.config` only has the default config values, so we need to run `new design(gist).__init()` to properly populate the config on the design, even if we don't intend to use the instantiated pattern for anything else