### PR TITLE
fix(core): In Path.clean(), initialize cur variable before use.

### DIFF
--- a/packages/core/src/path.mjs
+++ b/packages/core/src/path.mjs
@@ -177,6 +177,7 @@ Path.prototype.bbox = function () {
  */
 Path.prototype.clean = function () {
   const ops = []
+  let cur
   for (const i in this.ops) {
     const op = this.ops[i]
     if (['move', 'close', 'noop'].includes(op.type)) ops.push(op)
@@ -186,7 +187,7 @@ Path.prototype.clean = function () {
       if (!(op.cp1.sitsRoughlyOn(cur) && op.cp2.sitsRoughlyOn(cur) && op.to.sitsRoughlyOn(cur)))
         ops.push(ops)
     }
-    const cur = op?.to
+    cur = op?.to
   }
 
   if (ops.length < this.ops.length) this.ops = ops


### PR DESCRIPTION
Per the comments in https://github.com/freesewing/freesewing/commit/fab1e2f8777e75ef950016b594230435752ccf30, that commit which added `Path.clean()` also introduced 3 test errors:
```
  1) Path
       offset
         Should offset a curve:
     ReferenceError: Cannot access 'cur' before initialization
...
  2) Path
       offset
         Should offset a curve where cp1 = start:
     ReferenceError: Cannot access 'cur' before initialization
...
  3) Path
       offset
         Should offset a curve where cp2 = end:
     ReferenceError: Cannot access 'cur' before initialization
      at Path.clean (.../packages/core/src/path.mjs:186:34)
...
```

The issue seems to be limited to the test errors. No problems are seen in the `develop` localhost lab.