### PR TITLE
fix(benjamin): Remove unused, inherited elements; hide round macro paths; fix ribbon dependency.

### DIFF
--- a/designs/benjamin/src/base.mjs
+++ b/designs/benjamin/src/base.mjs
@@ -67,9 +67,9 @@ function draftBenjaminBase({
   // Paths
   paths.cap = new Path().hide().move(points.tip2Bottom)
   if (options.endStyle === 'straight') {
-    paths.cap = new Path().move(points.tip2Bottom).line(points.tip2Top)
+    paths.cap = new Path().move(points.tip2Bottom).line(points.tip2Top).hide()
   } else if (options.endStyle === 'pointed') {
-    paths.cap = new Path().move(points.tip2Bottom).line(points.tip).line(points.tip2Top)
+    paths.cap = new Path().move(points.tip2Bottom).line(points.tip).line(points.tip2Top).hide()
   } else {
     points.roundBottom = new Point(points.tip.x, points.tip2Bottom.y)
     points.roundTop = points.roundBottom.flipY()
@@ -78,14 +78,16 @@ function draftBenjaminBase({
       to: points.tip,
       via: points.roundBottom,
       prefix: 'bottom',
+      hidden: true,
     })
     macro('round', {
       from: points.tip,
       to: points.tip2Top,
       via: points.roundTop,
       prefix: 'top',
+      hidden: true,
     })
-    paths.cap = paths.bottomRounded.join(paths.topRounded)
+    paths.cap = paths.bottomRounded.join(paths.topRounded).hide()
   }
 
   if (options.bowStyle === 'diamond' || options.bowStyle === 'butterfly') {

--- a/designs/benjamin/src/bow2.mjs
+++ b/designs/benjamin/src/bow2.mjs
@@ -10,10 +10,16 @@ function draftBenjaminBow2({
   macro,
   sa,
   store,
+  snippets,
   paperless,
   part,
 }) {
-  if (!options.adjustmentRibbon) return part.hide()
+  if (!options.adjustmentRibbon) {
+    for (const s in snippets) delete snippets[s]
+    for (const p in points) delete points[p]
+    for (const p in paths) delete paths[p]
+    return part.hide()
+  }
 
   points.bandBottomLeft = points.bandBottomLeft.shift(180, 90)
   points.bandTopLeft = points.bandBottomLeft.flipY()

--- a/designs/benjamin/src/bow3.mjs
+++ b/designs/benjamin/src/bow3.mjs
@@ -10,10 +10,16 @@ function draftBenjaminBow3({
   macro,
   sa,
   store,
+  snippets,
   paperless,
   part,
 }) {
-  if (!options.adjustmentRibbon) return part.hide()
+  if (!options.adjustmentRibbon) {
+    for (const s in snippets) delete snippets[s]
+    for (const p in points) delete points[p]
+    for (const p in paths) delete paths[p]
+    return part.hide()
+  }
 
   points.bandBottomLeft = points.bandBottomLeft.shift(180, 290)
   points.bandTopLeft = points.bandBottomLeft.flipY()

--- a/designs/benjamin/src/ribbon.mjs
+++ b/designs/benjamin/src/ribbon.mjs
@@ -1,3 +1,5 @@
+import { base } from './base.mjs'
+
 function draftBenjaminRibbon({
   Point,
   Path,
@@ -62,5 +64,6 @@ function draftBenjaminRibbon({
 
 export const ribbon = {
   name: 'benjamin.ribbon',
+  after: base,
   draft: draftBenjaminRibbon,
 }


### PR DESCRIPTION
1. https://github.com/freesewing/freesewing/issues/2844 causes the `round` macro paths to be visible by default. This PR adds the explicit `hidden: true` to them.
2. I missed adding the `after: base` dependency in `ribbon.mjs` when I ported the Benjamin to v3. This PR fixes it.
3. The new v3 changes somehow change how parts are injected/inherited such that paths and snippets from `base.mjs` are displayed for `bow2` and `bow3`, even if those parts are hidden. This PR deletes inherited Points, Paths, and Snippets when the part is hidden. 
![Screen Shot 2022-09-27 at 9 08 01 AM](https://user-images.githubusercontent.com/109869956/192579642-7253f898-4c8d-4ec7-af79-0308ebb83e34.png)
![Screen Shot 2022-09-27 at 9 08 26 AM](https://user-images.githubusercontent.com/109869956/192579660-a6d3f635-301f-4f4f-a9ae-3bbb1946d3ba.png)
![Screen Shot 2022-09-27 at 9 08 36 AM](https://user-images.githubusercontent.com/109869956/192579673-f7e409f6-bfb2-4d9a-ad08-cd120a338b6d.png)
