### PR TITLE
fix(org): Use absolute URL paths in navigation

### DIFF
--- a/sites/org/components/navigation/primary.js
+++ b/sites/org/components/navigation/primary.js
@@ -95,7 +95,7 @@ const SubLevel = ({ nodes = {}, active }) => (
             `}
             >
               <Link
-                href={`${child.__slug}`}
+                href={'/' + `${child.__slug}`}
                 title={child.__title}
                 className={`
                   grow pl-2 border-l-2
@@ -135,7 +135,7 @@ const SubLevel = ({ nodes = {}, active }) => (
       ) : (
         <li className="pl-2 flex flex-row items-center" key={child.__slug}>
           <Link
-            href={`${child.__slug}`}
+            href={'/' + `${child.__slug}`}
             title={child.__title}
             className={`
               pl-2 border-l-2
@@ -188,7 +188,7 @@ const TopLevel = ({ icon, title, current, slug, hasChildren = false, active }) =
     >
       <span className="text-secondary">{icon}</span>
       <Link
-        href={`${slug}`}
+        href={'/' + `${slug}`}
         className={`
           grow ${linkClasses} hover:cursor-pointer
           ${slug === active ? 'text-secondary sm:text-secondary' : ''}`}


### PR DESCRIPTION
Because the freesewing.org documentation is in the `docs/` directory, the sidebar navigation URLs incorrectly have duplicate `docs` in their paths. For example `http://localhost:8000/docs/docs/guide/patterns`.

The navigation seems to construct the URLs to be relative. Because the current path is `docs/`, the slug/href `docs/guide/patterns` becomes the incorrect URL `docs/docs/guide/pattens`.

This PR fixes this by changing the hrefs to absolute paths.

(I do not know whether this is the best fix or how it might affect pages not under the `docs/` hierarchy. Another way to fix this might be to strip the `docs/` from the beginning of the `slug`. Or, keep the `slug` intact, create a new `navSlug` for the stripped path, and have the navigation use `navSlug` instead of `slug`, if present.)