### PR TITLE
fix(docs): Settings documentation updates

### DIFF
--- a/markdown/dev/reference/settings/complete/en.md
+++ b/markdown/dev/reference/settings/complete/en.md
@@ -3,7 +3,11 @@ title: complete
 ---
 
 The `complete` setting controls the level of detail that is included on a
-pattern. Set `complete` to `false` to limit the level of detail on the pattern.
+pattern.
+Set `complete` to `false` when the pattern should include only
+the base outlines needed to cut out the pattern pieces.
+Seam allowance and all other details will be omitted from the pattern.
+
 This has different use cases, such as generating patterns to be cut out with a
 laser cutter.
 
@@ -30,6 +34,12 @@ const pattern = new Aaron({
 
 ## Notes
 
-Setting `complete` to `false` will force [sa](/reference/settings/sa) to
-also be set to `false`.
+The `complete` setting does not automatically cause pattern detail
+to be omitted.
+Instead, it is up to the pattern designer to have the design
+check for the `complete` setting,
+omit the appropriate details if set to `true`,
+and include them if set to `false`.
 
+Setting `complete` to `false` will also cause [`sa`](/reference/settings/sa)
+to be set to `0` to remove the seam allowance.

--- a/markdown/dev/reference/settings/en.md
+++ b/markdown/dev/reference/settings/en.md
@@ -10,19 +10,23 @@ settings are the measurements, but there's other settings too.
 
 ```js
 Object settings = {
+  Object absoluteOptions,
   Boolean complete=true,
+  Boolean debug=false,
   Boolean embed=false,
-  Boolean idPrefix='fs-',
-  Object|Boolean layout=false
+  String idPrefix='fs-',
+  Object|Boolean layout=true,
   String locale='en',
   Number margin=2,
-  Object measurements
-  Array only,
+  Object measurements,
+  String|Array|Boolean only=false,
   Object options,
-  Boolean paperless=false
-  Boolean sa=false
-  Number scale=1
-  String units='metric'
+  Boolean paperless=false,
+  Number|Boolean sa=false,
+  Object sample,
+  Number scale=1,
+  String stackPrefix='',
+  String units='metric',
 }
 ```
 

--- a/markdown/dev/reference/settings/layout/en.md
+++ b/markdown/dev/reference/settings/layout/en.md
@@ -3,7 +3,7 @@ title: layout
 ---
 
 The `layout` setting allows you to control the way pattern parts are
-layed out on the pattern. Either automatic, explicit, or not at all.
+laid out on the pattern. Either automatic, explicit, or not at all.
 
 ## Signature
 

--- a/markdown/dev/reference/settings/locale/en.md
+++ b/markdown/dev/reference/settings/locale/en.md
@@ -3,8 +3,9 @@ title: locale
 ---
 
 The `locale` setting allows you to specify the language of the pattern.  It
-should contain a 2-letter language code that indicates what language the user
-wants. The default is `en`.
+should contain an
+[ISO 639-1 2-letter language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+that indicates what language the user wants. The default is `en`.
 
 ## Signature
 

--- a/markdown/dev/reference/settings/margin/en.md
+++ b/markdown/dev/reference/settings/margin/en.md
@@ -3,7 +3,8 @@ title: margin
 ---
 
 The `margin` setting allows you to specify a part margin (in mm).
-Each part will have this margin applied. The default is `2mm`.
+Each part will have this margin applied when they are laid out on the pattern.
+The default is `2mm`.
 
 ## Signature
 
@@ -26,14 +27,12 @@ const pattern = new Aaron({
 ## Notes
 
 The _margin_ implies that:
-
 - At the edge of the SVG, the margin will be `margin * 1` (2mm by default)
 - Between parts, the margin will be `margin * 2` (4mm by default)
 
-Note that setting the margin to zero (or below) will cause parts to overlap.
+Setting the margin to zero (or below) will cause parts to overlap.
 
 In paperless mode, the margin will not go below 10mm.
-
 That is because text is not taken into account when calculating the bounding
 box of the part.  Since dimensions are typically the outermost elements in a
 paperless part, a too narrow margin would cause the dimension text to get cut

--- a/markdown/dev/reference/settings/measurements/en.md
+++ b/markdown/dev/reference/settings/measurements/en.md
@@ -2,7 +2,7 @@
 title: measurements
 ---
 
-The `measurements` settings should hold and object with the
+The `measurements` settings should hold an object with the
 measurements to draft the pattern for.
 
 ## Signature

--- a/markdown/dev/reference/settings/only/en.md
+++ b/markdown/dev/reference/settings/only/en.md
@@ -5,14 +5,13 @@ title: only
 The `only` setting allows you to specify one or more parts to
 draft, rather than the entire pattern.
 
-It accepts either a single part name as a string, or an array of
-one or more part names.
+It accepts a single part name as a string, an array of one or more part names, or it can be set to `false`.
 
 ## Signature
 
 ```js
 const settings = {
-  Array|Boolean only=false
+  String|Array|Boolean only=false
 }
 ```
 

--- a/markdown/dev/reference/settings/paperless/en.md
+++ b/markdown/dev/reference/settings/paperless/en.md
@@ -2,9 +2,13 @@
 title: paperless
 ---
 
-The `paperless` setting allows you to generate a variant of the pattern
-that does not require you to print it. It does that by including dimensions
-on the pattern, as wel as a grid overlay.
+The `paperless` setting indicates whether a pattern is to be printed onto paper.
+Set `paperless` to `true` when the pattern will not be printed as a standard paper pattern.
+Instead, the paperless pattern will include a grid overlay, dimensions, and
+other information.
+
+The grid overlay, dimensions, and other information is intended to help users
+who might transfer the pattern to paper by hand or using a projector.
 
 ## Signature
 
@@ -25,3 +29,16 @@ const pattern = new Aaron({
   paperless: true
 })
 ```
+
+## Notes
+
+The `paperless` setting does not automatically cause dimensions
+and other information to be generated on a pattern.
+Instead, it is up to the pattern designer to have the design
+check for the `paperless` setting,
+include the appropriate dimensions and information if set to `true`,
+and omit them if set to `false`.
+
+The `paperless` setting does automatically cause the grid to be included.
+
+Setting `paperless` to `true` will also cause the [margin](/reference/settings/margin) to not go below 10mm.

--- a/markdown/dev/reference/settings/sa/en.md
+++ b/markdown/dev/reference/settings/sa/en.md
@@ -5,6 +5,10 @@ title: sa
 The `sa` setting controls the seam allowance. Either provide value in
 millimeter or set it to `false` or `0` to disable seam allowance altogether.
 
+Setting a seam allowance causes the pattern to be generated with
+additional lines so pattern pieces can be cut out with the correct
+seam allowance included.
+
 ## Signature
 
 ```js
@@ -13,7 +17,7 @@ const settings = {
 }
 ```
 
-By default, the `sa` setting is `false` and seam allowance is no included.
+By default, the `sa` setting is `false` and seam allowance is not included.
 
 ## Example
 
@@ -27,10 +31,11 @@ const pattern = new Aaron({
 
 ## Notes
 
-This is ignored if [settings.complete](/reference/settings/complete) is `false`
+The `sa` setting does not automatically cause seam allowances to
+be displayed on a pattern.
+Instead, it is up to the pattern designer to have the design check
+for the `sa` setting and include the appropriate seam allowance lines
+on the pattern when `sa` is set to a non-zero numeric value.
 
-<Comment by="joost">
-This is not strictly enforced and left of to the designer, so different designs
-may behave differently with regards to including seam allowance when `complete` is
-set to `false`.
-</Comment>
+The `sa` setting is automatically set to `0` to disable seam allowance if
+[settings.complete](/reference/settings/complete) is `false`.

--- a/markdown/dev/reference/settings/scale/en.md
+++ b/markdown/dev/reference/settings/scale/en.md
@@ -2,7 +2,7 @@
 title: scale
 ---
 
-The `scale` setting is an overal factor that will influence a variety of
+The `scale` setting is an overall scaling factor that will influence a variety of
 factors to better support very large or very small patterns.
 
 To be clear, `scale` does not change the size of the pattern itself.

--- a/markdown/dev/reference/settings/units/en.md
+++ b/markdown/dev/reference/settings/units/en.md
@@ -2,8 +2,8 @@
 title: units
 ---
 
-The `units` setting controls the units used on the pattern.
-It can be either `metric` (the default) or `imperial`.
+The `units` setting controls the units of length used on the pattern.
+It can be either `metric` (millimeters, the default) or `imperial` (inches).
 
 ## Signature
 
@@ -26,4 +26,4 @@ const pattern = new Aaron({
 ## Notes
 
 This setting only applies to formatting of the output.
-Freesewing expects all input to be in millimeter.
+FreeSewing expects all input to be in millimeter.


### PR DESCRIPTION
I've included the previously-undocumented `settings.debug`, though it is unclear whether it was intended to exist. It doesn't seem to be used in `core` or in any designs.
