### PR TITLE
chore(designs.json): Normalize tags by changing "historic" to "historical".

### DIFF
--- a/config/software/designs.json
+++ b/config/software/designs.json
@@ -282,7 +282,7 @@
       "code": "Rika Tamaike",
       "design": "Rika Tamaike",
       "difficulty": 1,
-      "tags": ["tops", "historic"]
+      "tags": ["tops", "historical"]
     },
     "unice": {
       "description": "A FreeSewing pattern for a basic, highly-customizable underwear pattern",
@@ -310,7 +310,7 @@
       "code": "Rika Tamaike",
       "design": "Rika Tamaike",
       "difficulty": 1,
-      "tags": ["bottoms", "historic"]
+      "tags": ["bottoms", "historical"]
     },
     "waralee": {
       "description": "A FreeSewing pattern for wrap pants",


### PR DESCRIPTION
This PR changes the two instances of "historic" tags to "historical" in `config/software/designs.json` for consistency. The other two designs use "historical".

I checked with the design author, and they are okay with this change:
https://discord.com/channels/698854858052075530/757631205804998759/1028313790904815719
