### PR TITLE
fix(github): Showcase issues template updates and corrections

### DIFF
--- a/.github/ISSUE_TEMPLATE/04_showcase-template.yaml
+++ b/.github/ISSUE_TEMPLATE/04_showcase-template.yaml
@@ -1,22 +1,22 @@
 ---
 name: 📸 (request to) add a new Showcase post
 description: Add a new showcase on FreeSewing.org
-title: "[showcase]: Found a great project to showcase"
-labels: [ "\U0001F44D good first issue, \U0001F4F8 showcase, \U0001F917 community" ]
+title: '[showcase]: Found a great project to showcase'
+labels: [':+1: good first issue, :camera_flash: showcase, :hugs: community']
 body:
   - type: markdown
     attributes:
-      value: "Found a great project/make to showcase? Awesome :tada: Please complete the information below so we can add it to our showcases :point_down:"
+      value: 'Found a great project/make to showcase? Awesome :tada: Please complete the information below so we can add it to our showcases :point_down:'
   - type: input
     id: url
     attributes:
-      label: "Where can we find the awesomeness? 🤔"
+      label: 'Where can we find the awesomeness? 🤔'
       description: Provide a link here to where we can find the pictures/description. Like a blog post or Instagram post, or something on Discord or ...
-      placeholder: "https://www.instagram.com/p/CgRPJCqjgTw/"
+      placeholder: 'https://www.instagram.com/p/CgRPJCqjgTw/'
   - type: dropdown
     id: design
     attributes:
-      label: "Do you know what FreeSewing design was used? 🧐"
+      label: 'Do you know what FreeSewing design was used? 🧐'
       description: If you know which of our patterns was used, please select one of more from the list below
       multiple: true
       options:
@@ -47,6 +47,7 @@ body:
         - Lucy
         - Lunetius
         - Noble
+        - Octoplushy
         - Paco
         - Penelope
         - Sandy
@@ -56,7 +57,6 @@ body:
         - Sven
         - Tamiko
         - Teagan
-        - Theo
         - Tiberius
         - Titan
         - Trayvon
@@ -69,7 +69,7 @@ body:
   - type: dropdown
     id: permission
     attributes:
-      label: "Do we have permission to (re)post this? ✅"
+      label: 'Do we have permission to (re)post this? ✅'
       description: We only post showcases with permission from the original author. Please indicate whether or not permission was granted by choosing the relevant option in the list below
       options:
         - ✅ I am the original author, and hereby grant permission to repost this content
@@ -82,8 +82,9 @@ body:
       description: If there is any other info or pictures you'd like to add you can do so here
   - type: markdown
     attributes:
-      value: Looking to tackle this issue? We have [a how-to that shows how to add a showcase to the site](https://freesewing.dev/editors/howtos/showcase/).
+      value: Looking to tackle this issue? We have [a how-to that shows how to add a showcase to the site](https://freesewing.dev/howtos/editors/showcase/).
   - type: markdown
     attributes:
       value: Please keep in mind that **FreeSewing is a community project** that depends on **[your support](https://freesewing.org/community/join/)**.
 ---
+


### PR DESCRIPTION
3 minor corrections to the New Showcase issues template, plus 1 experimental change to the `labels:` property.

Currently, Labels are not populated in the GitHub New Showcase issue form. The change fixes this so the 3 Labels are automatically populated.

The change is experimental because I am not able to test its effect on the [GitHub New Issue page](https://github.com/freesewing/freesewing/issues/new/choose) until the template file is actually put back into the repository. However, I believe that it might be correct based on the fact that the following URL does cause the Labels to be populated correctly:
`https://github.com/freesewing/freesewing/issues/new?assignees=&labels=:%2B1:+good+first+issue%2C+:camera_flash:+showcase%2C+:hugs:+community&template=04_showcase-template.yaml&title=%5Bshowcase%5D%3A+Found+a+great+project+to+showcase`

If the fix works successfully, I'll make similar changes to the other GitHub issues templates.

(All of the double-quotes-changed-to-single-quotes changes were made by `eslint`. The extra line at the end of the file was also added by `eslint`.)