### PR TITLE
fix(bruce): Turn failing patterns into degraded patterns with warning messages

### DIFF
--- a/designs/bruce/src/side.mjs
+++ b/designs/bruce/src/side.mjs
@@ -15,8 +15,11 @@ function draftBruceSide({
   utils,
   snippets,
   Snippet,
+  log,
   part,
 }) {
+  let adjustment_warning = false
+
   // Initialize
   init(part)
 
@@ -37,7 +40,15 @@ function draftBruceSide({
     points.topLeft,
     store.get('backSeamLength')
   )
-  points.bottomLeft = isect[0]
+  if (isect) {
+    points.bottomLeft = isect[0]
+  } else {
+    // The circles are too far apart to intersect. Print a warning message
+    // and compromise by placing the bottom left point at the midpoint.
+    log.warning('Unable to calculate a correct bottom left point on the side part.')
+    adjustment_warning = true
+    points.bottomLeft = points.bottomRight.shiftFractionTowards(points.topLeft, 0.5)
+  }
 
   // Store side seam length
   store.set('sideSeamLength', points.topRight.dist(points.bottomRight))
@@ -112,6 +123,19 @@ function draftBruceSide({
       to: points.bottomRight,
       y: points.bottomLeft.y + 15 + sa,
     })
+  }
+
+  if (adjustment_warning) {
+    log.warning(
+      'We were not able to generate the Side pattern piece correctly. ' +
+        'Manual fitting and alteration of this and other pattern pieces ' +
+        'are likely to be needed. ' +
+        'First, please retake your measurements and generate a new pattern ' +
+        'using the new measurements. ' +
+        'If you still see this warning with the new pattern, then please ' +
+        'make a test garment, check fit, and make alterations as necessary ' +
+        'before trying to make the final garment.'
+    )
   }
 
   return part


### PR DESCRIPTION
This PR is the first in a series of pattern fixes to implement the philosophy of "Patterns should not crash with an error. Instead, they should produce a degraded pattern as best they can and print warning messages to the user."

Specifically this Bruce PR:
- Stops the iterative tusk adjustment loop as soon as it detects that the adjustments have stopped producing better results. The goal is to avoid "runaway" rotations that keep making the pattern worse the longer the iterations run.
- Avoids a crash when two circles do not intersect and the bottom left location on the side cannot be determined. Instead, it picks the best-but-arbitrary location for the point and creates it there.
- For each of these situations, a warning message is logged explaining the specific issue.
- For each of these situations, a stronger, detailed warning message is logged to tell the customer that the pattern is degraded and to provide instructions about what to do:

> We were not able to generate the Side pattern piece correctly. Manual fitting and alteration of this and other pattern pieces are likely to be needed. First, please retake your measurements and generate a new pattern using the new measurements. If you still see this warning with the new pattern, then please make a test garment, check fit, and make alterations as necessary before trying to make the final garment.

(In a future PR, we might put this message text into a library as a string or method. That way, this standard wording can be used in different patterns without having to duplicate the code in multiple files. An alternate implementation might be to print a shorter message with a link to an "error page" that would contain the longer explanation text.) 