### PR TITLE
fix(github): Use shortcodes for labels emoji

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug-report.yaml
@@ -2,7 +2,7 @@
 name: 🐛 Bug report
 description: Report a problem, or something that went wrong
 title: '[bug]: '
-labels: ["\U0001F41B bug"]
+labels: [':bug: bug']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/02_feature-request.yaml
@@ -1,8 +1,8 @@
 ---
 name: 🚀 Feature request
 description: Suggest an idea to make FreeSewing better
-title: "[feature]: "
-labels: [ "\U0001F48E enhancement" ]
+title: '[feature]: '
+labels: [':gem: enhancement']
 body:
   - type: markdown
     attributes:
@@ -10,20 +10,20 @@ body:
   - type: textarea
     id: desc
     attributes:
-      label: "What is it that you would like to see happen? 🤔"
+      label: 'What is it that you would like to see happen? 🤔'
       description: Please provide a clear and concise description of what you want to happen
       placeholder: |
         I would like to be able to export patterns as a Gitlab snippet, just like they can be exported as a Github gist
   - type: dropdown
     id: patron
     attributes:
-      label: Are you a FreeSewing patron? 😃 
-      description: "Patrons support us financially :pray: so they get priority"
+      label: Are you a FreeSewing patron? 😃
+      description: 'Patrons support us financially :pray: so they get priority'
       options:
-        - "Yes, I am a tier-2 patron ❤️"
-        - "Yes, I am a tier-4 patron ❤️  💙"
-        - "Yes, I am a tier-8 patron ❤️  💙 💜"
-        - "No, I am not 😞"
+        - 'Yes, I am a tier-2 patron ❤️'
+        - 'Yes, I am a tier-4 patron ❤️  💙'
+        - 'Yes, I am a tier-8 patron ❤️  💙 💜'
+        - 'No, I am not 😞'
     validations:
       required: true
   - type: textarea
