### PR TITLE
chore(docs): Add Utils.curveedge() documentation. Closes #3143. Replaces #3181

### DIFF
--- a/markdown/dev/reference/api/en.md
+++ b/markdown/dev/reference/api/en.md
@@ -65,6 +65,7 @@ The following named exports are **utility methods**:
 | `beamsIntersect`          | See the [beamsIntersect](/reference/api/utils/beamsintersect) documentation |
 | `capitalize`              | See the [capitalize](/reference/api/utils/capitalize) documentation |
 | `circlesIntersect`        | See the [circlesIntersect](/reference/api/utils/circlesintersect) documentation |
+| `curveEdge`               | See the [curveEdge](/reference/api/utils/curveedge) documentation |
 | `curveIntersectsX`        | See the [curveIntersectsX](/reference/api/utils/curveintersectsx) documentation |
 | `curveIntersectsY`        | See the [curveIntersectsY](/reference/api/utils/curveintersectsy) documentation |
 | `curvesIntersect`         | See the [curvesIntersect](/reference/api/utils/curvesintersect) documentation |

--- a/markdown/dev/reference/api/part/draft/en.md
+++ b/markdown/dev/reference/api/part/draft/en.md
@@ -41,6 +41,7 @@ access the following properties:
 | `unhide`          | See [the unhide documentation](/reference/api/part/unhide) |
 | `units`           | A version of [`utils.units()`](/reference/api/utils/units) that is preconfigured with the user's chosenunits |
 | `utils`           | See [the utils documentation](/reference/api/utils) |
+| `Bezier`          | The [bezier-js](https://pomax.github.io/bezierjs/) library's `Bezier` named export |
 || **_Return value_**   |
 | `part`            | Your draft method **must** return this |
 

--- a/markdown/dev/reference/api/utils/curveedge/en.md
+++ b/markdown/dev/reference/api/utils/curveedge/en.md
@@ -17,7 +17,7 @@ Point utils.curveEdge(
 
 <Example caption="A Utils.curveEdge() example">
 ```js
-({ Point, points, Path, paths, Snippet, snippets, utils, part }) => {
+({ Point, points, Path, paths, Snippet, snippets, utils, Bezier, part }) => {
 
   points.A = new Point(20, 10)
   points.Acp = new Point(310, 40)
@@ -28,15 +28,12 @@ Point utils.curveEdge(
     .move(points.A)
     .curve(points.Acp, points.Bcp, points.B)
 
-/*
-  let curveA = new Bezier(
+  const curveA = new Bezier(
     { x: points.A.x, y: points.A.y },
     { x: points.Acp.x, y: points.Acp.y },
     { x: points.Bcp.x, y: points.Bcp.y },
     { x: points.B.x, y: points.B.y }
   )
-  */
-  let curveA = utils.bezier(points.A, points.Acp, points.Bcp, points.B)
 
   points.edge = utils.curveEdge(curveA, "left")
   snippets.edge = new Snippet("notch", points.edge)

--- a/markdown/dev/reference/api/utils/curveedge/en.md
+++ b/markdown/dev/reference/api/utils/curveedge/en.md
@@ -1,0 +1,47 @@
+---
+title: utils.curveEdge()
+---
+
+The `utils.curveEdge()` function finds the edge of a cubic Bezier curve, given the curve, the edge to find ("top", "bottom", "left", or "right"), and the number of steps to divide the curve into while walking it.
+
+## Signature
+
+```js
+Point utils.curveEdge(
+  Bezier curve,
+  string edge,
+  int steps = 500)
+```
+
+## Example
+
+<Example caption="A Utils.curveEdge() example">
+```js
+({ Point, points, Path, paths, Snippet, snippets, utils, part }) => {
+
+  points.A = new Point(20, 10)
+  points.Acp = new Point(310, 40)
+  points.Bcp = new Point(-210, 40)
+  points.B = new Point(100, 70)
+
+  paths.pathA = new Path()
+    .move(points.A)
+    .curve(points.Acp, points.Bcp, points.B)
+
+/*
+  let curveA = new Bezier(
+    { x: points.A.x, y: points.A.y },
+    { x: points.Acp.x, y: points.Acp.y },
+    { x: points.Bcp.x, y: points.Bcp.y },
+    { x: points.B.x, y: points.B.y }
+  )
+  */
+  let curveA = utils.bezier(points.A, points.Acp, points.Bcp, points.B)
+
+  points.edge = utils.curveEdge(curveA, "left")
+  snippets.edge = new Snippet("notch", points.edge)
+
+  return part
+}
+```
+</Example>

--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -1,3 +1,4 @@
+import { Bezier } from 'bezier-js'
 import { Attributes } from './attributes.mjs'
 import * as utils from './utils.mjs'
 import { Point, pointsProxy } from './point.mjs'
@@ -122,6 +123,7 @@ Part.prototype.shorthand = function () {
     store: this.context.store,
     units: this.__unitsClosure(),
     utils: utils,
+    Bezier: Bezier,
   }
   // Add top-level store methods and add a part name parameter
   const partName = this.name


### PR DESCRIPTION
This is the documentation that was written by @BenJamesBen for the `utils.curveEdge()` method.

However, the underlying Bezier library is not available in the part's draft method.

Ben worked around this by creating a dedicated method to create a Bezier instance in utils.
However, after giving it some thought, I think it's better to just make the Bezier library available in the part's draft method so that users can use it for whatever.

I have cherry-picked Ben's documentation commits, and adapted the example to use the Bezier library passed to the draft method. And obviously adapted core to pass it in the first place.

This PR replaces #3181 