### PR TITLE
Fix more broken links & typos, add link to translation guide

### DIFF
--- a/markdown/dev/guides/v3/en.md
+++ b/markdown/dev/guides/v3/en.md
@@ -180,16 +180,16 @@ The following methods have been added to the core API in v3:
 #### On the `Attributes` object
 
 - [Attributes.addClass](/reference/api/attributes/addclass)
-- [Attributes.asPropIfPrefixIs](/reference/api/attributes/aspropifprefixis)
+- [Attributes.asPropsIfPrefixIs](/reference/api/attributes/aspropsifprefixis)
 - [Attributes.render](/reference/api/attributes/render)
 - [Attributes.renderAsCss](/reference/api/attributes/renderascss)
 - [Attributes.renderIfPrefixIs](/reference/api/attributes/renderifprefixis)
 
 #### On the `Part` object
 
-- [Part.hide](/reference/api/part/hide)
-- [Part.setHidden](/reference/api/part/sethidden)
-- [Part.unhide](/reference/api/part/unhide)
+- [Part.hide](/reference/api/part/draft/hide)
+- [Part.setHidden](/reference/api/part/draft/sethidden)
+- [Part.unhide](/reference/api/part/draft/unhide)
 
 #### On the `Path` object
 
@@ -205,8 +205,8 @@ The following methods have been added to the core API in v3:
 
 #### On the `Pattern` object
 
-- [Pattern.addPart](/reference/api/pattern/addPart)
-- [Pattern.getConfig](/reference/api/pattern/getConfig)
+- [Pattern.addPart](/reference/api/pattern/addpart)
+- [Pattern.getConfig](/reference/api/pattern/getconfig)
 
 
 #### On the `Point` object

--- a/markdown/dev/guides/v3/en.md
+++ b/markdown/dev/guides/v3/en.md
@@ -12,7 +12,7 @@ If you're looking for a more hands-on list of changes between v2 and v3, please
 refer to [the v3 migration guide](/guides/v3/migration).
 
 Once v3 is in production, these guides will become less relevant. For now,
-short of reading the code itself, they are your best source for the incide
+short of reading the code itself, they are your best source for the inside
 scoop on v3, unless you want to read the source code of course.
 
 ## Why a version 3 in the first place?
@@ -51,7 +51,7 @@ people to combine parts from different designs in a seamless way.
 
 Design inheritance was already possible in v2, but because the configuration
 was handled on the design level, it required careful re-confiruration of
-(required) measuremetns, options, part dependencies, and so on. It was
+(required) measurements, options, part dependencies, and so on. It was
 possible, but came with a lot of friction. 
 
 So in v3, all configuration is moved to the part level, and a design is now not
@@ -66,12 +66,12 @@ This migration of the configuration from the design level to the part level is
 the biggest and most fundamental change between v2 and v3. It is also where
 most of the work needs to be done to port existing designs from v2 to v3.
 
-### Improved developer experience.
+### Improved developer experience
 
 The effort to improve the developer experience started already in v2. We've
 shipped a new development environment based on NextJS (previously we used
 Create React App) and have designing patterns more frictionless both for
