### PR TITLE
fix(docs): Add context property to Part.draft()

### DIFF
--- a/markdown/dev/reference/api/part/draft/en.md
+++ b/markdown/dev/reference/api/part/draft/en.md
@@ -32,6 +32,7 @@ access the following properties:
 | `sa`              | Access to `settings.sa` |
 | `scale`           | Access to `settings.scale` |
 || **_Access to utilities_**   |
+| `context`         | The pattern context |
 | `getId`           | See [the getId documentation](/reference/api/part/getid) |
 | `hide`            | See [the hide documentation](/reference/api/part/hide) |
 | `log`             | See [the logging documentation](/reference/api/store/log) |


### PR DESCRIPTION
I am not sure how to explain or document what `context` is. However, it exists and should be documented (unless the intention was that is supposed to be undocumented). 

I note that `context` is the only way to access `settings.debug`, as I understand it.