### PR TITLE
fix(plugintest): Add measurements required for calculated measurements.

### DIFF
--- a/designs/plugintest/src/plugin-measurements.mjs
+++ b/designs/plugintest/src/plugin-measurements.mjs
@@ -28,6 +28,7 @@ const pluginMeasurements = ({ points, Point, paths, Path, measurements, options,
 
 export const measurements = {
   name: 'plugintest.measurements',
+  measurements: ['seat', 'seatBack', 'waist', 'waistBack', 'crossSeam', 'crossSeamFront'],
   plugins: measurementsPlugin,
   draft: pluginMeasurements,
 }


### PR DESCRIPTION
If PluginTest is supposed to actually test plugin functionality, then the design should require the measurements that measurementsPlugin needs.

