### PR TITLE
fix(docs): Arrange measurements into a table with additional information

### DIFF
--- a/markdown/dev/reference/measurements/en.md
+++ b/markdown/dev/reference/measurements/en.md
@@ -66,13 +66,12 @@ they are derived from are provided:
 ## Measurements from pluginBust
 
 In addition, the [pluginBust](/reference/plugins/bust) plugin from
-`@freesewing/plugin-bust` will add and modify the following measurements
-if the `underbust` measurement is provided:
+`@freesewing/plugin-bust` will add and modify the following measurements.
 
-| Measurement | Description | Required Measurements |
-|-------------|-------------|-----------|
-| `bust` | The original `chest` circumference is copied to `bust` and is used as the bust circumference | `underbust` |
-| `chest` | `chest` is changed to the value of `highbust` | `underbust` |
+| Measurement | Description |
+|-------------|-------------|
+| `bust` | Bust circumference (`bust` is set to the value of `chest`) |
+| `chest` | (`chest` is changed to the value of `highBust`) |
 
 <Tip>
 

--- a/markdown/dev/reference/measurements/en.md
+++ b/markdown/dev/reference/measurements/en.md
@@ -47,7 +47,7 @@ currently used by the designs we maintain:
 
 [hps]: https://freesewing.org/docs/measurements/hps/
 
-## Measurements from plugin-measurements
+## Measurements from `plugin-measurements`
 
 In addition, the [@freesewing/plugin-measurements](/reference/plugins/measurements)
 plugin will add the following measurements if the required measurements
@@ -63,7 +63,7 @@ they are derived from are provided:
 | `waistFrontArc` | Half of `waistFront` | `waist`, `waistBack` |
 | `crossSeamBack` | Back portion of `crossSeam` | `crossSeam`,  `crossSeamFront` |
 
-## Measurements from plugin-bust
+## Measurements from `plugin-bust`
 
 In addition, the [@freesewing/plugin-bust](/reference/plugins/bust)
 plugin will add and modify the following measurements.

--- a/markdown/dev/reference/measurements/en.md
+++ b/markdown/dev/reference/measurements/en.md
@@ -47,10 +47,10 @@ currently used by the designs we maintain:
 
 [hps]: https://freesewing.org/docs/measurements/hps/
 
-## Measurements from measurementsPlugin
+## Measurements from plugin-measurements
 
-In addition, [measurementsPlugin](/reference/plugins/measurements) from `@freesewing/plugin-measurements`
-will add the following measurements if the required measurements
+In addition, the [@freesewing/plugin-measurements](/reference/plugins/measurements)
+plugin will add the following measurements if the required measurements
 they are derived from are provided:
 
 | Measurement | Description | Required Measurements |
@@ -63,10 +63,10 @@ they are derived from are provided:
 | `waistFrontArc` | Half of `waistFront` | `waist`, `waistBack` |
 | `crossSeamBack` | Back portion of `crossSeam` | `crossSeam`,  `crossSeamFront` |
 
-## Measurements from bustPlugin
+## Measurements from plugin-measurements
 
-In addition, [bustPlugin](/reference/plugins/bust) from
-`@freesewing/plugin-bust` will add and modify the following measurements.
+In addition, the [@freesewing/plugin-bust](/reference/plugins/bust)
+plugin will add and modify the following measurements.
 
 | Measurement | Description |
 |-------------|-------------|

--- a/markdown/dev/reference/measurements/en.md
+++ b/markdown/dev/reference/measurements/en.md
@@ -63,7 +63,7 @@ they are derived from are provided:
 | `waistFrontArc` | Half of `waistFront` | `waist`, `waistBack` |
 | `crossSeamBack` | Back portion of `crossSeam` | `crossSeam`,  `crossSeamFront` |
 
-## Measurements from plugin-measurements
+## Measurements from plugin-bust
 
 In addition, the [@freesewing/plugin-bust](/reference/plugins/bust)
 plugin will add and modify the following measurements.

