### PR TITLE
(fix) Remove duplicate snapseries package from software config.

### DIFF
--- a/config/software/packages.json
+++ b/config/software/packages.json
@@ -1,5 +1,4 @@
 {
-  "snapseries": "A FreeSewing package to facilitate snapped percentage options in designs",
   "core": "A library for creating made-to-measure sewing patterns",
   "i18n": "Translations for the FreeSewing project",
   "models": "Body measurements data for a range of default sizes",


### PR DESCRIPTION
"snapseries" is listed twice in `config/software/packages.json`. This PR removes one of the entries.