### PR TITLE
chore(tutorial): Port Pattern Design tutorial text to v3.

### DIFF
--- a/markdown/dev/tutorials/pattern-design/adding-measurements/en.md
+++ b/markdown/dev/tutorials/pattern-design/adding-measurements/en.md
@@ -41,4 +41,6 @@ For example `38` as 38cm is a realistic head circumference measurement for a bab
 Enter `38` in the box, and click on **Draft Design** in the sidebar under the **View** heading.
 This brings you back to our work in progress:
 
-<Example pattern="tutorial" part="step1">Nothing has changed, yet</Example>
+<Examples pattern="tutorial" part="tutorial.step1" />
+
+_Nothing has changed, yet._

--- a/markdown/dev/tutorials/pattern-design/adding-measurements/en.md
+++ b/markdown/dev/tutorials/pattern-design/adding-measurements/en.md
@@ -15,10 +15,10 @@ So let's add it as a required measurement.
 
 ## Add required measurements
 
-Open the config file at `design/config.js` and update the `measurements` array with the name of our required measurement:
+Open the part file at `design/src/bib.mjs` and update the `measurements` array with the name of our required measurement:
 
 ```js
-measurements: ["head"],
+measurements: ['head'],
 ```
 
 <Tip>

--- a/markdown/dev/tutorials/pattern-design/adding-options/en.md
+++ b/markdown/dev/tutorials/pattern-design/adding-options/en.md
@@ -20,14 +20,14 @@ flexible and let the user decide. All you have to do is add options to your patt
 The first option we're going to add controls the ratio between the neck opening
 and the head circumference. Let's call it `neckRatio`.
 
-Open the config file at `design/config.js` and add this to the options:
+Open the part file at `design/src/bib.mjs` and add this to the options:
 
 ```js
   options: {
     // Remove this size option
-    //size: { pct: 50, min: 10, max: 100 }
+    //size: { pct: 50, min: 10, max: 100, menu: 'size' }
     // And add the neckRatio options
-    neckRatio: { pct: 80, min: 70, max: 90 }, 
+    neckRatio: { pct: 80, min: 70, max: 90, menu: 'fit' },
   }
 ```
 
@@ -37,6 +37,7 @@ Can you guess what it means?
 - Its minimum value is 70%
 - Its maximum value is 90%
 - Its default value is 80%
+- It will be listed under the 'Fit' Design Options menu.
 
 <Note>
 
@@ -49,35 +50,23 @@ Let's do something similar for the width and length of our bib:
 
 ```js
 options: {
-  neckRatio: { pct: 80, min: 70, max: 90 }, 
-  widthRatio: { pct: 45, min: 35, max: 55 }, 
-  lengthRatio: { pct: 75, min: 55, max: 85 }, 
+  neckRatio: { pct: 80, min: 70, max: 90, menu: 'fit' },
+  widthRatio: { pct: 45, min: 35, max: 55, menu: 'fit' },
+  lengthRatio: { pct: 75, min: 55, max: 85, menu: 'fit' },
 }
 ```
 
 - You've added `widthRatio` and `lengthRatio` options
 - You've given all options sensible defaults
 - You've given all options sensible maximum and minimum boundaries
+- All of these options will be listed under the 'Fit' menu.
 
 <Note>
 
 Later, you'll test-drive your pattern to see how it behaves when you adapt the options
 between their minimum and maximum values. At that time, you can still tweak these values.
 
-</Note>
-
-Before you close the `design/config.js` file, make sure to update the `optionGroups` entry as follows:
-
-```js
-optionGroups: {
-  fit: ["neckRatio", "widthRatio", "lengthRatio"]
-},
-```
-
-<Note>
-
-The `optionGroups` entry does not do anything for your pattern as such.
-Instead it signals to the frontend that this is how options should be grouped together and presented to the user.
+Options and option menus will be listed in alphabetical order, except for the 'Advanced' menu which will be listed last.
 
 </Note>
 

