### PR TITLE
chore(docs): Add Utils.curveedge() documentation. Closes #3143.

### DIFF
--- a/markdown/dev/reference/api/en.md
+++ b/markdown/dev/reference/api/en.md
@@ -65,6 +65,7 @@ The following named exports are **utility methods**:
 | `beamsIntersect`          | See the [beamsIntersect](/reference/api/utils/beamsintersect) documentation |
 | `capitalize`              | See the [capitalize](/reference/api/utils/capitalize) documentation |
 | `circlesIntersect`        | See the [circlesIntersect](/reference/api/utils/circlesintersect) documentation |
+| `curveEdge`               | See the [curveEdge](/reference/api/utils/curveedge) documentation |
 | `curveIntersectsX`        | See the [curveIntersectsX](/reference/api/utils/curveintersectsx) documentation |
 | `curveIntersectsY`        | See the [curveIntersectsY](/reference/api/utils/curveintersectsy) documentation |
 | `curvesIntersect`         | See the [curvesIntersect](/reference/api/utils/curvesintersect) documentation |

--- a/markdown/dev/reference/api/utils/curveedge/en.md
+++ b/markdown/dev/reference/api/utils/curveedge/en.md
@@ -1,0 +1,47 @@
+---
+title: utils.curveEdge()
+---
+
+The `utils.curveEdge()` function finds the edge of a cubic Bezier curve, given the curve, the edge to find ("top", "bottom", "left", or "right"), and the number of steps to divide the curve into while walking it.
+
+## Signature
+
+```js
+Point utils.curveEdge(
+  Bezier curve,
+  string edge,
+  int steps = 500)
+```
+
+## Example
+
+<Example caption="A Utils.curveEdge() example">
+```js
+({ Point, points, Path, paths, Snippet, snippets, utils, part }) => {
+
+  points.A = new Point(20, 10)
+  points.Acp = new Point(310, 40)
+  points.Bcp = new Point(-210, 40)
+  points.B = new Point(100, 70)
+
+  paths.pathA = new Path()
+    .move(points.A)
+    .curve(points.Acp, points.Bcp, points.B)
+
+/*
+  let curveA = new Bezier(
+    { x: points.A.x, y: points.A.y },
+    { x: points.Acp.x, y: points.Acp.y },
+    { x: points.Bcp.x, y: points.Bcp.y },
+    { x: points.B.x, y: points.B.y }
+  )
+  */
+  let curveA = utils.bezier(points.A, points.Acp, points.Bcp, points.B)
+
+  points.edge = utils.curveEdge(curveA, "left")
+  snippets.edge = new Snippet("notch", points.edge)
+
+  return part
+}
+```
+</Example>

--- a/packages/core/src/utils.mjs
+++ b/packages/core/src/utils.mjs
@@ -44,7 +44,7 @@ export function beamIntersectsCircle(c, r, p1, p2, sort = 'x') {
 }
 
 /**
- * Finds qhere an endless line intersects with a given X-value
+ * Finds where an endless line intersects with a given X-value
  *
  * @param {Point} from - First Point on the line
  * @param {Point} to - Second Point on the line
@@ -60,7 +60,7 @@ export function beamIntersectsX(from, to, x) {
 }
 
 /**
- * Finds qhere an endless line intersects with a given Y-value
+ * Finds where an endless line intersects with a given Y-value
  *
  * @param {Point} from - First Point 1 on the line
  * @param {Point} to - Second Point on the line
@@ -109,6 +109,20 @@ export function beamsIntersect(a1, a2, b1, b2) {
 
     return new Point(x, y)
   }
+}
+
+/**
+ * Constructs and returns a BezierJs instance curve
+ *
+ * @param {Point} from - The starting point
+ * @param {Point} cp1 - The first control point
+ * @param {Point} cp2 - The second control point
+ * @param {Point} to - The end point
+ * @return {BezierJs} bezier - The Bezier curve
+ */
+export function bezier(from, cp1, cp2, to) {
+  const bezier = new Bezier(from, cp1, cp2, to)
+  return bezier
 }
 
 /**


### PR DESCRIPTION
This PR might need modification, but I will need guidance about how to proceed.

I ran into issues when creating the Example for `curveEdge()`. I was not able to import BezierJS to use in the live Example, so I was not able to create the required `Bezier` object. 

As a workaround, I created a new `Utils.bezier()` helper function that creates and returns a `Bezier`. If this is not the best way to resolve the issue, the code change will need to be removed from this PR.

In the documentation Example, I commented out the original code I was trying to use. If we do keep `Utils.bezier()`, then we might want to remove this commented code from this PR. (But, we could also just keep it in to demonstrate how to create a `Bezier` directly.)

If we keep `Utils.bezier()`, then further work will need to be done to create documentation for it.

It could be that we might want to simply omit the live Example for `curveEdge()`. Instead, we could just list the code that should be used.