### PR TITLE
fix(docs): Plugins documentation updates

### DIFF
--- a/markdown/dev/reference/api/part/config/plugins/en.md
+++ b/markdown/dev/reference/api/part/config/plugins/en.md
@@ -17,7 +17,7 @@ const part = {
 ```
 <Tip>
 
-You should only list the plugins that required by the part itself, 
+You should only list the plugins that are required by the part itself,
 not those required by its dependencies
 
 </Tip>
@@ -44,20 +44,21 @@ const part = {
 
 ## Conditional plugins
 
-A conditional plugin is loaded conditionally. It should be provided
-as an object with the following structure:
+A conditional plugin is loaded only when a condition is met.
+The plugin and condition should be provided as an `Object`
+with the following structure:
 
 ```js
 import myPlugin from './my-plugin.mjs'
 
-const plugin = {
-  plugin,
+const myConditionalPlugin = {
+  myPlugin,
   condition,
 }
 ```
 
-Where `plugin` is the plugin itself, and `condition` is the 
-method to determing whether or not to load it.
+Where `myPlugin` is the plugin itself, and `condition` is the method
+that returns `true` if the plugin should be loaded.
 
 <Related>
 

--- a/markdown/dev/reference/api/pattern/use/en.md
+++ b/markdown/dev/reference/api/pattern/use/en.md
@@ -12,6 +12,8 @@ For more details, refer to [the plugin guide](/guides/plugins/).
 
 ```js
 Pattern pattern.use(object plugin)
+// or
+Pattern pattern.use(object plugin, object plugin_data)
 ```
 
 See [the plugin guide](/guides/plugins/) for details on how to structure

--- a/markdown/dev/reference/plugins/banner/en.md
+++ b/markdown/dev/reference/plugins/banner/en.md
@@ -18,9 +18,15 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { bannerPlugin } from '@freesewing/plugin-banner'
+// or
+import { pluginBanner } from '@freesewing/plugin-banner'
+```
+
 ## Notes
 
 The banner plugin is part of our [plugin-bundle](/reference/plugins/bundle)
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-banner
-

--- a/markdown/dev/reference/plugins/bartack/en.md
+++ b/markdown/dev/reference/plugins/bartack/en.md
@@ -5,7 +5,7 @@ title: plugin-bartack
 Published as [@freesewing/plugin-bartack][1], this plugin provides 
 the [bartack](/reference/macros/bartack),
 [bartackAlong](/reference/macros/bartackalong), and
-the [bartackFractionAlong](/reference/macros/bartack) macros
+the [bartackFractionAlong](/reference/macros/bartackfractionalong) macros
 which allows you to add bartacks — a set
 of tight zig-zag stitches used to enforce a seam — to your design.
 
@@ -21,9 +21,15 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { bartackPlugin } from '@freesewing/plugin-bartack'
+// or
+import { pluginBartack } from '@freesewing/plugin-bartack'
+```
+
 ## Notes
 
 The bartack plugin is part of our [plugin-bundle](/reference/plugins/bundle)
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-bartack
-

--- a/markdown/dev/reference/plugins/bundle/en.md
+++ b/markdown/dev/reference/plugins/bundle/en.md
@@ -35,3 +35,11 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { bundlePlugin } from '@freesewing/plugin-bundle'
+// or
+import { pluginBundle } from '@freesewing/plugin-bundle'
+```
+
+[1]: https://www.npmjs.com/package/@freesewing/plugin-bundle

--- a/markdown/dev/reference/plugins/bust/en.md
+++ b/markdown/dev/reference/plugins/bust/en.md
@@ -5,7 +5,7 @@ title: plugin-bust
 Published as [@freesewing/plugin-bust][1], this plugin helps you adapt menswear
 patterns for people with breasts.  If you are designing a womenswear pattern,
 you won't need this plugin. But if you're adapting a menswear pattern for
-breasts, or merely want to accomodate both people with and without breasts,
+breasts or merely want to accomodate both people with and without breasts,
 this plugin can help you accomplish that.
 
 ## Installation
@@ -20,6 +20,17 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { bustPlugin } from '@freesewing/plugin-bust'
+// or
+import { pluginBust } from '@freesewing/plugin-bust'
+```
+
+To import the plugin and condition method for conditional loading:
+```js
+import { withCondition } from '@freesewing/plugin-bust'
+```
 
 ## Notes
 
@@ -37,7 +48,7 @@ womenswear pattern for a person with above-average sized breasts.
 This plugin helps you by:
 
 - Storing the chest circumference in `measurements.bust`
-- Changing `measurments.chestCircumference` to the value of
+- Changing `measurments.chest` to the value of
   `measurements.highBust`
 
 ### Use when extending breastless patterns into a with-breasts version
@@ -50,32 +61,48 @@ This way you can extend a menswear pattern and have it drafted with the high
 bust measurement as chest measurment, after which you can create room for the
 breasts.
 
-You can see this in practice in our [Carlita][2] pattern, which extends the
-menswear [Carlton][3] pattern.
+You can see this in practice in our [Carlita][2] design, which extends the
+menswear [Carlton][3] design.
 
 <Related compact>
-To learn more about extending a pattern, see [Part
+To learn more about extending a design, see [Part
 inheritance](/howtos/code/from/)
 </Related>
 
-### Use when creating gender-neutral patterns
+### Use when creating gender-neutral designs
 
-To create a truly gender-neutral pattern — one that will adapt to breasts only
+To create a truly gender-neutral design — one that will adapt to breasts only
 if they are present — you can use this plugin, but you'll also need a few other
 things:
 
-- You'll need to mark the breast measurements as [optional
+- You'll need to include and mark the bust measurements, including `highBust`,
+as [optional
   measurements](/reference/api/part/config/measurements#optionalmeasurements)
 - You'll need to [conditionally load this
   plugin](/reference/api/part/config/plugins#conditional-plugins)
+- You'll need to create your design such that, when appropriate,
+it is able to produce the condition to cause the plugin to load
 
 You can see an example of this in [our Teagan design][4].
 
-[1]: https://www.npmjs.com/package/@freesewing/plugin-banner
+### Condition for loading `withCondition`
+
+For convenience, `plugin-bust` provides a `withCondition` named export
+that is a conditional plugin, an `Object` consisting of the plugin
+along with a condition method.
+
+The condition is met if both:
+1. `options.draftForHighBust` is set to `true`
+2. `measurements.highBust` is set
+
+You can use `withCondition` to conditionally load `plugin-bust`,
+or you are free to instead create and use your own condition method
+to pass along with the plugin.
+
+[1]: https://www.npmjs.com/package/@freesewing/plugin-bust
 
 [2]: https://github.com/freesewing/freesewing/blob/develop/designs/carlita/src/index.mjs#L25
 
 [3]: https://github.com/freesewing/freesewing/blob/develop/designs/carlton
 
 [4]: https://github.com/freesewing/freesewing/blob/develop/designs/teagan/src/index.mjs
-

--- a/markdown/dev/reference/plugins/buttons/en.md
+++ b/markdown/dev/reference/plugins/buttons/en.md
@@ -24,9 +24,15 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { buttonsPlugin } from '@freesewing/plugin-buttons'
+// or
+import { pluginButtons } from '@freesewing/plugin-buttons'
+```
+
 ## Notes
 
 The buttons plugin is part of our [plugin-bundle](/reference/plugins/bundle)
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-buttons
-

--- a/markdown/dev/reference/plugins/cutonfold/en.md
+++ b/markdown/dev/reference/plugins/cutonfold/en.md
@@ -3,7 +3,7 @@ title: plugin-cutonfold
 ---
 
 Published as [@freesewing/plugin-cutonfold][1], this plugin provides [the
-cutonfold macro](/reference/macros/cutonfold) which adds a cut-on-fold
+cutonfold macro](/reference/macros/cutonfold) which adds a _cut on fold_
 indicator to your design.
 
 ## Installation
@@ -18,9 +18,15 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { cutonfoldPlugin } from '@freesewing/plugin-cutonfold'
+// or
+import { pluginCutonfold } from '@freesewing/plugin-cutonfold'
+```
+
 ## Notes
 
 The cutonfold plugin is part of our [plugin-bundle](/reference/plugins/bundle)
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-cutonfold
-

--- a/markdown/dev/reference/plugins/dimension/en.md
+++ b/markdown/dev/reference/plugins/dimension/en.md
@@ -24,9 +24,15 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { dimensionPlugin } from '@freesewing/plugin-dimension'
+// or
+import { pluginDimension } from '@freesewing/plugin-dimension'
+```
+
 ## Notes
 
 The dimension plugin is part of our [plugin-bundle](/reference/plugins/bundle)
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-dimension
-

--- a/markdown/dev/reference/plugins/en.md
+++ b/markdown/dev/reference/plugins/en.md
@@ -6,7 +6,28 @@ FreeSewing uses a modular approach where functionality can be extended with
 plugins. Plugins can provide macros, store methods, or use any of the lifecycle
 hooks.
 
-We maintain the following plugins:
+## Using plugins
+
+Plugins can be either
+[added to part configurations](/reference/api/part/config/plugins) in designs or
+[added to a pattern instance with Pattern.use()](/reference/api/pattern/use).
+
+To import a plugin for use:
+```js
+import { namePlugin } from { @freesewing/plugin-name }
+// or
+import { pluginName } from { @freesewing/plugin-name }
+```
+
+<Tip>
+
+For convenience, each plugin is exported in two name formats:
+"plugin\<Name>" and "\<name\>Plugin".
+For example, either `pluginBanner` or `bannerPlugin` can be used.
+
+</Tip>
+
+## Plugins we maintain
 
 <ReadMore />
 

--- a/markdown/dev/reference/plugins/flip/en.md
+++ b/markdown/dev/reference/plugins/flip/en.md
@@ -19,5 +19,11 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
-[1]: https://www.npmjs.com/package/@freesewing/plugin-flip
+To import the plugin for use:
+```js
+import { flipPlugin } from '@freesewing/plugin-flip'
+// or
+import { pluginFlip } from '@freesewing/plugin-flip'
+```
 
+[1]: https://www.npmjs.com/package/@freesewing/plugin-flip

--- a/markdown/dev/reference/plugins/gore/en.md
+++ b/markdown/dev/reference/plugins/gore/en.md
@@ -8,7 +8,7 @@ segments](https://en.wikipedia.org/wiki/Gore_\(segment\)); 2D panels to create
 a sphehrical shape as used in hats for example.
 
 This plugin handles all the mathematics to create a (part-)sphere in your
-patterns.
+designs.
 
 ## Installation
 
@@ -22,5 +22,11 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
-[1]: https://www.npmjs.com/package/@freesewing/plugin-gore
+To import the plugin for use:
+```js
+import { gorePlugin } from '@freesewing/plugin-gore'
+// or
+import { pluginGore } from '@freesewing/plugin-gore'
+```
 
+[1]: https://www.npmjs.com/package/@freesewing/plugin-gore

--- a/markdown/dev/reference/plugins/grainline/en.md
+++ b/markdown/dev/reference/plugins/grainline/en.md
@@ -18,9 +18,15 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { grainlinePlugin } from '@freesewing/plugin-grainline'
+// or
+import { pluginGrainline } from '@freesewing/plugin-grainline'
+```
+
 ## Notes
 
 The grainline plugin is part of our [plugin-bundle](/reference/plugins/bundle)
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-grainline
-

--- a/markdown/dev/reference/plugins/i18n/en.md
+++ b/markdown/dev/reference/plugins/i18n/en.md
@@ -3,7 +3,8 @@ title: plugin-i18n
 ---
 
 Published as [@freesewing/plugin-i18n][1], this plugin faciliates
-translation of your designs.
+translation of your designs by allowing you to provide your own
+language translations.
 
 ## Installation
 
@@ -17,30 +18,52 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { i18nPlugin } from '@freesewing/plugin-i18n'
+// or
+import { pluginI18n } from '@freesewing/plugin-i18n'
+```
+
 ## Notes
 
-This plugin provides the mechanism for translation, but does not come with
+This plugin provides the mechanism for translation but does not come with
 translations itself.  For this, you can use our [i18n
-package](/reference/packages/i18n).
+package](https://www.npmjs.com/package/@freesewing/i18n).
 
-To add (your own) translations, you should pass data to this plugin.
-It should be structured as such:
+To add your own translations, you will need to pass data to this plugin
+containing translation keys and the translations for them for each language.
+The data should be in the form of an `Object` structured as such:
 
 ```js
 {
   strings:
     en: {
-      example: "Example"
+      example: "Example",
+      examplePhrase: "An example phrase",
+      anotherTranslationKey: "(English translation for the translation key)",
+      // More translations can follow...
     },
     nl: {
-      example: "Voorbeeld"
+      example: "Voorbeeld",
+      examplePhrase: "Een voorbeeldzin",
+      anotherTranslationKey: "(Dutch translation for the translation key)",
+      // More translations can follow...
     },
-    // More languages can follow
+    es: {
+      example: "Ejemplo",
+      examplePhrase: "Una frase de ejemplo",
+      anotherTranslationKey: "(Spanish translation for the translation key)",
+      // More translations can follow...
+    },
+    // More languages can follow...
   }
 }
 ```
 
-The i18n plugin is part of our [plugin-bundle](/reference/plugins/bundle)
+<Related compact>
+To learn more about using translations in a design, see the
+[Translation guide](/guides/translation/)
+</Related>
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-i18n
-

--- a/markdown/dev/reference/plugins/logo/en.md
+++ b/markdown/dev/reference/plugins/logo/en.md
@@ -18,6 +18,13 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { logoPlugin } from '@freesewing/plugin-logo'
+// or
+import { pluginLogo } from '@freesewing/plugin-logo'
+```
+
 ## Notes
 
 The logo plugin is part of our [plugin-bundle](/reference/plugins/bundle)

--- a/markdown/dev/reference/plugins/measurements/en.md
+++ b/markdown/dev/reference/plugins/measurements/en.md
@@ -3,7 +3,7 @@ title: plugin-measurements
 ---
 
 Published as [@freesewing/plugin-measurements][1], this plugin will
-provide a number of extra measurements to your pattern insofar as
+provide a number of extra measurements to your design insofar as
 they can be deduced from the measurements that are provided.
 
 It will add the following measurements:
@@ -14,7 +14,12 @@ It will add the following measurements:
 - `waistFront` (if both `waist` and `waistBack` are provided)
 - `waistBackArc` (if both `waist` and `waistBack` are provided)
 - `waistFrontArc` (if both `waist` and `waistBack` are provided)
-- `crossSeamBack` (if both `crossSeam` and `crossSeamFront` are available)
+- `crossSeamBack` (if both `crossSeam` and `crossSeamFront` are provided)
+
+<Related compact>
+For more information about these extra measurements, please see
+[Measurements from `plugin-measurements`](/reference/measurements#measurements-from-plugin-measurements)
+</Related>
 
 ## Installation
 
@@ -27,6 +32,13 @@ npm install @freesewing/plugin-measurements
 Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
+
+To import the plugin for use:
+```js
+import { measurementsPlugin } from '@freesewing/plugin-measurements'
+// or
+import { pluginMeasurements } from '@freesewing/plugin-measurements'
+```
 
 ## Notes
 

--- a/markdown/dev/reference/plugins/mirror/en.md
+++ b/markdown/dev/reference/plugins/mirror/en.md
@@ -18,6 +18,13 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { mirrorPlugin } from '@freesewing/plugin-mirror'
+// or
+import { pluginMirror } from '@freesewing/plugin-mirror'
+```
+
 ## Notes
 
 The mirror plugin is part of our [plugin-bundle](/reference/plugins/bundle)

--- a/markdown/dev/reference/plugins/notches/en.md
+++ b/markdown/dev/reference/plugins/notches/en.md
@@ -18,6 +18,13 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { notchesPlugin } from '@freesewing/plugin-notches'
+// or
+import { pluginNotches } from '@freesewing/plugin-notches'
+```
+
 ## Notes
 
 The notches plugin is part of our [plugin-bundle](/reference/plugins/bundle)

--- a/markdown/dev/reference/plugins/round/en.md
+++ b/markdown/dev/reference/plugins/round/en.md
@@ -3,7 +3,7 @@ title: plugin-round
 ---
 
 Published as [@freesewing/plugin-round][1], this plugin provides [the round
-macro](/reference/macros/round) which helps you round corners on your
+macro](/reference/macros/round) which helps you create rounded corners on your
 designs.
 
 ## Installation
@@ -18,12 +18,17 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+```js
+import { roundPlugin } from '@freesewing/plugin-round'
+// or
+import { pluginRound } from '@freesewing/plugin-round'
+```
+
 ## Notes
 
-The round macro is intended for rounding 90° angles.
+The `round` macro is intended for rounding 90° angles.
 It does not support rounding other angles/corners.
 
 The round plugin is part of our [plugin-bundle](/reference/plugins/bundle)
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-round
-

--- a/markdown/dev/reference/plugins/scalebox/en.md
+++ b/markdown/dev/reference/plugins/scalebox/en.md
@@ -20,13 +20,19 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { scaleboxPlugin } from '@freesewing/plugin-scalebox'
+// or
+import { pluginScalebox } from '@freesewing/plugin-scalebox'
+```
+
 ## Notes
 
 This plugin by default includes FreeSewing branding, but you can
-override that when calling the scalebox macro in case you want to
+override that when calling the `scalebox` macro in case you want to
 generate your own branded designs.
 
 The scalebox plugin is part of our [plugin-bundle](/reference/plugins/bundle)
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-scalebox
-

--- a/markdown/dev/reference/plugins/sprinkle/en.md
+++ b/markdown/dev/reference/plugins/sprinkle/en.md
@@ -19,6 +19,13 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { sprinklePlugin } from '@freesewing/plugin-sprinkle'
+// or
+import { pluginSprinkle } from '@freesewing/plugin-sprinkle'
+```
+
 ## Notes
 
 The sprinkle plugin is part of our [plugin-bundle](/reference/plugins/bundle)

--- a/markdown/dev/reference/plugins/svgattr/en.md
+++ b/markdown/dev/reference/plugins/svgattr/en.md
@@ -3,7 +3,8 @@ title: plugin-svgattr
 ---
 
 Published as [@freesewing/plugin-svgattr][1], this plugin takes an object of
-key-value pairs and adds them ass attributes to your SVG document on render.
+key-value pairs and adds them as attributes of the `<svg>` tag
+of a pattern's SVG document on render.
 
 ## Installation
 
@@ -17,11 +18,34 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { svgAttrPlugin } from '@freesewing/plugin-svgattr'
+// or
+import { svgattrPlugin } from '@freesewing/plugin-svgattr'
+// or
+import { pluginSvgAttr } from '@freesewing/plugin-svgattr'
+// or
+import { pluginSvgattr } from '@freesewing/plugin-svgattr'
+```
+<Tip>
+For convenience, this plugin is exported
+under multiple names with variations of capitalization.
+</Tip>
+
 ## Notes
 
-You should pass a second argument which holds key-value pairs of the attributes
-you want to add to the SVG tag.
+To provide the attributes for the `<svg>` tag, you will need to pass a
+second argument which holds key-value pairs.
+It should be an `Object` structured as such:
 
-The svgattr plugin is part of our [plugin-bundle](/reference/plugins/bundle)
+```js
+{
+  key1: 'value1',
+  key2: 'value2',
+  key3: 'value3',
+  // More key-value pairs can follow...
+}
+```
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-svgattr

--- a/markdown/dev/reference/plugins/theme/en.md
+++ b/markdown/dev/reference/plugins/theme/en.md
@@ -17,6 +17,13 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { themePlugin } from '@freesewing/plugin-theme'
+// or
+import { pluginTheme } from '@freesewing/plugin-theme'
+```
+
 ## Notes
 
 This plugin will inject CSS in the SVG document when rendering to SVG.
@@ -24,7 +31,4 @@ This plugin will inject CSS in the SVG document when rendering to SVG.
 If you use other ways to render your pattern (using `Pattern.getRenderProps()`)
 you will need to apply your own styles.
 
-The theme plugin is part of our [plugin-bundle](/reference/plugins/bundle)
-
 [1]: https://www.npmjs.com/package/@freesewing/plugin-theme
-

--- a/markdown/dev/reference/plugins/title/en.md
+++ b/markdown/dev/reference/plugins/title/en.md
@@ -18,6 +18,13 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
+To import the plugin for use:
+```js
+import { titlePlugin } from '@freesewing/plugin-title'
+// or
+import { pluginTitle } from '@freesewing/plugin-title'
+```
+
 ## Notes
 
 The title plugin is part of our [plugin-bundle](/reference/plugins/bundle)

--- a/markdown/dev/reference/plugins/versionfree-svg/en.md
+++ b/markdown/dev/reference/plugins/versionfree-svg/en.md
@@ -1,11 +1,13 @@
 ---
-title: versionfree-svg
+title: plugin-versionfree-svg
 ---
 
 Published as [@freesewing/plugin-versionfree-svg][1], this plugin suppresses
-the inclusion of the FreeSewing version number in SVG output.  This allows
-diffing pattern output between versions to check for any differences in the
-output between different versions of FreeSewing.
+the inclusion of the FreeSewing version number in SVG output.
+This allows you to more easily check for differences in the
+output of different pattern versions of the same design.
+Without the plugin, false positives could be seen simply due to
+differing FreeSewing version numbers.
 
 ## Installation
 
@@ -19,5 +21,11 @@ Either [add it as a part plugins](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
 
-[1]: https://www.npmjs.com/package/@freesewing/plugin-versionfree-svg
+To import the plugin for use:
+```js
+import { versionfreeSvgPlugin } from '@freesewing/plugin-versionfree-svg'
+// or
+import { pluginVersionfreeSvg } from '@freesewing/plugin-versionfree-svg'
+```
 
+[1]: https://www.npmjs.com/package/@freesewing/plugin-versionfree-svg

--- a/plugins/plugin-bundle/src/index.mjs
+++ b/plugins/plugin-bundle/src/index.mjs
@@ -5,13 +5,13 @@ import { cutonfoldPlugin } from '../../plugin-cutonfold/src/index.mjs'
 import { dimensionPlugin } from '../../plugin-dimension/src/index.mjs'
 import { grainlinePlugin } from '../../plugin-grainline/src/index.mjs'
 import { logoPlugin } from '../../plugin-logo/src/index.mjs'
+import { measurementsPlugin } from '../../plugin-measurements/src/index.mjs'
 import { mirrorPlugin } from '../../plugin-mirror/src/index.mjs'
 import { notchesPlugin } from '../../plugin-notches/src/index.mjs'
-import { titlePlugin } from '../../plugin-title/src/index.mjs'
-import { scaleboxPlugin } from '../../plugin-scalebox/src/index.mjs'
 import { roundPlugin } from '../../plugin-round/src/index.mjs'
+import { scaleboxPlugin } from '../../plugin-scalebox/src/index.mjs'
 import { sprinklePlugin } from '../../plugin-sprinkle/src/index.mjs'
-import { measurementsPlugin } from '../../plugin-measurements/src/index.mjs'
+import { titlePlugin } from '../../plugin-title/src/index.mjs'
 import { name, version } from '../data.mjs'
 
 const bundledPlugins = [
@@ -22,13 +22,13 @@ const bundledPlugins = [
   dimensionPlugin,
   grainlinePlugin,
   logoPlugin,
+  measurementsPlugin,
   mirrorPlugin,
   notchesPlugin,
-  titlePlugin,
-  scaleboxPlugin,
   roundPlugin,
+  scaleboxPlugin,
   sprinklePlugin,
-  measurementsPlugin,
+  titlePlugin,
 ]
 
 function bundleHooks() {


### PR DESCRIPTION
This PR is a somewhat large update to dev reference Plugins-related documentation.

Other than corrections, the most significant changes are:
- Add import usage for each plugin.
- More information about conditional plugins and how to use them. This is especially seen in the `plugin-bust` changes.
- More information about how to use `plugin-i18n`.
- More information about `plugin-svgattr` and how to use it.
- Alphabetize plugins in `plugin-bundle`, to make it easier to see what plugins it includes.

Hopefully my understanding of conditional plugins, `plugin-i18n`, and `plugin-svgattr` and the information I added is correct.

Not included in this PR and still to be done:
- Add documentation for `plugin-cutlist` and `plugin-timing`
- Doc review for the Plugin Guide.