### PR TITLE
fix(docs): Harmonize shoulder tip measurement wording

### DIFF
--- a/markdown/org/docs/measurements/shouldertoelbow/en.md
+++ b/markdown/org/docs/measurements/shouldertoelbow/en.md
@@ -2,6 +2,11 @@
 title: Shoulder to elbow
 ---
 
-The **shoulder to elbow** measurement runs from the edge of your shoulder down to your elbow.
+The **shoulder to elbow** measurement runs from the tip of your shoulder down to your elbow.
 
-To measure your **shoulder to elbow**, start at the edge of your shoulder, where your sleeve starts at a well-fitting shirt. Follow your arm down to your elbow.
+To measure your **shoulder to elbow**, start at the tip of your shoulder,
+the tip or corner of the protruding bone that is located where the
+top of the shoulder meets the side of the arm.
+It is also where the top of the shoulder seam sits and the sleeve begins
+on a well-fitting dress shirt,
+Follow your arm down to your elbow.

--- a/markdown/org/docs/measurements/shouldertoelbow/en.md
+++ b/markdown/org/docs/measurements/shouldertoelbow/en.md
@@ -8,5 +8,5 @@ To measure your **shoulder to elbow**, start at the tip of your shoulder,
 the tip or corner of the protruding bone that is located where the
 top of the shoulder meets the side of the arm.
 It is also where the top of the shoulder seam sits and the sleeve begins
-on a well-fitting dress shirt,
+on a well-fitting dress shirt.
 Follow your arm down to your elbow.

--- a/markdown/org/docs/measurements/shouldertoshoulder/en.md
+++ b/markdown/org/docs/measurements/shouldertoshoulder/en.md
@@ -4,5 +4,9 @@ title: Shoulder to shoulder
 
 The **shoulder to shoulder** measurement runs from the tip of your shoulder on one side across your back to the tip of your other shoulder.
 
-To measure your **shoulder to shoulder** find the edge of your shoulder where on a good fitting shirt the shoulder seam would sit.
+To measure your **shoulder to shoulder** find the tip of your shoulder,
+the tip or corner of the protruding bone that is located where the
+top of the shoulder meets the side of the arm.
+It is also where the top of the shoulder seam sits and the sleeve begins
+on a well-fitting dress shirt,
 Then, measure from there across your back to the same point at the other side.

--- a/markdown/org/docs/measurements/shouldertoshoulder/en.md
+++ b/markdown/org/docs/measurements/shouldertoshoulder/en.md
@@ -8,5 +8,5 @@ To measure your **shoulder to shoulder** find the tip of your shoulder,
 the tip or corner of the protruding bone that is located where the
 top of the shoulder meets the side of the arm.
 It is also where the top of the shoulder seam sits and the sleeve begins
-on a well-fitting dress shirt,
+on a well-fitting dress shirt.
 Then, measure from there across your back to the same point at the other side.

--- a/markdown/org/docs/measurements/shouldertowrist/en.md
+++ b/markdown/org/docs/measurements/shouldertowrist/en.md
@@ -8,5 +8,5 @@ To measure your **shoulder to wrist** measurement, place your tape measure at th
 the tip or corner of the protruding bone that is located where the
 top of the shoulder meets the side of the arm.
 It is also where the top of the shoulder seam sits and the sleeve begins
-on a well-fitting dress shirt,
+on a well-fitting dress shirt.
 Let your arm hang naturally in a slight bend, and measure along your slightly bent arm up to your wrist.

--- a/markdown/org/docs/measurements/shouldertowrist/en.md
+++ b/markdown/org/docs/measurements/shouldertowrist/en.md
@@ -2,7 +2,11 @@
 title: Shoulder to wrist
 ---
 
-The **shoulder to wrist** measurement determines your sleeve length, and runs from the shoulder point along the arm to your wrist.
+The **shoulder to wrist** measurement determines your sleeve length, and runs from the tip of your shoulder along the arm to your wrist.
 
-To measure your **shoulder to wrist** measurement, place your tape measure at your shoulder point.
+To measure your **shoulder to wrist** measurement, place your tape measure at the tip of your shoulder,
+the tip or corner of the protruding bone that is located where the
+top of the shoulder meets the side of the arm.
+It is also where the top of the shoulder seam sits and the sleeve begins
+on a well-fitting dress shirt,
 Let your arm hang naturally in a slight bend, and measure along your slightly bent arm up to your wrist.


### PR DESCRIPTION
This PR updates the documentation for Shoulder to Elbow, Shoulder, to Shoulder, and Shoulder to Wrist measurements to use the same "tip of the shoulder" wording to describe the start point and where it is located.

(I am holding this as a draft PR for 3 days before marking it as ready.)