### PR TITLE
fix(Titan) fitGuides points.hipsOut

### DIFF
--- a/designs/titan/src/back.mjs
+++ b/designs/titan/src/back.mjs
@@ -242,9 +242,12 @@ function titanBack({
       points.hipsInTarget = points.waistIn
         .shiftTowards(points.waistOut, measurements.waistToHips)
         .rotate(-90, points.waistIn)
-      points.hipsOutTarget = points.waistOut
-        .shiftTowards(points.waistIn, measurements.waistToHips)
-        .rotate(90, points.waistOut)
+      points.hipsOutTarget = points.hipsInTarget.shiftOutwards(
+        points.waistOut
+          .shiftTowards(points.waistIn, measurements.waistToHips)
+          .rotate(90, points.waistOut),
+        measurements.waist
+      )
       points.hipsIn = utils.beamsIntersect(
         points.hipsOutTarget,
         points.hipsInTarget,
@@ -278,7 +281,7 @@ function titanBack({
         if (points.waistOut.x > points.seatOut.x) {
           points.hipsOut = utils.lineIntersectsCurve(
             points.hipsOutTarget,
-            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.hipsIn,
             points.kneeOut,
             points.kneeOutCp2,
             points.seatOut,
@@ -295,7 +298,7 @@ function titanBack({
         } else {
           points.hipsOut = utils.lineIntersectsCurve(
             points.hipsOutTarget,
-            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.hipsIn,
             points.seatOut,
             points.seatOutCp2,
             points.waistOut,
@@ -309,7 +312,7 @@ function titanBack({
         if (points.waistOut.x > points.seatOut.x) {
           points.hipsOut = utils.lineIntersectsCurve(
             points.hipsOutTarget,
-            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.hipsIn,
             points.floorOut,
             points.kneeOutCp2,
             points.seatOut,
@@ -334,7 +337,7 @@ function titanBack({
         } else {
           points.hipsOut = utils.lineIntersectsCurve(
             points.hipsOutTarget,
-            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.hipsIn,
             points.seatOut,
             points.seatOutCp2,
             points.waistOut,
@@ -518,7 +521,6 @@ export const back = {
     fitCrossSeam: true,
     fitCrossSeamFront: true,
     fitCrossSeamBack: true,
-    fitGuides: true,
     // Fit
     waistEase: { pct: 2, min: 0, max: 10, menu: 'fit' },
     seatEase: { pct: 2, min: 0, max: 10, menu: 'fit' },
@@ -546,6 +548,7 @@ export const back = {
       ...pctBasedOn('waistToFloor'),
       menu: 'advanced',
     },
+    fitGuides: { bool: true, menu: 'advanced' },
   },
   draft: titanBack,
 }

--- a/designs/titan/src/front.mjs
+++ b/designs/titan/src/front.mjs
@@ -314,9 +314,12 @@ function titanFront({
       points.hipsInTarget = points.waistIn
         .shiftTowards(points.waistOut, measurements.waistToHips)
         .rotate(90, points.waistIn)
-      points.hipsOutTarget = points.waistOut
-        .shiftTowards(points.waistIn, measurements.waistToHips)
-        .rotate(-90, points.waistOut)
+      points.hipsOutTarget = points.hipsInTarget.shiftOutwards(
+        points.waistOut
+          .shiftTowards(points.waistIn, measurements.waistToHips)
+          .rotate(-90, points.waistOut),
+        measurements.waist
+      )
       points.hipsIn = utils.beamsIntersect(
         points.hipsOutTarget,
         points.hipsInTarget,
@@ -350,7 +353,7 @@ function titanFront({
         if (points.waistOut.x < points.seatOut.x) {
           points.hipsOut = utils.lineIntersectsCurve(
             points.hipsOutTarget,
-            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.hipsIn,
             points.waistOut,
             points.seatOut,
             points.kneeOutCp1,
@@ -367,7 +370,7 @@ function titanFront({
         } else {
           points.hipsOut = utils.lineIntersectsCurve(
             points.hipsOutTarget,
-            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.hipsIn,
             points.waistOut,
             points.waistOut,
             points.seatOutCp1,
@@ -381,7 +384,7 @@ function titanFront({
         if (points.waistOut.x < points.seatOut.x) {
           points.hipsOut = utils.lineIntersectsCurve(
             points.hipsOutTarget,
-            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.hipsIn,
             points.waistOut,
             points.seatOut,
             points.kneeOutCp1,
@@ -406,7 +409,7 @@ function titanFront({
         } else {
           points.hipsOut = utils.lineIntersectsCurve(
             points.hipsOutTarget,
-            points.hipsIn.rotate(180, points.hipsOutTarget),
+            points.hipsIn,
             points.waistOut,
             points.waistOut,
             points.seatOutCp1,


### PR DESCRIPTION
Fix for #2924

Problem:
points.hipsOut would sometimes not be able to be set because the line used with utils.lineIntersectsCurve would not past through the outseam.

Solution:
points.hipsOutTarget is now extended out from where it originally drafted using .shiftOutwards and points.hipsInTarget.
points.hipsIn is no longer rotated around points.hipsOutTarget in the utils.lineIntersectsCurve as the line created between it and the new points.hipsOutTarget will cross the outseam curve.

Additional Changes:
I have also changed fitGuides to an optional option in advanced so if another bug is found do to with the fitGuides they can be turned off as a workaround whilst a fixed is made. (Rather than the current which would be using the advanced contents for Paco or Charlie) This has presented an interesting an intersting bug in the v3 lab detailed here https://discord.com/channels/698854858052075530/698862765053575188/1027282797313937408

Easy to backport to v2 if needed,