### PR TITLE
chore: Change config-helpers to snapseries

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug-report.yaml
@@ -1,8 +1,8 @@
 ---
 name: 🐛 Bug report
 description: Report a problem, or something that went wrong
-title: "[bug]: "
-labels: [ "\U0001F41B bug" ]
+title: '[bug]: '
+labels: ["\U0001F41B bug"]
 body:
   - type: markdown
     attributes:
@@ -10,7 +10,7 @@ body:
   - type: textarea
     id: desc
     attributes:
-      label: "What seems to be the problem? 🤔"
+      label: 'What seems to be the problem? 🤔'
       description: Please provide a clear and concise description of the problem you encountered
       placeholder: |
         When I generate a Simone with my dimensions, the corners of the yoke appear malformed. \
@@ -18,7 +18,7 @@ body:
   - type: dropdown
     id: pkg
     attributes:
-      label: "Design / Plugin / Package 🧐"
+      label: 'Design / Plugin / Package 🧐'
       description: Do you know what design/plugin/package the bug is in?
       multiple: true
       options:
@@ -98,7 +98,6 @@ body:
         - plugins/plugin-validate
         - plugins/plugin-versionfree-svg
         - packages/components
-        - packages/config-helpers
         - packages/core
         - packages/css-theme
         - packages/gatsby-remark-jargon
@@ -110,17 +109,18 @@ body:
         - packages/prettier-config
         - packages/rehype-jargon
         - packages/remark-jargon
+        - packages/snapseries
         - packages/utils
   - type: dropdown
     id: patron
     attributes:
-      label: Are you a FreeSewing patron? 😃 
-      description: "Patrons support us financially :pray: so they get priority"
+      label: Are you a FreeSewing patron? 😃
+      description: 'Patrons support us financially :pray: so they get priority'
       options:
-        - "Yes, I am a tier-2 patron ❤️"
-        - "Yes, I am a tier-4 patron ❤️  💙"
-        - "Yes, I am a tier-8 patron ❤️  💙 💜"
-        - "No, I am not 😞"
+        - 'Yes, I am a tier-2 patron ❤️'
+        - 'Yes, I am a tier-4 patron ❤️  💙'
+        - 'Yes, I am a tier-8 patron ❤️  💙 💜'
+        - 'No, I am not 😞'
     validations:
       required: true
   - type: textarea