--- a/markdown/dev/tutorials/pattern-design/avoiding-overlap/en.md
+++ b/markdown/dev/tutorials/pattern-design/avoiding-overlap/en.md
@@ -47,8 +47,8 @@ While we're at it, let's add a point where the closure's snap should go:
 points.snapLeft = points.top.shiftFractionTowards(points.edgeTop, 0.5)
 ```
 
-<Example pattern="tutorial" part="step8">
-The right part looks a bit wonky now, but we'll get to that
-</Example>
+<Examples pattern="tutorial" part="tutorial.step8" />
+
+_The right part looks a bit wonky now, but we'll get to that._
 
 Now let's mirror this on the other side, and replace our `neck` and `rect` paths with a new path.

--- a/markdown/dev/tutorials/pattern-design/completing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/completing-the-neck-opening/en.md
@@ -17,10 +17,10 @@ To accomplish this, update the code and add this one line:
 paths.quarterNeck = new Path()
 	  .move(points.right)
 	  .curve(points.rightCp1, points.bottomCp2, points.bottom)
-    .setRender(false) // <== Add this line
+    .hidden(true) // <== Add this line
 ```
 
-We're saying: don't render this path. In other words, don't show it.
+We're saying: hide or don't show this path. In other words, don't render it.
 The path is now known, and we can still use it to calculate the length of the neck opening.
 But it won't show up on screen or on the page.
 

--- a/markdown/dev/tutorials/pattern-design/completing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/completing-the-neck-opening/en.md
@@ -64,6 +64,6 @@ paths.neck = new Path()
   .close()
 ```
 
-<Example pattern="tutorial" part="step4">
-And now you have a complete neck opening
-</Example>
+<Examples pattern="tutorial" part="tutorial.step4" />
+
+_And now you have a complete neck opening._

--- a/markdown/dev/tutorials/pattern-design/completing-your-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/completing-your-pattern/en.md
@@ -6,8 +6,18 @@ order: 260
 When we started out, we said a good part boilerplate looks like this:
 
 ```js
-export default function(part) {
-  const { Point, points, Path, paths, complete, sa, paperless } = part.shorthand()
+import { pluginBundle } from '@freesewing/plugin-bundle'
+
+function draftBib({
+  Point,
+  points,
+  Path,
+  paths,
+  complete,
+  sa,
+  paperless,
+  part,
+}) {
   // Design pattern here
 
   // Complete?
@@ -19,6 +29,17 @@ export default function(part) {
     }
   }
   return part
+}
+
+export const bib = {
+  name: 'bib.bib',
+  measurements: [ 'head' ],
+  options: {
+    neckRatio: { pct: 80, min: 70, max: 90, menu: 'fit' },
+    widthRatio: { pct: 45, min: 35, max: 55, menu: 'fit' },
+    lengthRatio: { pct: 75, min: 55, max: 85, menu: 'fit' },
+  }
+  plugins: [ pluginBundle, ],
 }
 ```
 
@@ -37,12 +58,12 @@ This has different uses, such as generating patterns to be cut out with a laser 
 </Note>
 
 The `complete` setting is `true` by default, but the user can change it.
-To access the setting, we merely have to tell `part.shorthand()` that we'd like to access it.
+To access the setting, we merely have to pass it into the draft method so we can use it.
 
 While we're at it, also add `snippets` and `Snippet`, like this:
 
 ```js
