### PR TITLE
fix(core): Fix Path.join() to work with noop

### DIFF
--- a/packages/core/src/path.mjs
+++ b/packages/core/src/path.mjs
@@ -1202,6 +1202,8 @@ function __joinPaths(paths, closed = false) {
     for (let op of p.ops) {
       if (op.type === 'curve') {
         joint.curve(op.cp1, op.cp2, op.to)
+      } else if (op.type === 'noop') {
+        // Skip noop operations.
       } else if (op.type !== 'close') {
         // We're using sitsRoughlyOn here to avoid miniscule line segments
         if (current && !op.to.sitsRoughlyOn(current)) joint.line(op.to)


### PR DESCRIPTION
This PR fixes a bug where `Path.joinI()` produces an error if any of the paths have a `noop()` operation.

 ![Screenshot 2022-12-23 at 2 22 59 PM](https://user-images.githubusercontent.com/109869956/209413450-f79551e5-bb0b-4422-994e-e1acdb661f44.png)
