### PR TITLE
chore(yuri): Re-add the temporarily-removed hoodCenter part.

### DIFF
--- a/designs/yuri/src/index.mjs
+++ b/designs/yuri/src/index.mjs
@@ -10,14 +10,7 @@ import { hoodCenter } from './hoodcenter.mjs'
 // Setup our new design
 const Yuri = new Design({
   data,
-  parts: [
-    back,
-    front,
-    sleeve,
-    gusset,
-    hoodSide,
-    //  hoodCenter
-  ],
+  parts: [back, front, sleeve, gusset, hoodSide, hoodCenter],
 })
 
 // Named exports


### PR DESCRIPTION
Yuri was ported to v3 via 4086f2de1dbb7f4b6275caeea5c004e80d06d556, with the hoodCenter part commented out and the commit comment of:
> wip(yuri): Ported to v3
>  
>    The tests don't pass (for giants) but everything works fine in the lab
    so it might be an issue with how the tests are setup.
    I'll investigate this later.

I uncommented the hoodCenter part and ran `yarn test` without any errors, including in the "Draft for giant" section. So, it appears that the part might be safely re-added now?