--- a/markdown/dev/reference/measurements/en.md
+++ b/markdown/dev/reference/measurements/en.md
@@ -2,58 +2,77 @@
 title: Measurements
 ---
 
-Below is the complete list of measurements currently used by
-the designs we maintain:
+Below are the standard measurement names for all measurements
+currently used by the designs we maintain:
 
-- `ankle`
-- `biceps`
-- `bustFront`
-- `bustPointToUnderbust`
-- `bustSpan`
-- `chest`
-- `crossSeam`
-- `crossSeamFront`
-- `crotchDepth`
-- `head`
-- `heel`
-- `highBust`
-- `highBustFront`
-- `hips`
-- `hpsToBust`
-- `hpsToWaistBack`
-- `hpsToWaistFront`
-- `inseam`
-- `knee`
-- `neck`
-- `seat`
-- `seatBack`
-- `shoulderSlope`
-- `shoulderToElbow`
-- `shoulderToShoulder`
-- `shoulderToWrist`
-- `underbust`
-- `upperLeg`
-- `waist`
-- `waistBack`
-- `waistToFloor`
-- `waistToHips`
-- `waistToKnee`
-- `waistToSeat`
-- `waistToUnderbust`
-- `waistToUpperLeg`
-- `wrist`
+| Measurement | Description |
+|-------------|-------------|
+| `ankle` | Ankle circumference |
+| `biceps` | Biceps circumference |
+| `bustFront` | Front part of `chest` circumference |
+| `bustPointToUnderbust` | Distance from bust point to `underbust` circumference |
+| `bustSpan`  | Distance between two bust apex points |
+| `chest` | Chest circumference at fullest part (but see [pluginBust below](#measurements-from-pluginbust)) |
+| `crossSeam` | Distance from `waist` line in front, through legs, to `waist` line in back |
+| `crossSeamFront` | Front portion of `crossSeam` |
+| `crotchDepth` | Height from surface to `waist` line when seated |
+| `head` | Head circumference |
+| `heel` | Heel circumference |
+| `highBust` | Chest circumference just under the arms |
+| `highBustFront` | Front portion of `highBust` |
+| `hips` | Hips circumference |
+| `hpsToBust` | [High point shoulder][hps] to `bust` line |
+| `hpsToWaistBack` | [High point shoulder][hps] to `waist` line in back |
+| `hpsToWaistFront` | [High point shoulder][hps] to `waist` line in front |
+| `inseam` | Distance from crotch fork to floor |
+| `knee` | Knee circumference |
+| `neck` | Neck circumference |
+| `seat` | Seat circumference |
+| `seatBack` | Back portion of `seat` circumference |
+| `shoulderSlope` | Angle that the shoulder line slopes downward, in degrees |
+| `shoulderToElbow` | Distance from tip of shoulder to elbow |
+| `shoulderToShoulder` | Distance from tip of one shoulder to the other, across the back |
+| `shoulderToWrist` | Distance from tip of shoulder to wrist |
+| `underbust` | Chest circumference just below the breasts |
+| `upperLeg` | Leg circumference near the top of the leg |
+| `waist` | Waist circumference |
+| `waistBack` | Back portion of `waist` circumference |
+| `waistToFloor` | Distance from `waist` line to floor |
+| `waistToHips` | Distance from `waist` line to `hips` circumference, along side of body |
+| `waistToKnee` | Distance from `waist` line to `knee` circumference, along side of body |
+| `waistToSeat` | Distance from `waist` line to `seat` circumference, along side of body |
+| `waistToUnderbust` | Distance from `waist` line to `underbust` circumference, along side of body |
+| `waistToUpperLeg` | Distance from `waist` line to `upperLeg` circumference, along side of body |
+| `wrist` | Wrist circumference |
 
-In addition, the [@freesewing/plugin-measurements](/reference/plugins/measurements) plugin
-will add the following measurements when the measurements they are derived
-from are provided:
+[hps]: https://freesewing.org/docs/measurements/hps/
 
-- `seatFront` (if both `seat` and `seatBack` are provided)
-- `seatBackArc` (if both `seat` and `seatBack` are provided)
-- `seatFrontArc` (if both `seat` and `seatBack` are provided)
-- `waistFront` (if both `waist` and `waistBack` are provided)
-- `waistBackArc` (if both `waist` and `waistBack` are provided)
-- `waistFrontArc` (if both `waist` and `waistBack` are provided)
-- `crossSeamBack` (if both `crossSeam` and `crossSeamFront` are available)
+## Measurements from pluginMeasurements
+
+In addition, the [pluginMeasurements](/reference/plugins/measurements) plugin from `@freesewing/plugin-measurements`
+will add the following measurements if the required measurements
+they are derived from are provided:
+
+| Measurement | Description | Required Measurements |
+|-------------|-------------|-----------|
+| `seatFront` | Front portion of `seat` circumference | `seat`, `seatBack` |
+| `seatBackArc` | Half of `seatBack` | `seat`, `seatBack` |
+| `seatFrontArc` | Half of `seatFront` | `seat`, `seatBack` |
+| `waistFront` | Front portion of `waist` circumference | `waist`, `waistBack` |
+| `waistBackArc` | Half of `waistBack` | `waist`, `waistBack` |
+| `waistFrontArc` | Half of `waistFront` | `waist`, `waistBack` |
+| `crossSeamBack` | Back portion of `crossSeam` | `crossSeam`,  `crossSeamFront` |
+
+## Measurements from pluginBust
+
+In addition, the [pluginBust](/reference/plugins/bust) plugin from
+`@freesewing/plugin-bust` will add and modify the following measurements
+if the `underbust` measurement is provided:
+
+| Measurement | Description | Required Measurements |
+|-------------|-------------|-----------|
+| `bust` | The original `chest` circumference is copied to `bust` and is used as the bust circumference | `underbust` |
+| `chest` | `chest` is changed to the value of `highbust` | `underbust` |
 
 <Tip>
 

--- a/markdown/dev/reference/measurements/en.md
+++ b/markdown/dev/reference/measurements/en.md
@@ -47,9 +47,9 @@ currently used by the designs we maintain:
 
 [hps]: https://freesewing.org/docs/measurements/hps/
 
-## Measurements from pluginMeasurements
+## Measurements from measurementsPlugin
 
-In addition, the [pluginMeasurements](/reference/plugins/measurements) plugin from `@freesewing/plugin-measurements`
+In addition, [measurementsPlugin](/reference/plugins/measurements) from `@freesewing/plugin-measurements`
 will add the following measurements if the required measurements
 they are derived from are provided:
 
@@ -63,9 +63,9 @@ they are derived from are provided:
 | `waistFrontArc` | Half of `waistFront` | `waist`, `waistBack` |
 | `crossSeamBack` | Back portion of `crossSeam` | `crossSeam`,  `crossSeamFront` |
 
-## Measurements from pluginBust
+## Measurements from bustPlugin
 
-In addition, the [pluginBust](/reference/plugins/bust) plugin from
+In addition, [bustPlugin](/reference/plugins/bust) from
 `@freesewing/plugin-bust` will add and modify the following measurements.
 
 | Measurement | Description |


### PR DESCRIPTION
This PR arranges Measurements into a table, along with a short description of each measurement. (The goal is to help developers understand what measurement names represent without having to refer back to the other measurement documentation on the .org site.) It also adds more information about the measurements from `plugin-measurements` and `plugin-bust`.

![Screenshot 2022-12-11 at 10 16 19 AM](https://user-images.githubusercontent.com/109869956/206921604-4e3ddb09-8063-4842-baae-d47797ed012e.png)