@@ -133,3 +133,4 @@ body:
       value: |
         Please keep in mind that **FreeSewing is a community project** that depends on **[your support](https://freesewing.org/community/join/)**.
 ---
+

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -2,7 +2,6 @@
 labelPRBasedOnFilePath:
   # "label": [ folder or subfolders ]
   ":package: components": [ packages/components/* ]
-  ":package: config-helpers": [ packages/config-helpers/* ]
   ":package: core": [ packages/core/* ]
   ":package: create-freesewing-pattern": [ packages/create-freesewing-pattern/* ]
   ":package: css-theme": [ packages/css-theme/* ]
@@ -15,6 +14,7 @@ labelPRBasedOnFilePath:
   ":package: prettier-config": [ packages/prettier-config/* ]
   ":package: rehype-jargon": [ packages/rehype-jargon/* ]
   ":package: remark-jargon": [ packages/remark-jargon/* ]
+  ":package: snapseries": [ packages/snapseries/* ]
   ":package: utils": [ packages/utils/* ]
   ":electric_plug: plugin-banner": [ plugins/plugin-banner/* ]
   ":electric_plug: plugin-bartack": [ plugins/plugin-bartack/* ]

--- a/config/build-order.mjs
+++ b/config/build-order.mjs
@@ -6,7 +6,7 @@ import { designs, plugins, packages } from './software/index.mjs'
  * order. This file takes care of that
  */
 
-const first = ['core', 'config-helpers', 'remark-jargon', 'snapseries']
+const first = ['core', 'remark-jargon', 'snapseries']
 const blocks = ['brian', 'titan', 'bella', 'breanna']
 const extended = ['bent', 'simon', 'carlton', 'ursula']
 const last = ['i18n']

--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -3,7 +3,6 @@ _types:
     peer:
       '@freesewing/core': &freesewing '^{{version}}'
       '@freesewing/plugin-bundle': *freesewing
-      '@freesewing/config-helpers': *freesewing
     dev:
       'mocha': &mocha '^10.0.0'
       'chai': &chai '^4.2.0'
@@ -50,6 +49,7 @@ charlie:
     '@freesewing/plugin-bartack': *freesewing
     '@freesewing/plugin-mirror': *freesewing
     '@freesewing/titan': *freesewing
+    '@freesewing/snapseries': *freesewing
 core:
   _:
     'bezier-js': '^6.1.0'
@@ -111,6 +111,7 @@ legend:
 paco:
   peer:
     '@freesewing/titan': *freesewing
+    '@freesewing/snapseries': *freesewing
 plugin-bundle:
   dev:
     '@freesewing/plugin-banner': *freesewing
@@ -154,6 +155,10 @@ rehype-jargon:
 rehype-highlight-lines:
   _:
     'unist-util-remove': '^3.1.0'
+sandy:
+  '@freesewing/snapseries': *freesewing
+shin:
+  '@freesewing/snapseries': *freesewing
 simon:
   peer:
     '@freesewing/brian': *freesewing
@@ -176,6 +181,10 @@ teagan:
   peer:
     '@freesewing/brian': *freesewing
     '@freesewing/plugin-bust': *freesewing
+titan:
+  '@freesewing/snapseries': *freesewing
+trayvon:
+  '@freesewing/snapseries': *freesewing
 wahid:
   peer:
     '@freesewing/brian': *freesewing

--- a/sites/shared/config/next.mjs
+++ b/sites/shared/config/next.mjs
@@ -11,14 +11,13 @@ import { designs, plugins } from '../../../config/software/index.mjs'
  * srcPkgs: Array of folders in the monorepo/packages that should be aliased
  * so they are loaded from source, rather than from a compiled bundle
  */
-const config = (site, remarkPlugins=[]) => ({
+const config = (site, remarkPlugins = []) => ({
   experimental: {
     externalDir: true,
   },
-  pageExtensions: [ 'js', 'md', 'mjs' ],
+  pageExtensions: ['js', 'md', 'mjs'],
   webpack: (config, options) => {
-
-		// Fixes npm packages that depend on node modules
+    // Fixes npm packages that depend on node modules
     if (!options.isServer) {
       config.resolve.fallback.fs = false
       config.resolve.fallback.path = false
@@ -34,35 +33,30 @@ const config = (site, remarkPlugins=[]) => ({
           loader: '@mdx-js/loader',
           //providerImportSource: '@mdx-js/react',
           options: {
-            remarkPlugins: [
-              remarkGfm,
-              ...remarkPlugins,
-            ]
-          }
-        }
-      ]
+            remarkPlugins: [remarkGfm, ...remarkPlugins],
+          },
+        },
+      ],
     })
 
     // YAML support
     config.module.rules.push({
       test: /\.ya?ml$/,
-      use: 'yaml-loader'
+      use: 'yaml-loader',
     })
 
     // Fix for nextjs bug #17806
     config.module.rules.push({
       test: /index.mjs$/,
-      type: "javascript/auto",
+      type: 'javascript/auto',
       resolve: {
-        fullySpecified: false
-      }
+        fullySpecified: false,
+      },
     })
 
     // Suppress warnings about importing version from package.json
     // We'll deal with it in v3 of FreeSewing
-    config.ignoreWarnings = [
-      /only default export is available soon/
-    ]
+    config.ignoreWarnings = [/only default export is available soon/]
 
     // Aliases
     config.resolve.alias.shared = path.resolve('../shared/')
@@ -75,19 +69,25 @@ const config = (site, remarkPlugins=[]) => ({
 
     // Load designs from source, rather than compiled package
     for (const design in designs) {
-      config.resolve.alias[`@freesewing/${design}$`] = path.resolve(`../../designs/${design}/src/index.mjs`)
+      config.resolve.alias[`@freesewing/${design}$`] = path.resolve(
+        `../../designs/${design}/src/index.mjs`
+      )
     }
     // Load plugins from source, rather than compiled package
     for (const plugin in plugins) {
-      config.resolve.alias[`@freesewing/${plugin}$`] = path.resolve(`../../plugins/${plugin}/src/index.mjs`)
+      config.resolve.alias[`@freesewing/${plugin}$`] = path.resolve(
+        `../../plugins/${plugin}/src/index.mjs`
+      )
     }
     // Load these from source, rather than compiled package
-    for (const pkg of ['core', 'config-helpers', 'i18n', 'models']) {
-      config.resolve.alias[`@freesewing/${pkg}$`] = path.resolve(`../../packages/${pkg}/src/index.mjs`)
+    for (const pkg of ['core', 'snapseries', 'i18n', 'models']) {
+      config.resolve.alias[`@freesewing/${pkg}$`] = path.resolve(
+        `../../packages/${pkg}/src/index.mjs`
+      )
     }
 
     return config
-  }
+  },
 })
 
 export default config

--- a/sites/shared/config/next.mjs
+++ b/sites/shared/config/next.mjs
@@ -80,7 +80,7 @@ const config = (site, remarkPlugins = []) => ({
       )
     }
     // Load these from source, rather than compiled package
-    for (const pkg of ['core', 'snapseries', 'i18n', 'models']) {
+    for (const pkg of ['core', 'i18n', 'models', 'snapseries']) {
       config.resolve.alias[`@freesewing/${pkg}$`] = path.resolve(
         `../../packages/${pkg}/src/index.mjs`
       )


### PR DESCRIPTION
This PR changes instances of `config-helpers` to `snapseries` (or removes it where appropriate). 

For the design dependencies yaml template, it removes `config-helpers` from all designs and adds `snapseries` to the individual designs that require it. (I didn't touch the actual `designs/*/package.json` files. They will just get updated with the next `yarn reconfigure`.)

Additional edits were made by `eslint`.