### PR TITLE
feat(core): Make Part.getId() a prototype method

### DIFF
--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -79,6 +79,17 @@ Part.prototype.attr = function (name, value, overwrite = false) {
 }
 
 /**
+ * Gets a free ID to use in the part
+ *
+ * @return {string} id - A free ID to use
+ */
+Part.prototype.getId = function (prefix = '') {
+  this.freeId += 1
+
+  return prefix + this.freeId
+}
+
+/**
  * Hide the part
  *
  * @return {Part} part - The Part instance

--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -81,6 +81,7 @@ Part.prototype.attr = function (name, value, overwrite = false) {
 /**
  * Gets a free ID to use in the part
  *
+ * @param {string} prefix - An optional prefix to apply to the ID
  * @return {string} id - A free ID to use
  */
 Part.prototype.getId = function (prefix = '') {

--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -85,9 +85,7 @@ Part.prototype.attr = function (name, value, overwrite = false) {
  * @return {string} id - A free ID to use
  */
 Part.prototype.getId = function (prefix = '') {
-  this.freeId += 1
-
-  return prefix + this.freeId
+  return this.__getIdClosure()(prefix)
 }
 
 /**

--- a/packages/core/tests/part.test.mjs
+++ b/packages/core/tests/part.test.mjs
@@ -31,6 +31,14 @@ describe('Part', () => {
     expect(macro('unknown')).to.equal(undefined)
   })
 
+  it('Should return a valid ID with Part.getId()', () => {
+    const part = new Part()
+    const id = part.getId()
+    const prefixed = part.getId('orange')
+    expect(id).to.equal('1')
+    expect(prefixed).to.equal('orange2')
+  })
+
   it('Should register and run a macro', () => {
     const plugin = {
       name: 'test',


### PR DESCRIPTION
As requested by @BenJamesBen in #3282