### PR TITLE
Remove duplicated `Added:` in changelog

### DIFF
--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -98,12 +98,10 @@ Unreleased:
       - Use localized date format
     unice:
       - Updated gusset to always curve inward
-      
+
   Added:
     unice:
       - Added new Front Curve and Back Curve style options
-
-  Added:
     waralee:
       - Added *mini* version of main pants part
       - Added new pocket options


### PR DESCRIPTION
It resulted in `npm run reconfigure` failing, which in turn made `yarn new design` fail in a spectacular and confusing way.