### PR TITLE
fix(cornelius): Unhide accidentally-hidden seams in Pocket and Pocket Facing

### DIFF
--- a/designs/cornelius/src/pocket.mjs
+++ b/designs/cornelius/src/pocket.mjs
@@ -63,7 +63,6 @@ function draftCorneliusPocket({
     .join(paths.pocketBottom)
     .join(paths.sideSeam)
     .close()
-    .hide()
     .attr('class', 'fabric')
 
   if (complete) {

--- a/designs/cornelius/src/pocketfacing.mjs
+++ b/designs/cornelius/src/pocketfacing.mjs
@@ -50,7 +50,6 @@ function draftCorneliusPocketFacing({
     .join(paths.facingInside)
     .join(paths.sideSeam)
     .close()
-    .hide()
     .attr('class', 'fabric')
 
   if (complete) {


### PR DESCRIPTION
Two seams were accidentally hidden in the `setRender()` -> `hide()` change.
![Screen Shot 2022-09-28 at 11 07 46 AM](https://user-images.githubusercontent.com/109869956/192857227-a8abca37-da89-49a6-adf0-087187a64969.png)
