### PR TITLE
fix(legend): Add missing dimension and sa elements.

### DIFF
--- a/designs/legend/src/index.mjs
+++ b/designs/legend/src/index.mjs
@@ -11,6 +11,8 @@ import { title } from './title.mjs'
 import { scalebox } from './scalebox.mjs'
 import { textSize } from './textsize.mjs'
 import { bartack } from './bartack.mjs'
+import { dimension } from './dimension.mjs'
+import { sa } from './sa.mjs'
 
 // Setup our new design
 const Legend = new Design({
@@ -31,6 +33,8 @@ const Legend = new Design({
     scalebox,
     textSize,
     bartack,
+    dimension,
+    sa,
   ],
 })
 
@@ -51,5 +55,7 @@ export {
   scalebox,
   textSize,
   bartack,
+  dimension,
+  sa,
   Legend,
 }


### PR DESCRIPTION
The `develop` localhost lab version of the Legend design is missing the dimension and seam allowance elements that are on the lab.freesewing.dev version. I assume that they were accidentally omitted? If so, this PR re-adds them.