### PR TITLE
[Fix] Paperless exports to SVG and PDF

### DIFF
--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -241,6 +241,7 @@ Pattern.prototype.getRenderProps = function () {
     })),
   }
 
+  svg.__runHooks('postRender')
   return props
 }
 

--- a/plugins/plugin-theme/src/css.mjs
+++ b/plugins/plugin-theme/src/css.mjs
@@ -1,37 +1,41 @@
-export const paperlessStyle = `
-/* Paperless grid */
-svg.freesewing path.grid {
-  fill: none;
+export const paperlessStyle = (stripped) => `
+${!stripped ? '/* Paperless grid */' : ''}
+${!stripped ? 'svg.freesewing ' : ''}path.grid {
   stroke: #555;
   stroke-width: 0.3;
 }
-svg.freesewing path.gridline {
+${!stripped ? 'svg.freesewing ' : ''}path.gridline {
   stroke: #555;
   stroke-width: 0.2;
+  fill: none;
 }
-svg.freesewing path.gridline-lg {
+${!stripped ? 'svg.freesewing ' : ''}path.gridline-lg {
   stroke: #777;
   stroke-width: 0.2;
   stroke-dasharray: 1.5,1.5;
+  fill: none;
 }
-svg.freesewing path.gridline-sm {
+${!stripped ? 'svg.freesewing ' : ''}path.gridline-sm {
   stroke: #999;
   stroke-width: 0.1;
+  fill: none;
 }
-svg.freesewing path.gridline-xs {
+${!stripped ? 'svg.freesewing ' : ''}path.gridline-xs {
   stroke: #999;
   stroke-width: 0.1;
   stroke-dasharray: 0.5,0.5;
+  fill: none;
 }
-svg.freesewing path.gridbox {
+${!stripped ? 'svg.freesewing ' : ''}path.gridbox {
   fill: url(#grid);
 }`
-export const sampleStyle = `
-/* Sample classes */
-svg.freesewing path.sample {
+
+export const sampleStyle = (stripped) => `
+${!stripped ? '/* Sample classes */' : ''}
+${!stripped ? 'svg.freesewing ' : ''}path.sample {
   stroke-width: 0.75
 }
-svg.freesewing path.sample-focus {
+${!stripped ? 'svg.freesewing ' : ''}path.sample-focus {
   stroke-width: 1.5; fill: rgba(0,0,0,0.1)
 }`
 

--- a/plugins/plugin-theme/src/index.mjs
+++ b/plugins/plugin-theme/src/index.mjs
@@ -28,8 +28,8 @@ export const plugin = {
       const current = svg.attributes.get('class')
       if (!current || current.indexOf('freesewing') !== -1) {
         svg.attributes.set('class', 'freesewing')
-        svg.style += sampleStyle
-        svg.style += paperlessStyle
+        svg.style += sampleStyle(data.stripped)
+        svg.style += paperlessStyle(data.stripped)
         svg.style += buildStylesheet(svg.pattern.settings.scale, data.stripped)
         let paperless = false
         for (const set of svg.pattern.settings) {
@@ -40,10 +40,10 @@ export const plugin = {
             ? (svg.defs += grid.imperial)
             : (svg.defs += grid.metric)
           const parts = svg.pattern.parts[svg.pattern.activeSet]
-          const skip = data.skipGrid || []
+          const skipGrid = data.skipGrid || []
           for (const key in parts) {
             const part = parts[key]
-            if (!part.hidden && !data.skipGrid.includes(key) && svg.pattern.__needs(key)) {
+            if (!part.hidden && !skipGrid.includes(key) && svg.pattern.__needs(key)) {
               const { Path, paths, getId, Point, points } = part.shorthand()
               let anchor = new Point(0, 0)
               if (typeof points.gridAnchor !== 'undefined') anchor = part.points.gridAnchor

--- a/plugins/plugin-theme/src/index.mjs
+++ b/plugins/plugin-theme/src/index.mjs
@@ -39,20 +39,23 @@ export const plugin = {
           svg.pattern.settings[0].units === 'imperial'
             ? (svg.defs += grid.imperial)
             : (svg.defs += grid.metric)
-          for (const key in svg.pattern.parts[0]) {
-            const part = svg.pattern.parts[key]
-            if (!part.hidden && svg.pattern.__needs(key)) {
-              let anchor = new svg.pattern.Point(0, 0)
-              if (typeof part.points.gridAnchor !== 'undefined') anchor = part.points.gridAnchor
-              else if (typeof part.points.anchor !== 'undefined') anchor = part.points.anchor
+          const parts = svg.pattern.parts[svg.pattern.activeSet]
+          const skip = data.skipGrid || []
+          for (const key in parts) {
+            const part = parts[key]
+            if (!part.hidden && !data.skipGrid.includes(key) && svg.pattern.__needs(key)) {
+              const { Path, paths, getId, Point, points } = part.shorthand()
+              let anchor = new Point(0, 0)
+              if (typeof points.gridAnchor !== 'undefined') anchor = part.points.gridAnchor
+              else if (typeof points.anchor !== 'undefined') anchor = part.points.anchor
               svg.defs += `<pattern id="grid_${key}" `
               svg.defs += `xlink:href="#grid" x="${anchor.x}" y="${anchor.y}">`
               svg.defs += '</pattern>'
-              part.paths[part.getId()] = new svg.pattern.Path()
+              paths[getId()] = new Path()
                 .move(part.topLeft)
-                .line(new svg.pattern.Point(part.topLeft.x, part.bottomRight.y))
+                .line(new Point(part.topLeft.x, part.bottomRight.y))
                 .line(part.bottomRight)
-                .line(new svg.pattern.Point(part.bottomRight.x, part.topLeft.y))
+                .line(new Point(part.bottomRight.x, part.topLeft.y))
                 .close()
                 .attr('class', 'grid')
                 .attr('style', `fill: url(#grid_${key})`)

--- a/sites/shared/components/workbench/draft/part/index.js
+++ b/sites/shared/components/workbench/draft/part/index.js
@@ -1,4 +1,4 @@
-import {forwardRef} from 'react'
+import { forwardRef } from 'react'
 import Path from '../path'
 import Point from '../point'
 import Snippet from '../snippet'
@@ -17,11 +17,11 @@ const partInfo = (props) => (
         </Tr>
         <Tr>
           <KeyTd>Width</KeyTd>
-          <ValTd>{round(props.part.width,2)}mm</ValTd>
+          <ValTd>{round(props.part.width, 2)}mm</ValTd>
         </Tr>
         <Tr>
           <KeyTd>Height</KeyTd>
-          <ValTd>{round(props.part.height,2)}mm</ValTd>
+          <ValTd>{round(props.part.height, 2)}mm</ValTd>
         </Tr>
         <Tr>
           <KeyTd>Top Left</KeyTd>
@@ -33,116 +33,124 @@ const partInfo = (props) => (
         </Tr>
         <Tr>
           <KeyTd>Attributes</KeyTd>
-          <ValTd><Attributes list={props.part.attributes.list} /></ValTd>
+          <ValTd>
+            <Attributes list={props.part.attributes.list} />
+          </ValTd>
         </Tr>
       </tbody>
     </table>
     <div className="flex flex-row flex-wrap gap-2 mt-4">
-    {props.gist?.only && props.gist.only.length > 0
-      ? (
-        <button
-          className="btn btn-primary"
-          onClick={() => props.unsetGist(['only'])}
-        >Show all parts</button>
+      {props.gist?.only && props.gist.only.length > 0 ? (
+        <button className="btn btn-primary" onClick={() => props.unsetGist(['only'])}>
+          Show all parts
+        </button>
       ) : (
         <button
           className="btn btn-primary"
           onClick={() => props.updateGist(['only'], [props.partName])}
-        >Show only this part</button>
+        >
+          Show only this part
+        </button>
       )}
-      <button
-        className="btn btn-success"
-        onClick={() => console.log(props.part)}
-      >console.log(part)</button>
-      <button
-        className="btn btn-success"
-        onClick={() => console.table(props.part.points)}
-      >console.table(part.points)</button>
-      <button
-        className="btn btn-success"
-        onClick={() => console.table(props.part.paths)}
-      >console.table(part.paths)</button>
+      <button className="btn btn-success" onClick={() => console.log(props.part)}>
+        console.log(part)
+      </button>
+      <button className="btn btn-success" onClick={() => console.table(props.part.points)}>
+        console.table(part.points)
+      </button>
+      <button className="btn btn-success" onClick={() => console.table(props.part.paths)}>
+        console.table(part.paths)
+      </button>
     </div>
   </div>
 )
 
-const XrayPart = props => {
+const XrayPart = (props) => {
   const { topLeft, bottomRight } = props.part
 
   return (
     <g>
-      <path d={`
+      <path
+        d={`
         M ${topLeft.x} ${topLeft.y}
         L ${topLeft.x} ${bottomRight.y}
         L ${bottomRight.x} ${bottomRight.y}
         L ${bottomRight.x} ${topLeft.y}
         z
-        `} className={`peer stroke-note lashed opacity-30 hover:opacity-90 fill-fabric hover:cursor-pointer hover:stroke-mark`}
-        style={{ fillOpacity: 0}}
-        onClick={(evt) => { evt.stopPropagation(); props.showInfo(partInfo(props)) }}
+        `}
+        className={`peer stroke-note lashed opacity-30 hover:opacity-90 fill-fabric hover:cursor-pointer hover:stroke-mark`}
+        style={{ fillOpacity: 0 }}
+        onClick={(evt) => {
+          evt.stopPropagation()
+          props.showInfo(partInfo(props))
+        }}
       />
     </g>
   )
 }
 
 export const PartInner = forwardRef((props, ref) => {
-  const { partName, part, gist } = props
+  const { partName, part, gist, skipGrid } = props
 
-  const Grid = gist.paperless ? (
-    <rect
-      x={part.topLeft.x}
-      y={part.topLeft.y}
-      width={part.width}
-      height={part.height}
-      className="grid"
-      fill={'url(#grid-' + partName + ')'}
-    />
-  ) : null
-
-  return (<g ref={ref}>
-    {Grid}
-    {
-      gist._state?.xray?.enabled &&
-      <XrayPart {...props} />
-    }
-    {Object.keys(part.paths).map((pathName) => (
-      <Path
-        key={pathName}
-        pathName={pathName}
-        path={part.paths[pathName]}
-        topLeft={props.part.topLeft}
-        bottomRight={props.part.bottomRight}
-        {...props}
+  const Grid =
+    gist.paperless && !skipGrid ? (
+      <rect
+        x={part.topLeft.x}
+        y={part.topLeft.y}
+        width={part.width}
+        height={part.height}
+        className="grid"
+        fill={'url(#grid-' + partName + ')'}
       />
-    ))}
-    {Object.keys(props.part.points).map((pointName) => (
-      <Point
-        key={pointName}
-        pointName={pointName}
-        point={props.part.points[pointName]}
-        topLeft={props.part.topLeft}
-        bottomRight={props.part.bottomRight}
-        {...props}
-      />
-    ))}
-    {Object.keys(props.part.snippets).map((snippetName) => (
-      <Snippet
-        key={snippetName}
-        snippetName={snippetName}
-        snippet={props.part.snippets[snippetName]}
-        {...props}
-      />
-    ))}
-  </g>)
-})
-
-const Part = props => {
-  const { partName, part} = props
+    ) : null
 
   return (
-      <g {...getProps(part)} id={`${part.context.settings.idPrefix || ''}part-${partName}`} className={part.context.settings.idPrefix || ''}>
-        <PartInner {...props}/>
-      </g>
+    <g ref={ref}>
+      {Grid}
+      {gist._state?.xray?.enabled && <XrayPart {...props} />}
+      {Object.keys(part.paths).map((pathName) => (
+        <Path
+          key={pathName}
+          pathName={pathName}
+          path={part.paths[pathName]}
+          topLeft={props.part.topLeft}
+          bottomRight={props.part.bottomRight}
+          {...props}
+        />
+      ))}
+      {Object.keys(props.part.points).map((pointName) => (
+        <Point
+          key={pointName}
+          pointName={pointName}
+          point={props.part.points[pointName]}
+          topLeft={props.part.topLeft}
+          bottomRight={props.part.bottomRight}
+          {...props}
+        />
+      ))}
+      {Object.keys(props.part.snippets).map((snippetName) => (
+        <Snippet
+          key={snippetName}
+          snippetName={snippetName}
+          snippet={props.part.snippets[snippetName]}
+          {...props}
+        />
+      ))}
+    </g>
+  )
+})
+
+const Part = (props) => {
+  const { partName, part } = props
+
+  return (
+    <g
+      {...getProps(part)}
+      id={`${part.context.settings.idPrefix || ''}part-${partName}`}
+      className={part.context.settings.idPrefix || ''}
+    >
+      <PartInner {...props} />
+    </g>
   )
 }
 /*

--- a/sites/shared/components/workbench/draft/part/index.js
+++ b/sites/shared/components/workbench/draft/part/index.js
@@ -140,6 +140,8 @@ export const PartInner = forwardRef((props, ref) => {
   )
 })
 
+PartInner.displayName = 'PartInner'
+
 const Part = (props) => {
   const { partName, part } = props
 

--- a/sites/shared/components/workbench/exporting/export-handler.js
+++ b/sites/shared/components/workbench/exporting/export-handler.js
@@ -74,7 +74,7 @@ export const handleExport = async (format, gist, design, t, app, onComplete, onE
     let pattern = new design({ ...gist, layout })
 
     // add the theme and translation to the pattern
-    pattern.use(themePlugin, { stripped: format !== 'svg' })
+    pattern.use(themePlugin, { stripped: format !== 'svg', skipGrid: ['pages'] })
     pattern.use(
       {
         hooks: {
@@ -115,13 +115,13 @@ export const handleExport = async (format, gist, design, t, app, onComplete, onE
 
       // add the svg and pages data to the worker args
       workerArgs.pages = pattern.setStores[pattern.activeSet].get('pages')
+
+      // post a message to the worker with all needed data
+      worker.postMessage(workerArgs)
     } catch (err) {
       console.log(err)
       app.stopLoading()
       onError && onError(err)
     }
   }
-
-  // post a message to the worker with all needed data
-  worker.postMessage(workerArgs)
 }

--- a/sites/shared/components/workbench/exporting/pdf-maker.js
+++ b/sites/shared/components/workbench/exporting/pdf-maker.js
@@ -3,9 +3,9 @@ import SVGtoPDF from 'svg-to-pdfkit'
 import { path as logoPath } from 'shared/components/icons/freesewing.js'
 
 /** an svg of the logo to put on the cover page */
-const logoSvg = `<svg viewBox="-22 -36 46 50">
-	<style> path {fill: none; stroke: #555555; stroke-width: 0.5} </style>
-  <path d=${logoPath} />
+const logoSvg = `<svg viewBox="0 0 25 25">
+	<style> path {fill: none; stroke: #555555; stroke-width: 0.25} </style>
+  <path d="${logoPath}" />
 </svg>`
 
 /**

--- a/sites/shared/components/workbench/layout/draft/index.js
+++ b/sites/shared/components/workbench/layout/draft/index.js
@@ -69,7 +69,12 @@ const Draft = (props) => {
   // Bottom in SVG means we need to draw it first
   const stacks = [
     <PartInner
-      {...{ part: patternProps.parts[0][props.layoutPart], partName: props.layoutPart, gist }}
+      {...{
+        part: patternProps.parts[0][props.layoutPart],
+        partName: props.layoutPart,
+        gist,
+        skipGrid: true,
+      }}
       key={props.layoutPart}
     />,
   ]

--- a/sites/shared/components/workbench/layout/draft/stack.js
+++ b/sites/shared/components/workbench/layout/draft/stack.js
@@ -55,6 +55,7 @@ const Stack = (props) => {
   const { layout, stack, stackName, gist } = props
 
   const stackLayout = layout.stacks?.[stackName]
+  const stackExists = typeof stackLayout?.move?.x !== 'undefined'
 
   // Use a ref for direct DOM manipulation
   const stackRef = useRef(null)
@@ -75,12 +76,12 @@ const Stack = (props) => {
   // Initialize drag handler
   useEffect(() => {
     // don't drag the pages
-    if (props.isLayoutPart) return
+    if (props.isLayoutPart || !stackExists) return
     handleDrag(select(stackRef.current))
   }, [rotate, stackRef, stackLayout])
 
   // // Don't just assume this makes sense
-  if (typeof stackLayout?.move?.x === 'undefined') return null
+  if (!stackExists) return null
 
   // These are kept as vars because re-rendering on drag would kill performance
   // Managing the difference between re-render and direct DOM updates makes this

--- a/sites/shared/components/workbench/layout/print/plugin.js
+++ b/sites/shared/components/workbench/layout/print/plugin.js
@@ -165,6 +165,22 @@ const basePlugin = ({
         pattern.height = sheetHeight * generatedPageData.rows
       }
     },
+    preRender: function (svg) {
+      const pattern = svg.pattern
+      const only = pattern.settings[pattern.activeStack || 0].only
+      // add the layout part to the include list if there is one so that it gets rendered
+      if (Array.isArray(only) && !only.includes(partName)) {
+        pattern.settings[pattern.activeStack || 0].only.push(partName)
+      }
+    },
+    postRender: function (svg) {
+      const pattern = svg.pattern
+      const only = pattern.settings[pattern.activeStack || 0].only
+      // remove the layout part from the include list if there is one so that we don't pollute the settings
+      if (Array.isArray(only) && only.includes(partName)) {
+        pattern.settings[pattern.activeStack || 0].only.splice(only.indexOf(partName), 1)
+      }
+    },
   },
   macros: {
     /** draft the pages */

--- a/sites/shared/components/wrappers/workbench.js
+++ b/sites/shared/components/wrappers/workbench.js
@@ -121,7 +121,7 @@ const WorkbenchWrapper = ({ app, design, preload = false, from = false, layout =
     //draft.__init()
 
     // add theme to svg renderer
-    if (gist.renderer === 'svg') draft.use(pluginTheme)
+    if (gist.renderer === 'svg') draft.use(pluginTheme, { skipGrid: ['pages'] })
 
     // draft it for draft and event views. Other views may add plugins, etc and we don't want to draft twice
     try {

--- a/sites/shared/package.json
+++ b/sites/shared/package.json
@@ -55,7 +55,7 @@
     "remark-frontmatter": "^4.0.1",
     "remark-smartypants": "^2.0.0",
     "sharp": "^0.31.1",
-    "svg-to-pdfkit": "^0.1.8",
+    "svg-to-pdfkit": "https://github.com/eriese/SVG-to-PDFKit",
     "to-vfile": "^7.2.2",
     "unist-util-visit": "^4.1.0",
     "web-worker": "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17814,7 +17814,7 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdfkit@>=0.8.1, pdfkit@^0.13.0:
+pdfkit@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/pdfkit/-/pdfkit-0.13.0.tgz#da4c2becd63a129e3aae448fdaed4ee7be790f8f"
   integrity sha512-AW79eHU5eLd2vgRDS9z3bSoi0FA+gYm+100LLosrQQMLUzOBGVOhG7ABcMFpJu7Bpg+MT74XYHi4k9EuU/9EZw==
@@ -22543,12 +22543,9 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-svg-to-pdfkit@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/svg-to-pdfkit/-/svg-to-pdfkit-0.1.8.tgz#5921765922044843f0c1a5b25ec1ef8a4a33b8af"
-  integrity sha512-QItiGZBy5TstGy+q8mjQTMGRlDDOARXLxH+sgVm1n/LYeo0zFcQlcCh8m4zi8QxctrxB9Kue/lStc/RD5iLadQ==
-  dependencies:
-    pdfkit ">=0.8.1"
+"svg-to-pdfkit@https://github.com/eriese/SVG-to-PDFKit":
+  version "0.1.10"
+  resolved "https://github.com/eriese/SVG-to-PDFKit#2702cbe6b225224c4b5ea25b6a1ee8936cd8cf61"
 
 svgo@^1.0.0:
   version "1.3.2"


### PR DESCRIPTION
expected behavior:
exporting to SVG and PDF with `paperless: true` will include the gridlines and measurement markup in the export without errors

Resolves #3008 