### PR TITLE
(fix) Add name to sites/email/package.json. Fixes #3052.

### DIFF
--- a/sites/email/package.json
+++ b/sites/email/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "freesewing.email",
   "private": true,
   "scripts": {
     "dev": "maizzle serve",


### PR DESCRIPTION
A fix to avoid a `yarn kickstart` error: https://github.com/freesewing/freesewing/issues/3052