### PR TITLE
fix(docs): Remove linktitle Frontmatter keys

### DIFF
--- a/markdown/dev/reference/api/part/config/hide/en.md
+++ b/markdown/dev/reference/api/part/config/hide/en.md
@@ -1,6 +1,5 @@
 ---
 title: Hiding parts
-linktitle: hide, hideDependencies, hideAll
 ---
 
 The `hide`, `hideDependencies`, and `hideAll` properties on the

--- a/markdown/dev/reference/api/part/config/name/en.md
+++ b/markdown/dev/reference/api/part/config/name/en.md
@@ -1,6 +1,5 @@
 ---
 title: Naming parts
-linktitle: name
 ---
 
 The `name` property is  -- together with [the `draft()` 


### PR DESCRIPTION
From looking at the code, it appears that `linktitle` in regular Markdown pages is nether parsed nor used. Instead, the property simply gets set with the value of `title` later in the process.

This PR removes `linktitle` from the 2 pages that included it, to help avoid confusion.