### PR TITLE
Remove grow CSS from tabs to prevent them from being obscured.

### DIFF
--- a/sites/shared/components/mdx/tabs.js
+++ b/sites/shared/components/mdx/tabs.js
@@ -19,7 +19,9 @@ export const Tabs = ({ tabs = '', active = 0, children }) => {
         {tablist.map((title, tabId) => (
           <button
             key={tabId}
-            className={`text-xl font-bold capitalize tab tab-bordered grow ${activeTab === tabId ? 'tab-active' : ''}`}
+            className={`text-xl font-bold capitalize tab tab-bordered ${
+              activeTab === tabId ? 'tab-active' : ''
+            }`}
             onClick={() => setActiveTab(tabId)}
           >
             {title}


### PR DESCRIPTION
This change removes the "grow" CSS class from tabs to prevent them from expanding. For the tabs in the Logs view, this prevents the "Set 0" tab from being obscured by the View menu.

(I simply removed the " grow" text. The rest of the code formatting was done by eslint.)

Before:
![Screen Shot 2022-09-26 at 9 17 55 AM](https://user-images.githubusercontent.com/109869956/192329895-13bd7234-ebbe-4d08-8eba-c46f779fb38b.png)

After:
![Screen Shot 2022-09-26 at 9 18 20 AM](https://user-images.githubusercontent.com/109869956/192329873-b88e6d37-0b80-48ab-9a65-696286595cfa.png)