-stand-along development, as well as for people working with(in) [our
+stand-alone development, as well as for people working with(in) [our
 monorepo](https://github.com/freesewing/freesewing).
 
 We've also switched from Rollup to Esbuild as our bundler, and in the process
@@ -104,7 +104,7 @@ v2 this was bolted on as an afterthought, and as such implemented in a somewhat
 hackish way.
 
 In v2, only paths are sampled and you can't compare list options among other
-restrictions.  Improving this and making sampling a cover the entire spectrum
+restrictions.  Improving this and making sampling cover the entire spectrum
 of what goes in a design has been on our roadmap for a while, but we were not
 able to do much without introducing breaking changes.
 
@@ -122,10 +122,9 @@ like layers.
 
 These two new features not only make sampling a lot more straight-forward, they
 also allow other possibilities such as drafting a pattern for two sets of
-measurements when dealing with an assymetric body.
+measurements when dealing with an asymmetric body.
 
-### Provide more generic extending capabilities, rather than tight-coupling
-with our frontend
+### Provide more generic extending capabilities, rather than tight-coupling with our frontend
 
 This is something that works on two different levels.
 
@@ -143,7 +142,7 @@ extend the software with the features they need for frontend integration.
 
 Removing the FreeSewing.org specific stuff means that designs now no longer
 ship with any FreeSewing.org specific info.  Instead, plugins can now further
-extend core with *store methods*, and we allow passing in any data into the
+extend core with *store methods*, and we allow passing any data into the
 design that you can then access on the pattern object.
 
 You can also add additional data to your part's options to further facilitate

--- a/markdown/dev/guides/v3/migration/en.md
+++ b/markdown/dev/guides/v3/migration/en.md
@@ -26,7 +26,7 @@ To make this explicit, we now use `.mjs` as file extention for our source code.
 All our published packages now have only named exports, and no longer any
 default exports.
 
-Please refer to [the reference documentation](/reference/api/core) to see what
+Please refer to [the reference documentation](/reference/api#named-exports) to see what
 named exports are available.
 
 ### NodeJS 16 or more recent

--- a/markdown/dev/howtos/git/editing-content-on-github/en.md
+++ b/markdown/dev/howtos/git/editing-content-on-github/en.md
@@ -61,8 +61,11 @@ contains several files, one for each language.
 - Select on the file you want to update. 
 
 <Warning>
+  
 Please only edit the English language files (called `en.md`), 
-our translation software will handle the other languages.
+our translation software will handle the other languages. 
+Read more about translations in our [translation guide](/guides/translation).
+  
 </Warning>
 - Click on the **Edit** button.
 ![edit button image](edit-button.png)

--- a/markdown/dev/reference/api/en.md
+++ b/markdown/dev/reference/api/en.md
@@ -11,7 +11,7 @@ sewing patterns, but can be utilized for a variety of similar 2D design tasks.
 ##### Looking to get started?
 
 You are currently browsing the reference documentation. 
-Please refer to [the quick start guide](/guides/quick) to get started.
+Please refer to our [tutorials](/tutorials) to get started.
 
 </Tip>
 

--- a/markdown/dev/reference/api/en.md
+++ b/markdown/dev/reference/api/en.md
@@ -59,20 +59,20 @@ The following named exports are **uitility methods**:
 
 | Named export | Description |
 | ------------ | ------------|
-| `beamIntersectsCircle`    | See the [beamIntersectsCircle](/reference/api/utils/beamintersectsCircle) documentation |
-| `beamIntersectsX`         | See the [beamIntersectsX](/reference/api/utils/beamintersectsX) documentation |
-| `beamIntersectsY`         | See the [beamIntersectsY](/reference/api/utils/) documentation |
+| `beamIntersectsCircle`    | See the [beamIntersectsCircle](/reference/api/utils/beamintersectscircle) documentation |
+| `beamIntersectsX`         | See the [beamIntersectsX](/reference/api/utils/beamintersectsx) documentation |
+| `beamIntersectsY`         | See the [beamIntersectsY](/reference/api/utils//beamintersectsy) documentation |
 | `beamsIntersect`          | See the [beamsIntersect](/reference/api/utils/beamsintersect) documentation |
 | `capitalize`              | See the [capitalize](/reference/api/utils/capitalize) documentation |
 | `circlesIntersect`        | See the [circlesIntersect](/reference/api/utils/circlesintersect) documentation |
 | `curveEdge`               | See the [curveEdge](/reference/api/utils/curveedge) documentation |
-| `curveIntersectsX`        | See the [curveIntersectsX](/reference/api/utils/curveintersectsX) documentation |
-| `curveIntersectsY`        | See the [curveIntersectsY](/reference/api/utils/curveintersectsY) documentation |
+| `curveIntersectsX`        | See the [curveIntersectsX](/reference/api/utils/curveintersectsx) documentation |
+| `curveIntersectsY`        | See the [curveIntersectsY](/reference/api/utils/curveintersectsy) documentation |
 | `curvesIntersect`         | See the [curvesIntersect](/reference/api/utils/curvesintersect) documentation |
 | `deg2rad`                 | See the [deg2rad](/reference/api/utils/deg2rad) documentation |
 | `generateStackTransform`  | see the [generateStackTransform](/reference/api/utils/generateStackTransform) documentation |
-| `lineIntersectsCircle`    | See the [lineIntersectsCircle](/reference/api/utils/lineintersectsCircle) documentation |
-| `lineIntersectsCurve`     | See the [lineIntersectsCurve](/reference/api/utils/lineintersectsCurve) documentation |
+| `lineIntersectsCircle`    | See the [lineIntersectsCircle](/reference/api/utils/lineintersectscircle) documentation |
+| `lineIntersectsCurve`     | See the [lineIntersectsCurve](/reference/api/utils/lineintersectscurve) documentation |
 | `linesIntersect`          | See the [linesIntersect](/reference/api/utils/linesintersect) documentation |
 | `pctBasedOn`              | See the [pctBasedOn](/reference/api/utils/pctbasedon) documentation |
 | `pointOnBeam`             | See the [pointOnBeam](/reference/api/utils/pointonbeam) documentation |


### PR DESCRIPTION
There are a few broken links where I could not find where they supposed to go (nothing in the search):

On https://freesewing.dev/reference/api:
`/reference/api/utils/generateStackTransform`
`/reference/api/utils/curveedge`

On https://freesewing.dev/guides/v3:
`/reference/api/attributes/addclass`
`/reference/api/store/remove`
I pointed the `part` links to the `/part/draft` pages, I hope that's correct.

Also, there is no quick start guide, right, @joostdecock? I linked to the tutorials instead.

Additionally, I added a link to the translation guide in the part where we talk about the `en.md` files.