### PR TITLE
fix(new-design): Add missing dependencies to package.json. Fixes #3051.

### DIFF
--- a/packages/new-design/templates/from-bella/package.json.mustache
+++ b/packages/new-design/templates/from-bella/package.json.mustache
@@ -35,6 +35,7 @@
   "dependencies": {
     "@freesewing/core": "{{ tag }}",
     "@freesewing/bella": "{{ tag }}",
+    "@freesewing/plugin-bundle": "{{ tag }}"
   },
   "devDependencies": {
     "@freesewing/plugin-svgattr": "{{ tag }}",

--- a/packages/new-design/templates/from-bent/package.json.mustache
+++ b/packages/new-design/templates/from-bent/package.json.mustache
@@ -34,7 +34,10 @@
   },
   "dependencies": {
     "@freesewing/core": "{{ tag }}",
-    "@freesewing/bent": "{{ tag }}"
+    "@freesewing/bent": "{{ tag }}",
+    "@freesewing/brian": "{{ tag }}",
+    "@freesewing/plugin-bundle": "{{ tag }}",
+    "@freesewing/plugin-bust": "{{ tag }}"
   },
   "devDependencies": {
     "@freesewing/plugin-svgattr": "{{ tag }}",

--- a/packages/new-design/templates/from-breanna/package.json.mustache
+++ b/packages/new-design/templates/from-breanna/package.json.mustache
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "@freesewing/core": "{{ tag }}",
-    "@freesewing/breanna": "{{ tag }}"
+    "@freesewing/breanna": "{{ tag }}",
+    "@freesewing/plugin-bundle": "{{ tag }}"
   },
   "devDependencies": {
     "@freesewing/plugin-svgattr": "{{ tag }}",

--- a/packages/new-design/templates/from-brian/package.json.mustache
+++ b/packages/new-design/templates/from-brian/package.json.mustache
@@ -34,7 +34,9 @@
   },
   "dependencies": {
     "@freesewing/core": "{{ tag }}",
-    "@freesewing/brian": "{{ tag }}"
+    "@freesewing/brian": "{{ tag }}",
+    "@freesewing/plugin-bundle": "{{ tag }}",
+    "@freesewing/plugin-bust": "{{ tag }}"
   },
   "devDependencies": {
     "@freesewing/plugin-svgattr": "{{ tag }}",

--- a/packages/new-design/templates/from-titan/package.json.mustache
+++ b/packages/new-design/templates/from-titan/package.json.mustache
@@ -34,7 +34,9 @@
   },
   "dependencies": {
     "@freesewing/core": "{{ tag }}",
-    "@freesewing/titan": "{{ tag }}"
+    "@freesewing/titan": "{{ tag }}",
+    "@freesewing/snapseries": "{{ tag }}",
+    "@freesewing/plugin-bundle": "{{ tag }}"
   },
   "devDependencies": {
     "@freesewing/plugin-svgattr": "{{ tag }}",


### PR DESCRIPTION
This fixes https://github.com/freesewing/freesewing/issues/3051 for all of the new-design templates by adding the missing dependencies to `package.json`.