### PR TITLE
fix(core): Fix Path.join() to work with noop

### DIFF
--- a/packages/core/src/path.mjs
+++ b/packages/core/src/path.mjs
@@ -1202,6 +1202,8 @@ function __joinPaths(paths, closed = false) {
     for (let op of p.ops) {
       if (op.type === 'curve') {
         joint.curve(op.cp1, op.cp2, op.to)
+      } else if (op.type === 'noop') {
+        joint.noop(op.id)
       } else if (op.type !== 'close') {
         // We're using sitsRoughlyOn here to avoid miniscule line segments
         if (current && !op.to.sitsRoughlyOn(current)) joint.line(op.to)

--- a/packages/core/tests/path.test.mjs
+++ b/packages/core/tests/path.test.mjs
@@ -201,6 +201,16 @@ describe('Path', () => {
     expect(joint.ops.length).to.equal(4)
   })
 
+  it('Should join paths that have noop operations', () => {
+    const line = new Path().move(new Point(0, 0)).line(new Point(0, 40)).noop('test1')
+    const curve = new Path()
+      .move(new Point(123, 456))
+      .curve(new Point(0, 40), new Point(123, 34), new Point(230, 4))
+      .noop('test2')
+    const joint = curve.join(line)
+    expect(joint.ops.length).to.equal(6)
+  })
+
   it('Should throw error when joining a closed paths', () => {
     const line = new Path().move(new Point(0, 0)).line(new Point(0, 40))
     const curve = new Path()


### PR DESCRIPTION
This PR fixes a bug in `Path.join()` where it produces the below error if any of the paths contains a `noop()` operation.

![Screenshot 2022-12-23 at 2 22 59 PM](https://user-images.githubusercontent.com/109869956/209413686-8c854e0f-563a-4860-a8c0-449c2e7cec57.png)
