### PR TITLE
fix(breanna): Eliminate warning messages when there is no secondary dart

### DIFF
--- a/designs/breanna/src/dart-utils.mjs
+++ b/designs/breanna/src/dart-utils.mjs
@@ -84,27 +84,39 @@ export function getDartLocationsAsNumbers(options) {
   else return [loc1, loc2]
 }
 
-export const getDartPaths = (Path, points) => [
-  new Path()
-    .line(points.primaryBustDart1)
-    .line(points.primaryBustDartTip)
-    .line(points.primaryBustDart2),
-  new Path()
-    .line(points.secondaryBustDart1)
-    .line(points.secondaryBustDartTip)
-    .line(points.secondaryBustDart2),
-]
+export const getDartPaths = (Path, points) => {
+  let dart_paths = [
+    new Path()
+      .line(points.primaryBustDart1)
+      .line(points.primaryBustDartTip)
+      .line(points.primaryBustDart2),
+  ]
+  if ('secondaryBustDart1' in points)
+    dart_paths.push(
+      new Path()
+        .line(points.secondaryBustDart1)
+        .line(points.secondaryBustDartTip)
+        .line(points.secondaryBustDart2)
+    )
+  return dart_paths
+}
 
-export const getSaDartPaths = (Path, points) => [
-  new Path()
-    .line(points.primaryBustDart1)
-    .line(points.primaryBustDartEdge)
-    .line(points.primaryBustDart2),
-  new Path()
-    .line(points.secondaryBustDart1)
-    .line(points.secondaryBustDartEdge)
-    .line(points.secondaryBustDart2),
-]
+export const getSaDartPaths = (Path, points) => {
+  let dart_paths = [
+    new Path()
+      .line(points.primaryBustDart1)
+      .line(points.primaryBustDartEdge)
+      .line(points.primaryBustDart2),
+  ]
+  if ('secondaryBustDart1' in points)
+    dart_paths.push(
+      new Path()
+        .line(points.secondaryBustDart1)
+        .line(points.secondaryBustDartEdge)
+        .line(points.secondaryBustDart2)
+    )
+  return dart_paths
+}
 
 /*
  * Once the front is constructed with the theorethical bust darts, we


### PR DESCRIPTION
This PR fixes the issue of when there is no secondary bust dart (set to none or set to same as primary bust dart), 6 warning messages are logged.
![Screenshot 2022-12-05 at 6 48 25 AM](https://user-images.githubusercontent.com/109869956/205667440-6dcce1ea-a5c6-4834-8e43-580947a788cd.png)
