### PR TITLE
fix(benjamin): Add missing dependency to Ribbon.

### DIFF
--- a/designs/benjamin/src/ribbon.mjs
+++ b/designs/benjamin/src/ribbon.mjs
@@ -1,3 +1,5 @@
+import { base } from './base.mjs'
+
 function draftBenjaminRibbon({
   Point,
   Path,
@@ -62,5 +64,6 @@ function draftBenjaminRibbon({
 
 export const ribbon = {
   name: 'benjamin.ribbon',
+  after: base,
   draft: draftBenjaminRibbon,
 }


### PR DESCRIPTION
When I ported Benjamin to v3, I neglected to add the `after: base` dependency in `ribbon.mjs`. This PR corrects that.

(The issue doesn't normally cause problems. The exception is when the Ribbon part is selected in Contents/Only, at which point an error occurs.)