@@ -36,3 +36,4 @@ body:
       value: |
         Please keep in mind that **FreeSewing is a community project** that depends on **[your support](https://freesewing.org/community/join/)**.
 ---
+

--- a/.github/ISSUE_TEMPLATE/03_documentation-update.yaml
+++ b/.github/ISSUE_TEMPLATE/03_documentation-update.yaml
@@ -1,28 +1,28 @@
 ---
 description: Suggest updates to FreeSewing documentation or site content
-labels: [ "\U0001F44D good first issue", "\U0001F4D6 documentation" ]
-name: "📝 Documentation or content update"
-title: "[docs]: "
+labels: [':+1: good first issue', ':book: documentation']
+name: '📝 Documentation or content update'
+title: '[docs]: '
 body:
   - type: markdown
     attributes:
-      value: "Found an issue in our documentation, a blog post, showcase or other content? Please complete the information below so we can fix it :point_down:"
+      value: 'Found an issue in our documentation, a blog post, showcase or other content? Please complete the information below so we can fix it :point_down:'
   - type: input
     id: url
     attributes:
-      label: "Where can we see the problem? 🤔"
+      label: 'Where can we see the problem? 🤔'
       description: Provide a link here to the page to be updated. If the page provides an anchor link to the section of interest (indicated by a chain icon next to a heading) please copy that link if possible.
-      placeholder: "https://freesewing/docs/patterns/aaron/cutting"
+      placeholder: 'https://freesewing/docs/patterns/aaron/cutting'
   - type: dropdown
     id: patron
     attributes:
-      label: Are you a FreeSewing patron? 😃 
-      description: "Patrons support us financially :pray: so they get priority"
+      label: Are you a FreeSewing patron? 😃
+      description: 'Patrons support us financially :pray: so they get priority'
       options:
-        - "Yes, I am a tier-2 patron ❤️"
-        - "Yes, I am a tier-4 patron ❤️  💙"
-        - "Yes, I am a tier-8 patron ❤️  💙 💜"
-        - "No, I am not 😞"
+        - 'Yes, I am a tier-2 patron ❤️'
+        - 'Yes, I am a tier-4 patron ❤️  💙'
+        - 'Yes, I am a tier-8 patron ❤️  💙 💜'
+        - 'No, I am not 😞'
     validations:
       required: true
   - type: textarea
@@ -42,3 +42,4 @@ body:
     attributes:
       value: Please keep in mind that **FreeSewing is a community project** that depends on **[your support](https://freesewing.org/community/join/)**.
 ---
+

--- a/.github/ISSUE_TEMPLATE/05_all-contributors.yaml
+++ b/.github/ISSUE_TEMPLATE/05_all-contributors.yaml
@@ -1,51 +1,51 @@
 ---
 name: 🎖️ All Contributors update
 description: Help capture the various contributions to FreeSewing
-title: "[all contributors]: Please add (username here)"
-labels: [ "\U0001F49C all contributors" ]
-assignees: [ 'joostdecock' ]
+title: '[all contributors]: Please add (username here)'
+labels: [':purple_heart: all contributors']
+assignees: ['joostdecock']
 body:
   - type: markdown
     attributes:
-      value: "FreeSewing is an [All Contributors](https://allcontributors.org/) project. Anybody can nominate someone to be added to our contributors list. Fill in the form below to do so :point_down:"
+      value: 'FreeSewing is an [All Contributors](https://allcontributors.org/) project. Anybody can nominate someone to be added to our contributors list. Fill in the form below to do so :point_down:'
   - type: input
     id: username
     attributes:
-      label: "Who made the contribution(s)? 🤔"
+      label: 'Who made the contribution(s)? 🤔'
       description: Please enter the Github username of the person who made the contribution(s)
-      placeholder: "joostdecock"
+      placeholder: 'joostdecock'
   - type: dropdown
     id: design
     attributes:
-      label: "What type(s) of contribution(s) did they make? 🧐"
+      label: 'What type(s) of contribution(s) did they make? 🧐'
       description: Check the emoji list and descriptions below and select whatever is appropriate
       multiple: true
       options:
-        - "♿️ a11y: Reporting or working on accessibility issues"
-        - "🐛 bug: Reporting or working on bugs"
-        - "📝 blog: Writing blog posts"
-        - "💻 code: Writing or improving our code"
-        - "🖋 content: Showcase posts, newsletters, social media, and so on (not documentation or blog)"
-        - "📖 doc: Documentation"
-        - "🎨 design: Pattern design, but also UI/UX"
-        - "📋 eventOrganizing: Organizing events and meetups"
-        - "💵 financial: Provding financial support"
-        - "🚇 infra: Hosting, Servers, SaaS, etc."
-        - "🚧 maintenance: Reserved for maintainers who do a bit of everything"
-        - "🧑‍🏫 mentoring: Mentoring of new contributors"
-        - "📦 platform: Providing specific platform support (Linux/Mac/Windows)"
-        - "🔌 plugin: Writing/improving plugins"
-        - "📆 projectManagement: Coordinating work"
-        - "💬 question: Answering Questions in Issues, on Discord, etc."
-        - "👀 review: Reviewing Pull Requests"
-        - "🛡️ security: Identify and/or reduce security threats, GDPR, Privacy, etc"
-        - "🔧 tool: Work on tooling"
-        - "🌍 translation: Providing translations"
-        - "⚠️ test: People who write tests"
-        - "✅ tutorial: Creating tutorials"
-        - "📢 talk: Giving talks or presentations"
-        - "📓 userTesting: End-to-end testing"
-        - "📹 video: Making videos"
+        - '♿️ a11y: Reporting or working on accessibility issues'
+        - '🐛 bug: Reporting or working on bugs'
+        - '📝 blog: Writing blog posts'
+        - '💻 code: Writing or improving our code'
+        - '🖋 content: Showcase posts, newsletters, social media, and so on (not documentation or blog)'
+        - '📖 doc: Documentation'
+        - '🎨 design: Pattern design, but also UI/UX'
+        - '📋 eventOrganizing: Organizing events and meetups'
+        - '💵 financial: Provding financial support'
+        - '🚇 infra: Hosting, Servers, SaaS, etc.'
+        - '🚧 maintenance: Reserved for maintainers who do a bit of everything'
+        - '🧑‍🏫 mentoring: Mentoring of new contributors'
+        - '📦 platform: Providing specific platform support (Linux/Mac/Windows)'
+        - '🔌 plugin: Writing/improving plugins'
+        - '📆 projectManagement: Coordinating work'
+        - '💬 question: Answering Questions in Issues, on Discord, etc.'
+        - '👀 review: Reviewing Pull Requests'
+        - '🛡️ security: Identify and/or reduce security threats, GDPR, Privacy, etc'
+        - '🔧 tool: Work on tooling'
+        - '🌍 translation: Providing translations'
+        - '⚠️ test: People who write tests'
+        - '✅ tutorial: Creating tutorials'
+        - '📢 talk: Giving talks or presentations'
+        - '📓 userTesting: End-to-end testing'
+        - '📹 video: Making videos'
   - type: textarea
     id: extra
     attributes:
@@ -55,3 +55,4 @@ body:
     attributes:
       value: Please keep in mind that **FreeSewing is a community project** that depends on **[your support](https://freesewing.org/community/join/)**.
 ---
+


### PR DESCRIPTION
This PR changes the GitHub issues templates to use shortcodes for emoji, so the labels get automatically populated on new issues.

(My commit changes only 1 line in each file. All of the other changes were made by `eslint`.)