-const {
+function draftBib({
   Point,
   points,
   Path,
@@ -53,10 +74,10 @@ const {
   measurements,
   options,
   macro,
-  complete,
   snippets,
-  Snippet
-} = part.shorthand()
+  Snippet,
+  part,
+}) {
 ```
 
 ## Adding snippets

--- a/markdown/dev/tutorials/pattern-design/completing-your-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/completing-your-pattern/en.md
@@ -193,8 +193,8 @@ macro("scalebox", { at: points.scalebox })
 
 And with that, our pattern is now _complete_:
 
-<Example pattern="tutorial" part="step11">
-We used attributes to add color, dashes, text on a path and even opacity
-</Example>
+<Examples pattern="tutorial" part="tutorial.step11" />
+
+_We used attributes to add color, dashes, text on a path and even opacity._
 
 We're not done yet though. There's one more thing the user can ask for: a _paperless_ pattern.

--- a/markdown/dev/tutorials/pattern-design/conclusion/en.md
+++ b/markdown/dev/tutorials/pattern-design/conclusion/en.md
@@ -19,7 +19,7 @@ you have learned a bunch of things along the way. Let's list some of the things 
 - You learned [how to offset a path](/tutorials/pattern-design/completing-your-pattern#seam-allowance) to create seam allowance, or in our case, mark the bias tape line
 - You learned how to create a [paperless pattern](/tutorials/pattern-design/paperless-bib) by adding dimensions
 
-You can find the complete code of the tutorial pattern [here on GitHub](https://github.com/freesewing/freesewing/blob/develop/designs/tutorial/src/bib.js).
+You can find the complete code of the tutorial pattern [here on GitHub](https://github.com/freesewing/freesewing/blob/develop/designs/tutorial/src/bib.mjs).
 
 ## More reading material
 

--- a/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
@@ -100,7 +100,9 @@ From there, we drew a Bezier curve to our `bottom` point by using `rightCp1` and
 
 When all is said and done, we now have a quarter of our neck opening:
 
-<Example pattern="tutorial" part="step2">You have drawn your first path</Example>
+<Examples pattern="tutorial" part="tutorial.step2" />
+
+_You have drawn your first path._
 
 The only problem is, we have no guarantee whatsoever that this opening is the correct size.
 

--- a/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
@@ -14,7 +14,7 @@ to our measurements and options to do so. For this, you first update the shortha
 to indicate you also want access to `measurements` and `options`:
 
 ```js
-const {
+function draftBib({
   Point,
   points,
   Path,
@@ -23,8 +23,9 @@ const {
   sa,
   paperless,
   measurements,
-  options
-} = part.shorthand()
+  options,
+  part,
+}) {
 ```
 
 Great. Now let's get to work:

--- a/markdown/dev/tutorials/pattern-design/creating-the-closure/en.md
+++ b/markdown/dev/tutorials/pattern-design/creating-the-closure/en.md
@@ -16,7 +16,7 @@ Before we can use it, we have to update our `part.shorthand()` call to indicate 
 also like to make use of macros. Simply add `macro` at the end:
 
 ```js
-const {
+function draftBib({
   Point,
   points,
   Path,
@@ -26,8 +26,9 @@ const {
   paperless,
   measurements,
   options,
-  macro
-} = part.shorthand()
+  macro,
+  part,
+}) {
 ```
 
 We need a half circle here, but the `round` macro works on 90° angles, so you'll use it twice.
@@ -46,14 +47,14 @@ macro("round", {
   to: points.tipRight,
   via: points.tipRightTop,
   prefix: "tipRightTop",
-  render: true
+  hide: false,
 })
 macro("round", {
   from: points.tipRight,
   to: points.top,
   via: points.tipRightBottom,
   prefix: "tipRightBottom",
-  render: true
+  hide: false,
 })
 ```
 

--- a/markdown/dev/tutorials/pattern-design/creating-the-closure/en.md
+++ b/markdown/dev/tutorials/pattern-design/creating-the-closure/en.md
@@ -60,9 +60,9 @@ macro("round", {
 
 <Note> You can find more information on the `round` macro in [the macros docs](/reference/api/macros/round/).</Note>
 
-<Example pattern="tutorial" part="step7">
-Pretty good, but how are we going to fit it over the baby's head?
-</Example>
+<Examples pattern="tutorial" part="tutorial.step7" />
+
+_Pretty good, but how are we going to fit it over the baby's head?_
 
 Like our neck opening, we've only drawn half since we can simply copy the points to the other side.
 

--- a/markdown/dev/tutorials/pattern-design/drawing-the-bib-outline/en.md
+++ b/markdown/dev/tutorials/pattern-design/drawing-the-bib-outline/en.md
@@ -63,6 +63,6 @@ and the sides are equidistant from the neck neck opening.
 
 You didn't have to do that. But it looks nicely balanced this way:
 
-<Example pattern="tutorial" part="step5">
-Note how the neck opening is the same distance from the left, right, and top edge
-</Example>
+<Examples pattern="tutorial" part="tutorial.step5" />
+
+_Note how the neck opening is the same distance from the left, right, and top edge._

--- a/markdown/dev/tutorials/pattern-design/drawing-the-straps/en.md
+++ b/markdown/dev/tutorials/pattern-design/drawing-the-straps/en.md
@@ -93,21 +93,21 @@ macro("round", {
   to: points.tipRight,
   via: points.tipRightTop,
   prefix: "tipRightTop",
-  render: false // set this from true to false
+  hide: true // set this from false to true
 })
 macro("round", {
   from: points.tipRight,
   to: points.top,
   via: points.tipRightBottom,
   prefix: "tipRightBottom",
-  render: false // set this from true to false
+  hide: true // set this from false to true
 })
 
 ```
 
 <Note>
 
-You can also remove the `render` line completely. More on this in the next section.
+You can also remove the `hide` lines completely. More on this in the next section.
 
 </Note>
 

--- a/markdown/dev/tutorials/pattern-design/drawing-the-straps/en.md
+++ b/markdown/dev/tutorials/pattern-design/drawing-the-straps/en.md
@@ -113,9 +113,9 @@ You can also remove the `hide` lines completely. More on this in the next sectio
 
 With that out of the way, our bib now looks like this:
 
-<Example pattern="tutorial" part="step9">
-That is looking a lot like a bib
-</Example>
+<Examples pattern="tutorial" part="tutorial.step9" />
+
+_That is looking a lot like a bib._
 
 <Note> 
 

--- a/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
@@ -43,8 +43,8 @@ If the delta is negative, our path is too short and we increase the tweak factor
 
 We keep on doing this until `Math.abs(delta)` is less than 1. Meaning that we are within 1mm of our target value.
 
-<Example pattern="tutorial" part="step2">
-It might look the same as before, but now it's just right
-</Example>
+<Examples pattern="tutorial" part="tutorial.step2" />
+
+_It might look the same as before, but now it's just right._
 
 Now that we're happy with the length of our quarter neck opening, let's construct the entire neck opening.

--- a/markdown/dev/tutorials/pattern-design/paperless-bib/en.md
+++ b/markdown/dev/tutorials/pattern-design/paperless-bib/en.md
@@ -5,11 +5,11 @@ order:  270
 
 Users can request paperless patterns by setting the `paperless` setting to `true`.
 
-We can get that value of the setting from the `part.shorthand()` method.
+We can get that value of the setting from the `paperless` object passed into the draft funciton.
 It will be the last shorthand we will put to use:
 
 ```js
-const {
+function draftBib({
   Point,
   points,
   Path,
@@ -21,8 +21,9 @@ const {
   options,
   macro,
   snippets,
-  Snippet
-} = part.shorthand()
+  Snippet,
+  part,
+}) {
 ```
 
 The idea behind _paperless patterns_ is that users don't need to print your

--- a/markdown/dev/tutorials/pattern-design/paperless-bib/en.md
+++ b/markdown/dev/tutorials/pattern-design/paperless-bib/en.md
@@ -84,9 +84,9 @@ if (paperless) {
 
 There's a lot going on, but it's mostly repetition. To see what that did to your pattern, you have to enable _paperless mode_ in your developing environment; you can find the option under _Pattern options_ on the right. Let's look at the end result, and discuss:
 
-<Example pattern="tutorial" part="bib" settings_paperless="true">
-Your paperless bib
-</Example>
+<Examples pattern="tutorial" part="tutorial.bib" settings_paperless="true" />
+
+_Your paperless bib._
 
 We used the `hd` macro to add two horizontal dimensions:
 

--- a/markdown/dev/tutorials/pattern-design/part-structure/en.md
+++ b/markdown/dev/tutorials/pattern-design/part-structure/en.md
@@ -4,11 +4,21 @@ order: 150
 ---
 
 Let's get rid of the example box first.
-Open `design/src/bib.js` and make sure it looks like this:
+Open `design/src/bib.mjs` and edit the file so it looks like this:
 
 ```js
-export default function(part) {
-  const { Point, points, Path, paths, complete, sa, paperless } = part.shorthand()
+import { pluginBundle } from '@freesewing/plugin-bundle'
+
+function draftBib({
+  Point,
+  points,
+  Path,
+  paths,
+  complete,
+  sa,
+  paperless,
+  part,
+}) {
   // Design pattern here
 
   // Complete?
@@ -21,6 +31,17 @@ export default function(part) {
   }
   return part
 }
+
+export const bib = {
+  name: 'bib.bib',
+  measurements: [ 'head' ],
+  options: {
+    neckRatio: { pct: 80, min: 70, max: 90, menu: 'fit' },
+    widthRatio: { pct: 45, min: 35, max: 55, menu: 'fit' },
+    lengthRatio: { pct: 75, min: 55, max: 85, menu: 'fit' },
+  }
+  plugins: [ pluginBundle, ],
+}
 ```
 
 This is an empty skeleton for a pattern part. Anytime you want to create a new part,
@@ -32,8 +53,16 @@ Even if there's not much going on yet, it's always good to understand what's goi
 ## The draft method
 
 ```js
-export default function(part) {
-
+function draftBib({
+  Point,
+  points,
+  Path,
+  paths,
+  complete,
+  sa,
+  paperless,
+  part,
+}) {
   // ...
   
   return part
@@ -41,7 +70,7 @@ export default function(part) {
 
 ```
 
-This is the boilerplate of our `draftBib` method. It takes the part as an argument, and returns it.
+This is the boilerplate of our `draftBib` method. It takes a number of Part shorthand objects and the part as arguments, and returns the part.
 
 <Note>
 
@@ -49,19 +78,22 @@ If you're new to JavaScript, and don't intuitively _get this_, stick with it. It
 
 </Note>
 
-## Using shorthand
+## Using shorthand objects
 
 ```js
-let {
+function draftBib({
   Point,
   points,
   Path,
   paths,
-} = part.shorthand()
+  complete,
+  sa,
+  paperless,
+  part,
+}) {
 ```
 
-This is FreeSewing's **shorthand** method. It returns an object with a bunch of handy helpers
-and you use JavaScript's _object destructuring_ to only get what you need.
+These helper objects like `Path', `points`, and `measurements` are handy helpers provided by Javascripts _object destructuring_ of FreeSewing's Part **shorthand**. You only need to include the ones that you need for the part's draft method.
 
 The example above makes the following variables available:
 
@@ -70,16 +102,18 @@ The example above makes the following variables available:
 - `Path`: The Path constructor
 - `paths`: A reference to the part's paths
 
-These will make it possible for you to draw points and paths easily.
+These will make it possible for you to create, draw, and reference points and paths easily.
 
 The following three variables are also needed to create a full-fledged FreeSewing pattern; their function and usage will
-be covered in detail [later on in this tutorial](/tutorials/pattern-design/completing-your-pattern/):
+be covered in detail [later on in this tutorial](/tutorials/pattern-design/completing-your-pattern/). For now, we only need these so that the pattern skeleton compiles properly:
 
 - `complete`: create a _complete_ pattern (or not)
 - `sa`: include _seam allowance_ (or not)
 - `paperless`: allow the pattern to be _paperless_
 
-For now, we only need these so that the pattern skeleton compiles properly.
+Finally, we include the part itself so it can be returned by the draft function.
+
+- `part`: The actual part itself
 
 <Note>
 

--- a/markdown/dev/tutorials/pattern-design/rounding-the-corners/en.md
+++ b/markdown/dev/tutorials/pattern-design/rounding-the-corners/en.md
@@ -26,21 +26,21 @@ But there's still something to be learned here. If you look at our earlier use o
 you'll notice that we used this line in the beginning:
 
 ```js
-  render: true,
+  hide: false,
 ```
 
 This instructs the `round` macro create a path that draws the rounded corner.
-Whereas by default, it merely constructs the points required to round the corner.
+Whereas by default, it merely constructs the points required to round the corner but does not draw the actual corner.
 
 Typically, your rounded corner will be part of a larger path and so you don't want the macro
-to draw it. That's why the `round` macro's `render` property defaults to `false`.
+to draw it. That's why the `round` macro's `hide` property defaults to `true`.
 
 We've left it out here, and you should also remove it from your earlier use of the `round` macro.
-We merely set `render` to `true` and then `false` at that time so you could see what the macro was doing.
+We merely set `hide` to `false` and then `true` at that time so you could see what the macro was doing.
 
 <Note>
 
-There is no need to explicitly specify a default value. While writing `render: false,` also works, it clutters up your code a bit.
+There is no need to explicitly specify a default value. While writing `hide: true,` also works, it clutters up your code a bit.
 
   </Note>
 

--- a/markdown/dev/tutorials/pattern-design/rounding-the-corners/en.md
+++ b/markdown/dev/tutorials/pattern-design/rounding-the-corners/en.md
@@ -71,6 +71,6 @@ and keep the rest of the path as it was.
 
 The shape our bib is now completed:
 
-<Example pattern="tutorial" part="step10">
-That is looking a lot like a bib
-</Example>
+<Examples pattern="tutorial" part="tutorial.step10" />
+
+_That is looking a lot like a bib._

--- a/markdown/dev/tutorials/pattern-design/shaping-the-straps/en.md
+++ b/markdown/dev/tutorials/pattern-design/shaping-the-straps/en.md
@@ -44,6 +44,6 @@ paths.rect = new Path()
 
 All of a sudden, things are starting to look like a bib:
 
-<Example pattern="tutorial" part="step6">
-Pretty good, but how are we going to fit it over the baby's head?
-</Example>
+<Examples pattern="tutorial" part="tutorial.step6" />
+
+_Pretty good, but how are we going to fit it over the baby's head?_

--- a/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
@@ -45,9 +45,9 @@ Click on any of the options we've added to our pattern, and your bib will be dra
 
 The `lengthRatio` option controls the length of our bib. Testing it confirms that it only influences the length:
 
-<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "option", option: "lengthRatio" } }}>
-Your bib with the lengthRatio option sampled
-</Example>
+<Examples sample part="tutorial.bib" pattern="tutorial" settings={{ sample: { type: "option", option: "lengthRatio" } }} />
+
+_Your bib with the lengthRatio option sampled._
 
 ### neckRatio
 
@@ -58,9 +58,9 @@ neck opening.
 Testing it confirms this. We can also see that as the neck opening gets smaller, we will rotate the straps
 further out of the way to avoid overlap:
 
-<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "option", option: "neckRatio" } }} >
-Your bib with the neckRatio option sampled
-</Example>
+<Examples sample part="tutorial.bib" pattern="tutorial" settings={{ sample: { type: "option", option: "neckRatio" } }} />
+
+_Your bib with the neckRatio option sampled._
 
 ### widthRatio
 
@@ -81,9 +81,9 @@ covered in this tutorial. It is left _as an exercise to the reader_.
 
 </Note>
 
-<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "option", option: "widthRatio" } }}>
-Your bib with the widthRatio option sampled
-</Example>
+<Examples sample part="tutorial.bib" pattern="tutorial" settings={{ sample: { type: "option", option: "widthRatio" } }} />
+
+_Your bib with the widthRatio option sampled._
 
 ## Testing measurements
 
@@ -92,9 +92,9 @@ This gives you the option to determine how any given measurement is influencing 
 
 For our bib, we only use one measurement, so it influences the entire pattern:
 
-<Example sample part="bib" pattern="tutorial" settings={{ sample: { type: "measurement", measurement: "head" } }}>
-Your bib with the head circumference measurement sampled
-</Example>
+<Examples sample part="tutorial.bib" pattern="tutorial" settings={{ sample: { type: "measurement", measurement: "head" } }} />
+
+_Your bib with the head circumference measurement sampled._
 
 ## Testing models
 
@@ -108,9 +108,9 @@ set of measurements.
 But most patterns use multiple measurements, and you'll find this test gives you insight into how your
 pattern will adapt to differently sized bodies.
 
-<Example sample pattern="tutorial" part="bib" settings={{ sample: { type: "models", models: { baby1: { head: 340 }, baby2: { head: 350 }, baby3: { head: 360 }, baby4: { head: 370 }, baby5: { head: 380 }, baby6: { head: 390 }, baby7: { head: 400 }, baby8: { head: 410 }, baby9: { head: 420 } } } }}>
-Your bib sampled for a range of baby sizes
-</Example>
+<Examples sample pattern="tutorial" part="tutorial.bib" settings={{ sample: { type: "models", models: { baby1: { head: 340 }, baby2: { head: 350 }, baby3: { head: 360 }, baby4: { head: 370 }, baby5: { head: 380 }, baby6: { head: 390 }, baby7: { head: 400 }, baby8: { head: 410 }, baby9: { head: 420 } } } }} />
+
+_Your bib sampled for a range of baby sizes._
 
 ## The antperson test
 
@@ -128,8 +128,8 @@ don't scale, and you should avoid them.
 
 The best patterns will pass the antperson test with 2 patterns exactly the same, where one will simply be 1/10th the scale of the other.
 
-<Example sample pattern="tutorial" part="bib" settings={{ sample: { type: "models", models: { ant: { head: 39 }, man: { head: 390 }, } } }}>
-Congratulations, your bib passes the antperson test
-</Example>
+<Examples sample pattern="tutorial" part="tutorial.bib" settings={{ sample: { type: "models", models: { ant: { head: 39 }, man: { head: 390 }, } } }} />
+
+_Congratulations, your bib passes the antperson test!_
 
 When you're happy with how your pattern passes these tests, it's time to complete it.

--- a/markdown/dev/tutorials/pattern-design/your-first-part/en.md
+++ b/markdown/dev/tutorials/pattern-design/your-first-part/en.md
@@ -18,52 +18,63 @@ Since we only need one part, we'll rename this _box_ part, and call it _bib_.
 
 ## Rename the box part to bib
 
-First, update the configuration file in `design/config.js`.
+First, update the index file in `design/src/index.mjs`.
+
+Update the **import** statement with `bib` and `bib.mjs`, rather than `box` and `box.mjs`.
+
+```js
+import { bib } from './bib.mjs'
+```
+
 Update the **parts** array with `bib`, rather than `box`:
 
 ```js
-parts: ['bib'],
+parts: [ bib ],
+```
+
+Update the **export** statement with `bib`, rather than `box`:
+
+```js
+export { bib, Pattern }
 ```
 
 <Note>
 
 ##### Don't worry about the big red error
 
-This will (temporarily) cause en error to appear in your development environment, because the rest of the code is still expecting to find a part named `box`, but we will fix this in the next steps.
+This will (temporarily) cause en error to appear in your development environment, because the rest of the code is expecting to find a part named `bib`, but we will fix this in the next steps.
 
 </Note>
 
-When that's done, rename the `design/src/box.js` file into `design/src/bib.js`.
+When that's done, rename the `design/src/box.mjs` file to `design/src/bib.mjs`.
 
-Then, in the `design/src/index.js` file, change the import accordingly:
-
-```js
-// Change this line
-//import draftBox from "./box"
-
-// Into this
-import draftBib from "./bib"
+```sh
+mv box.mjs bib.mjs
 ```
 
-Finally, still in the `design/src/index.js` file, update the draft method:
+Finally, in the `design/src/bib.mjs` file, update the draft method name from `draftBox` to `draftBib` and the part name from `bib.box` to `bib.bib`.:
 
 ```js
-// Change this line
-//Design.prototype.draftBox = draftBox
+function draftBib({
+```
 
-// Into this
-Design.prototype.draftBib = draftBib
+```js
+name: 'bib.bib',
+```
+
+```js
+draft: draftBib,
 ```
 
 <Tip>
 
 ###### Always use draftPartname
 
-FreeSewing will expect for each part to find a method named Draft\_Partname\_.
-
 If you have a part named `sleeve` you should have a method called `draftSleeve()` that drafts that part.
 
 In our case, we have a part named `bib` so we're using `draftBib()` as the method that drafts it.
+
+This will help with debugging when the error is reported coming from the `draftBib()` method (as opposed to a generic `draft()` method from an unknown part).
 
 </Tip>
 

--- a/markdown/dev/tutorials/pattern-design/your-first-part/en.md
+++ b/markdown/dev/tutorials/pattern-design/your-first-part/en.md
@@ -81,8 +81,8 @@ This will help with debugging when the error is reported coming from the `draftB
 Congratulations, your pattern now has a `bib` part, rather than a `box` part.
 It still looks the same though:
 
-<Example pattern="tutorial" part="step1">
-Our bib part, which is the renamed box part
-</Example>
+<Examples pattern="tutorial" part="tutorial.step1" />
+
+_Our bib part, which is the renamed box part._
 
 This `bib` part is where we'll do some real work. But first, we have some more configuration to do.

--- a/packages/new-design/templates/from-scratch/design/src/box.mjs.mustache
+++ b/packages/new-design/templates/from-scratch/design/src/box.mjs.mustache
@@ -169,7 +169,7 @@ export const box = {
      *
      * Documentation: https://freesewing.dev/reference/api/part/config/options
      */
-    size: { pct: 50, min: 10, max: 100 },
+    size: { pct: 50, min: 10, max: 100, menu: 'fit' },
   },
   measurements: [
     /*


### PR DESCRIPTION
A first step at porting the Pattern Design tutorial to v3.

These are just the markdown changes. The image files will also need to be updated later.

Also, I noticed that there is a new `structure/en.md` page, but I did not touch it. It will need to be edited and integrated into the tutorial at some point.