### PR TITLE
fix(core): Improve error messages for Firefox and Safari browsers

### DIFF
--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -172,6 +172,12 @@ Pattern.prototype.draftPartForSet = function (partName, set) {
       }
       return result
     } catch (err) {
+      // If the browser's JavaScript engine doesn't include the error's
+      // "name: message" string at the top of the stack, manually push it
+      // onto the stack so the information is shown in the error log.
+      if (!err.stack.startsWith(err.toString())) {
+        err.stack = err.toString() + '\n' + err.stack
+      }
       this.setStores[set].log.error([`Unable to draft part \`${partName}\` (set ${set})`, err])
     }
   } else

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -172,12 +172,6 @@ Pattern.prototype.draftPartForSet = function (partName, set) {
       }
       return result
     } catch (err) {
-      // If the browser's JavaScript engine doesn't include the error's
-      // "name: message" string at the top of the stack, manually push it
-      // onto the stack so the information is shown in the error log.
-      if (!err.stack.startsWith(err.toString())) {
-        err.stack = err.toString() + '\n' + err.stack
-      }
       this.setStores[set].log.error([`Unable to draft part \`${partName}\` (set ${set})`, err])
     }
   } else

--- a/sites/shared/components/workbench/logs.js
+++ b/sites/shared/components/workbench/logs.js
@@ -105,8 +105,6 @@ const StoreLogs = ({ logs, units }) => (
 )
 
 const Logs = (props) => {
-  const renderProps = props.draft.getRenderProps()
-
   return (
     <Tabs
       tabs={[

--- a/sites/shared/components/workbench/logs.js
+++ b/sites/shared/components/workbench/logs.js
@@ -2,21 +2,29 @@ import Markdown from 'react-markdown'
 import { formatMm } from 'shared/utils'
 import { Tab, Tabs } from '../mdx/tabs.js'
 
-export const Error = ({ err }) => (
-  <pre>
-    {err.stack
-      .split(/\n/g)
-      .slice(0, 5)
-      .map((l, i) => (
-        <code
-          key={`error-${i}`}
-          className={'block whitespace-pre-wrap' + (i > 0 ? ' break-all' : '')}
-        >
-          {l}
-        </code>
-      ))}
-  </pre>
-)
+export const Error = ({ err }) => {
+  // Include the error name and message info if it isn't already at the top
+  // of the error stack.
+  let stack = err.stack
+  if (!err.stack.startsWith(err.toString())) {
+    stack = err.toString() + '\n' + err.stack
+  }
+  return (
+    <pre>
+      {stack
+        .split(/\n/g)
+        .slice(0, 5)
+        .map((l, i) => (
+          <code
+            key={`error-${i}`}
+            className={'block whitespace-pre-wrap' + (i > 0 ? ' break-all' : '')}
+          >
+            {l}
+          </code>
+        ))}
+    </pre>
+  )
+}
 
 // Markdown wrapper to suppress creation of P tags
 const Md = ({ children }) => (


### PR DESCRIPTION
JavaScript's `Error.prototype.stack` is a non-standard feature, and different browser JavaScript engines produce error stacks of varying content. 

Chrome produces a stack with useful information:
![Screenshot 2022-12-21 at 1 01 48 PM](https://user-images.githubusercontent.com/109869956/209376193-317f3fe2-158c-4f71-bbf4-b82943a9fb28.png)

However, Firefox and Safari's stacks are less useful, specifically missing the `TypeError: part.getId is not a function` (the value of the error's `toString()`:
![image](https://user-images.githubusercontent.com/109869956/209376318-4790afe8-8f77-4615-85d7-4990c2eefdb1.png)
![Screenshot 2022-12-21 at 4 06 04 PM](https://user-images.githubusercontent.com/109869956/209376255-313465cc-100d-4ca0-b4e7-8f99f9919649.png)

This PR adds the `TypeError: part.getId is not a function` toString() output to the stack if it is not already there. This improves the error when seen in the logs. For example, on Safari:
![Screenshot 2022-12-21 at 5 05 44 PM](https://user-images.githubusercontent.com/109869956/209376635-92898079-5745-4ec6-b12d-edf0f8f0b84b.png)

References:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack