### PR TITLE
fix(plugintest): Cast options.dimensionD to integer.

### DIFF
--- a/designs/plugintest/src/plugin-dimension.mjs
+++ b/designs/plugintest/src/plugin-dimension.mjs
@@ -14,7 +14,7 @@ const pluginDimension = ({ points, Point, paths, Path, options, macro, part }) =
 
     const opts = {
       text: options.dimensionCustomText ? 'custom text' : false,
-      d: options.dimensionD,
+      d: Number(options.dimensionD),
       noStartMarker: !options.dimensionStartMarker,
       noEndMarker: !options.dimensionEndMarker,
     }


### PR DESCRIPTION
Currently (in both lab.freesewing.dev and `develop` localhost lab) changing the dimensionD option causes an error.