### PR TITLE
fix(lunetius): Unhide accidentally-hidden seam.

### DIFF
--- a/designs/lunetius/src/lacerna.mjs
+++ b/designs/lunetius/src/lacerna.mjs
@@ -61,7 +61,7 @@ function lunetiusLacerna({
     .line(points.bottom)
     .hide()
   paths.saBase = new Path().move(points.top).line(points.topLeft).hide()
-  paths.seam = paths.saBase.join(paths.hem).join(paths.fold).attr('class', 'fabric').hide()
+  paths.seam = paths.saBase.join(paths.hem).join(paths.fold).attr('class', 'fabric')
 
   // Complete?
   if (complete) {


### PR DESCRIPTION
Lunetius' Lacerna seam accidentally got hidden during the `setRender()` -> `hide()` change of c5138aad991d4e1b46ac84cbad0db5f93b8e62ca. This PR unhides it.