### PR TITLE
fix(new-design): Use Next.js version 12. Fixes #3050.

### DIFF
--- a/packages/new-design/templates/from-bella/package.json.mustache
+++ b/packages/new-design/templates/from-bella/package.json.mustache
@@ -61,7 +61,7 @@
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "lodash.clonedeep": "^4.5.0",
-    "next": "latest",
+    "next": "^12.3.2",
     "next-i18next": "^11.0.0",
     "react-copy-to-clipboard": "^5.0.4",
     "react-hotkeys-hook": "^3.4.4",

--- a/packages/new-design/templates/from-bent/package.json.mustache
+++ b/packages/new-design/templates/from-bent/package.json.mustache
@@ -63,7 +63,7 @@
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "lodash.clonedeep": "^4.5.0",
-    "next": "latest",
+    "next": "^12.3.2",
     "next-i18next": "^11.0.0",
     "react-copy-to-clipboard": "^5.0.4",
     "react-hotkeys-hook": "^3.4.4",

--- a/packages/new-design/templates/from-breanna/package.json.mustache
+++ b/packages/new-design/templates/from-breanna/package.json.mustache
@@ -63,7 +63,7 @@
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "lodash.clonedeep": "^4.5.0",
-    "next": "latest",
+    "next": "^12.3.2",
     "next-i18next": "^11.0.0",
     "react-copy-to-clipboard": "^5.0.4",
     "react-hotkeys-hook": "^3.4.4",

--- a/packages/new-design/templates/from-brian/package.json.mustache
+++ b/packages/new-design/templates/from-brian/package.json.mustache
@@ -60,7 +60,7 @@
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "lodash.clonedeep": "^4.5.0",
-    "next": "latest",
+    "next": "^12.3.2",
     "next-i18next": "^11.0.0",
     "react-copy-to-clipboard": "^5.0.4",
     "react-hotkeys-hook": "^3.4.4",

--- a/packages/new-design/templates/from-scratch/package.json.mustache
+++ b/packages/new-design/templates/from-scratch/package.json.mustache
@@ -61,7 +61,7 @@
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "lodash.clonedeep": "^4.5.0",
-    "next": "latest",
+    "next": "^12.3.2",
     "next-i18next": "^11.0.0",
     "pdfkit": "^0.13.0",
     "react-copy-to-clipboard": "^5.0.4",

--- a/packages/new-design/templates/from-titan/package.json.mustache
+++ b/packages/new-design/templates/from-titan/package.json.mustache
@@ -63,7 +63,7 @@
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "lodash.clonedeep": "^4.5.0",
-    "next": "latest",
+    "next": "^12.3.2",
     "next-i18next": "^11.0.0",
     "react-copy-to-clipboard": "^5.0.4",
     "react-hotkeys-hook": "^3.4.4",

--- a/packages/new-design/templates/from-tutorial/package.json.mustache
+++ b/packages/new-design/templates/from-tutorial/package.json.mustache
@@ -61,7 +61,7 @@
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "lodash.clonedeep": "^4.5.0",
-    "next": "latest",
+    "next": "^12.3.2",
     "next-i18next": "^11.0.0",
     "pdfkit": "^0.13.0",
     "react-copy-to-clipboard": "^5.0.4",


### PR DESCRIPTION
This PR fixes https://github.com/freesewing/freesewing/issues/3050 by specifying Next.js version 12 in the `package.json` files. The version that we previously specified was simply "latest", and this is caused issues after Next.js updated to version 13.

Because the issue is affecting standalone development via `npx @freesewing/new-design@next`, after the code changes are pulled the fix will also need to be deployed, if that is a separate step.