### PR TITLE
fix(hi): Unhide accidentally-hidden seam.

### DIFF
--- a/designs/hi/src/body.mjs
+++ b/designs/hi/src/body.mjs
@@ -409,7 +409,6 @@ function draftHiBody({
     .curve(points.body02cp1, points.body03cp2, points.body03)
     .join(paths.allButDart)
     .close()
-    .hide()
 
   let gillPath = new Path()
     .move(points.body17)


### PR DESCRIPTION
Hi's body seam accidentally got hidden during the `setRender()` -> `hide()` change of c5138aad991d4e1b46ac84cbad0db5f93b8e62ca. This PR unhides it.