### PR TITLE
fix(core): Update Pattern.sampleOptions() and documentation

### DIFF
--- a/markdown/dev/reference/api/pattern/sampleoption/en.md
+++ b/markdown/dev/reference/api/pattern/sampleoption/en.md
@@ -7,13 +7,13 @@ to draft multiple variants of the same pattern, and stack them on
 top of each other.
 
 In this particular case, the variants it drafts depend
- on [the type of option](/config/options/):
+ on [the type of option](/reference/api/part/config/options/):
 
-- For options that are an object with a **min** and **max** property, 10 steps will be sampled, between min and max
-- For options that are a numeric value (**constants**), 10 steps will be sampled between 90% and 110% of the value
-- For options with a **list** of options, each option in the list will be sampled
-
-<Fixme>Handle other option types</Fixme>
+- For a Percentage or Degree option, 10 steps will be sampled, between min and max
+- For a Counter or Millimeter option, a maximum of 10 steps will be sampled, between min and max
+- For a Constant numeric option, 10 steps will be sampled between 90% and 110% of the value
+- For a List option, each option in the list will be sampled
+- For a Boolean option, both `false` and `true` will be sampled
 
 <Tip>
 The goal of option sampling is to verify the impact of an option on the pattern, and verify that
@@ -38,5 +38,5 @@ const pattern = new Aaron({
   measurements: cisFemaleAdult34
 })
 
-const svg = pattern.draft().sampleMeasurement('chest')
+const svg = pattern.draft().sampleOption('backlineBend')
 ```


### PR DESCRIPTION
This is a more complicated PR, with a number of changes to `packages/core/src/pattern.mjs` to allow `Pattern.sampleOptions()` to work with all option types:
- Return an empty array of sets if the `optionName` does not exist (instead of throwing an error).
- Code refactoring to allow a different numbers of runs/steps (needed for `count` and `mm` options where there might be fewer than 10 values to step through).
- For `count` and `mm` options, adjust the number of runs/steps if needed and `round()` the values to integers.
- Extend `__listOptionSets()` to also work with Boolean options. Rename the method to `__listBoolOptionSets()`.

The PR also includes an update to the `Pattern.sampleOptions()` documentation for the new functionality.

I tested the code changes with every type of option, except `mm`.