### PR TITLE
chore(org): Add jargon file. Fixes #3109.

### DIFF
--- a/sites/org/jargon.mjs
+++ b/sites/org/jargon.mjs
@@ -1,0 +1,3 @@
+const jargon = {}
+
+export default jargon


### PR DESCRIPTION
From the documentation page https://freesewing.dev/guides/markdown/jargon#adding-jargon , it appears that the intention was that a `sites/org/jargon.mjs` file should exist. However, that file does not exist, and the URL linked on the documentation page points to a 404 page.

This PR adds the missing jargon file.