### PR TITLE
fix(charlie): Unhide accidentally-hidden seam for Fly Extension part.

### DIFF
--- a/designs/charlie/src/fly-extension.mjs
+++ b/designs/charlie/src/fly-extension.mjs
@@ -27,7 +27,7 @@ function draftCharlieFlyExtension({ points, paths, Path, complete, macro, sa, pa
     .line(points.styleWaistIn)
     .line(points.flyTop)
     .hide()
-  paths.seam = paths.saBase.clone().line(points.flyCorner).close().hide().attr('class', 'fabric')
+  paths.seam = paths.saBase.clone().line(points.flyCorner).close().unhide().attr('class', 'fabric')
 
   if (complete) {
     macro('cutonfold', {


### PR DESCRIPTION
The seam was accidentally hidden by c5138aad991d4e1b46ac84cbad0db5f93b8e62ca :
```diff
-    .setRender(false)
-  paths.seam = paths.saBase
-    .clone()
-    .line(points.flyCorner)
-    .close()
-    .setRender(true)
-    .attr('class', 'fabric')
+    .hide()
+  paths.seam = paths.saBase.clone().line(points.flyCorner).close().hide().attr('class', 'fabric')
```
![Screen Shot 2022-09-27 at 6 41 07 PM](https://user-images.githubusercontent.com/109869956/192668100-92ea71ab-90d6-4b60-ae83-25ab18be5eea.png)
