### PR TITLE
chore: Updated depdencies

### DIFF
--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -262,8 +262,8 @@ dev:
 email:
   _:
     '@maizzle/framework': '4.3.1'
-    'tailwindcss-box-shadow': '^1.0.0'
-    'tailwindcss-email-variants': '^1.0.0'
+    'tailwindcss-box-shadow': '2.0.0'
+    'tailwindcss-email-variants': '2.0.0'
     'tailwindcss-mso': '^1.2.0'
 
 lab:

--- a/sites/email/package.json
+++ b/sites/email/package.json
@@ -20,8 +20,8 @@
   "peerDependencies": {},
   "dependencies": {
     "@maizzle/framework": "4.3.1",
-    "tailwindcss-box-shadow": "^1.0.0",
-    "tailwindcss-email-variants": "^1.0.0",
+    "tailwindcss-box-shadow": "2.0.0",
+    "tailwindcss-email-variants": "2.0.0",
     "tailwindcss-mso": "^1.2.0"
   },
   "devDependencies": {},

--- a/sites/shared/package.json
+++ b/sites/shared/package.json
@@ -44,7 +44,7 @@
     "rehype-highlight": "6.0.0",
     "remark-smartypants": "^2.0.0",
     "sharp": "^0.31.1",
-    "svg-to-pdfkit": "https://github.com/eriese/SVG-to-PDFKit",
+    "svg-to-pdfkit": "^0.1.8",
     "to-vfile": "^7.2.2",
     "unist-util-visit": "^4.1.0",
     "web-worker": "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17791,7 +17791,7 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdfkit@0.13.0:
+pdfkit@0.13.0, pdfkit@>=0.8.1:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/pdfkit/-/pdfkit-0.13.0.tgz#da4c2becd63a129e3aae448fdaed4ee7be790f8f"
   integrity sha512-AW79eHU5eLd2vgRDS9z3bSoi0FA+gYm+100LLosrQQMLUzOBGVOhG7ABcMFpJu7Bpg+MT74XYHi4k9EuU/9EZw==
@@ -22488,9 +22488,12 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-"svg-to-pdfkit@https://github.com/eriese/SVG-to-PDFKit":
-  version "0.1.10"
-  resolved "https://github.com/eriese/SVG-to-PDFKit#2702cbe6b225224c4b5ea25b6a1ee8936cd8cf61"
+svg-to-pdfkit@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/svg-to-pdfkit/-/svg-to-pdfkit-0.1.8.tgz#5921765922044843f0c1a5b25ec1ef8a4a33b8af"
+  integrity sha512-QItiGZBy5TstGy+q8mjQTMGRlDDOARXLxH+sgVm1n/LYeo0zFcQlcCh8m4zi8QxctrxB9Kue/lStc/RD5iLadQ==
+  dependencies:
+    pdfkit ">=0.8.1"
 
 svgo@^1.0.0:
   version "1.3.2"
@@ -22539,15 +22542,15 @@ synckit@^0.8.4:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.4.0"
 
-tailwindcss-box-shadow@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/tailwindcss-box-shadow/-/tailwindcss-box-shadow-1.0.0.tgz#a32603edb896e8d061f583cd200a99fda9739371"
-  integrity sha512-H54nAGO+BIZiwvAp0LVh1tXGQ5GgaQMypAz4D7+Zkp0zLKtTNLRLocMT8bcZ3eVZ9EHKpU4i179q7O1P8gotfg==
+tailwindcss-box-shadow@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tailwindcss-box-shadow/-/tailwindcss-box-shadow-2.0.0.tgz#a7fd1e5255e73c26e5578119a5732289366056eb"
+  integrity sha512-RZdePEMzIpiTG0FmbncVlY6Zkqp3tBhpyCoVpc8UQBZEdGY8TqVcIrE75Si4vIz/oGDAIFRKGeKFt2HLLbLHHQ==
 
-tailwindcss-email-variants@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tailwindcss-email-variants/-/tailwindcss-email-variants-1.1.0.tgz#6801bff1b97ba30df2da34bff156be39c152cded"
-  integrity sha512-JS16QbkxtL07wtpwuYVbivHMEMiVEsKp5sNOwLVr3CgWZBBDkHPLj96hJBE6qdLLcUFZGWJYJGBwR8fw4YIOAw==
+tailwindcss-email-variants@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tailwindcss-email-variants/-/tailwindcss-email-variants-2.0.0.tgz#83663e4da96030edce1906ca0dfc4f00c5bf72b5"
+  integrity sha512-oNiHQCnh2KPfShPjqJLD2PqEgSZ9J4BUJPq3nsufJraxmMq2bowI3651GQBsxh5usT9CgmUNEkDe04d80DN9gQ==
   dependencies:
     lodash.get "^4.4.2"
 


### PR DESCRIPTION
Updated following dependencies in the central config:

- 'tailwindcss-box-shadow': '2.0.0'
- 'tailwindcss-email-variants': '2.0.0'