### PR TITLE
chore(charlie): Add debugging messages for inseam/outseam lengths

### DIFF
--- a/designs/charlie/src/back.mjs
+++ b/designs/charlie/src/back.mjs
@@ -16,18 +16,16 @@ function draftCharlieBack({
   sa,
   log,
   units,
+  utils,
   part,
 }) {
   // Helper method to draw the outseam path
   const drawOutseam = () => {
-    let outseam = new Path()
-      .move(points.styleWaistOut)
-      .curve(points.seatOut, points.kneeOutCp2, points.floorOut)
     return new Path()
       .move(points.slantOut)
       .line(points.slantCurveStart)
       .curve(points.slantCurveCp1, points.slantCurveCp2, points.slantCurveEnd)
-      .join(outseam.split(points.slantCurveEnd).pop())
+      .join(titanOutseam.split(points.slantCurveEnd).pop())
       .reverse()
   }
   /*
@@ -80,6 +78,11 @@ function draftCharlieBack({
   const titanOutseam = new Path()
     .move(points.styleWaistOut)
     .curve(points.seatOut, points.kneeOutCp2, points.floorOut)
+
+  // Helper object holding the inseam path
+  const backInseamPath = new Path()
+    .move(points.fork)
+    .curve(points.forkCp2, points.kneeInCp1, points.floorIn)
 
   // Keep the seat control point vertically between the (lowered) waist and seat line
   points.seatOutCp2.y = points.styleWaistOut.y + points.styleWaistOut.dy(points.seatOut) / 2
@@ -137,6 +140,28 @@ function draftCharlieBack({
     .close()
     .attr('class', 'fabric')
   paths.saBase.hide()
+
+  // Sanity check, to make sure inseams and outseams match front and back
+  const backInseamLength = backInseamPath.length()
+  const frontInseamLength = store.get('frontInseamLength')
+  const inseamDiff = frontInseamLength - backInseamLength
+  let inseamDesc = 'Charlie back inseam is longer than front'
+  if (inseamDiff > 0) inseamDesc = 'Charlie front inseam is longer than back'
+  if (Math.abs(inseamDiff) > 1) {
+    log.warning(inseamDesc + ' by ' + utils.round(Math.abs(inseamDiff)) + ' mm')
+    log.debug('Charlie frontInseam: ' + utils.round(frontInseamLength).toString())
+    log.debug('Charlie backInseam: ' + utils.round(backInseamLength).toString())
+  }
+  const backOutseamLength = drawOutseam().length()
+  const frontOutseamLength = store.get('frontOutseamLength')
+  const outseamDiff = frontOutseamLength - backOutseamLength
+  let outseamDesc = 'Charlie back outseam is longer than front'
+  if (outseamDiff > 0) outseamDesc = 'Charlie front outseam is longer than back'
+  if (Math.abs(outseamDiff) > 1) {
+    log.warning(outseamDesc + ' by ' + utils.round(Math.abs(outseamDiff)) + ' mm')
+    log.debug('Charlie frontOutseam: ' + utils.round(frontOutseamLength).toString())
+    log.debug('Charlie backOutseam: ' + utils.round(backOutseamLength).toString())
+  }
 
   if (complete) {
     paths.pocketLine = new Path()

--- a/designs/charlie/src/front.mjs
+++ b/designs/charlie/src/front.mjs
@@ -31,9 +31,8 @@ function draftCharlieFront({
   // Helper method to draw the outline path
   const drawPath = () => {
     let outseam = drawOutseam()
-    return new Path()
-      .move(points.floorIn)
-      .curve(points.kneeInCp2, points.forkCp1, points.fork)
+    return frontInseamPath
+      .clone()
       .curve(points.crotchSeamCurveCp1, points.crotchSeamCurveCp2, points.crotchSeamCurveStart)
       .line(points.styleWaistIn)
       .line(points.slantTop)
@@ -50,6 +49,11 @@ function draftCharlieFront({
           .move(points.styleWaistOut)
           ._curve(points.seatOutCp1, points.seatOut)
           .curve(points.seatOutCp2, points.kneeOutCp1, points.floorOut)
+
+  // Helper object holding the inseam path
+  const frontInseamPath = new Path()
+    .move(points.floorIn)
+    .curve(points.kneeInCp2, points.forkCp1, points.fork)
 
   // Draw fly J-seam
   const flyBottom = utils.curveIntersectsY(
@@ -167,6 +171,10 @@ function draftCharlieFront({
   store.set('waistbandFront', points.styleWaistIn.dist(points.slantTop))
   store.set('waistbandFly', points.styleWaistIn.dist(points.flyTop))
   store.set('legWidthFront', points.floorIn.dist(points.floorOut))
+
+  // Store inseam and outseam lengths
+  store.set('frontInseamLength', frontInseamPath.length())
+  store.set('frontOutseamLength', drawOutseam().length())
 
   if (complete) {
     points.titleAnchor = new Point(points.knee.x, points.fork.y)


### PR DESCRIPTION
This is the first of a set of two Charlie PRs that addresses Bug #3258. That is the bug where the front and back inseam lengths are different, and similarly the back and front outseams are also different lengths.

This first PR doesn't actually address the problem or change the Charlie pattern. Instead, it just adds helper paths and log messages to assist debugging the issue. With this PR, the different lengths are logged, and users can more easily see what is going on. 

(After the first PR is merged, I will wait a bit before submitting the second PR. That will be the one that actually tries to fix the problem.)