### PR TITLE
fix(docs): Insert space between numbers and SI units

### DIFF
--- a/markdown/dev/howtos/design/fit-sleeve/en.md
+++ b/markdown/dev/howtos/design/fit-sleeve/en.md
@@ -66,7 +66,7 @@ export default function (part) {
     // If we're short, increase the tweak factor
     else tweak = tweak * 1.02 
   } while (Math.abs(delta) > 2 && runs < 25) 
-  // Keep doing this until we're off by less than 2mm or we tried 25 times
+  // Keep doing this until we're off by less than 2 mm or we tried 25 times
 ```
 
 A few things that are important:

--- a/markdown/dev/reference/api/part/config/options/pct/fromabs/en.md
+++ b/markdown/dev/reference/api/part/config/options/pct/fromabs/en.md
@@ -33,7 +33,7 @@ function fromAbs(millimeter, settings) {
 ```
 
 The first parameter is the desired value in millimeter (for example
-`130` for `13cm`).
+`130` for `13 cm`).
 The second parameter is the pattern's [settings](/reference/settings) object
 which holds -- among other things -- the measurements provided by the user.
 

--- a/markdown/dev/reference/api/part/config/options/pct/snap/en.md
+++ b/markdown/dev/reference/api/part/config/options/pct/snap/en.md
@@ -42,7 +42,7 @@ When `snap` holds a number, the option will be _snapped_ to a
 multiple of this value.
 
 In the example below, the absolute value of this option will be set to a multiple of `7`
-(so one of `0mm`, `7mm`, `14mm`, `21mm`, `28mm`, `35mm`, `42mm`, ...).
+(so one of `0 mm`, `7 mm`, `14 mm`, `21 mm`, `28 mm`, `35 mm`, `42 mm`, ...).
 
 ```js
 myOption: {
@@ -68,7 +68,7 @@ When snap holds an array of numbers, the option will be _snapped_ to one of
 the numbers unless it's further away than half the distance to its closest neighbor.
 
 In the example below, if the absolute value returned by `toAbs()` is in the
-region of influence -- in this example between `4.5mm` and `69.5mm` --  the nearest snap value
+region of influence -- in this example between `4.5 mm` and `69.5 mm` --  the nearest snap value
 will be used. If instead it is outside the region of influence, the result of
 `toAbs()` will be uses as-is.
 
@@ -94,8 +94,8 @@ In the example below, the value of [settings.units](/reference/settings/units) w
 determine which list of snap values gets used.
 
 Then, if the absolute value returned by `toAbs()` is in the
-region of influence -- in this example between `4.5mm` and `69.5mm` for metric
-and between `12.7mm` and `88.9mm` for imperial --  the nearest snap value
+region of influence -- in this example between `4.5 mm` and `69.5 mm` for metric
+and between `12.7 mm` and `88.9 mm` for imperial --  the nearest snap value
 will be used. If instead it is outside the region of influence, the result of
 `toAbs()` will be used as-is.
 
@@ -138,8 +138,8 @@ We have a few different ways we can approach this:
 We use a percentage option based on a vertical measurement, like
 `waistToFloor`.
 
-The elastic width people end up with is something like `34.12mm` for
-user A and `27.83mm` for user B.
+The elastic width people end up with is something like `34.12 mm` for
+user A and `27.83 mm` for user B.
 
 Elastic of that width is not for sale in the store, so that's not great.
 
@@ -178,7 +178,7 @@ under the hood, let's first agree on terminology:
 - The **percentage value** is the value passed by the user for the option.
   Its value always represents a percentage. For example `0.5` for 50%.
 - The **millimeter value** is the result of feeding the **percentage value** to
-  the `toAbs()` method. Its value always represents millimeters. For example `12mm`.
+  the `toAbs()` method. Its value always represents millimeters. For example `12 mm`.
 - The **snap values** are the values provided by the snap configuration.
   Each of the values always represents millimeters (even for imperial users).
 

--- a/markdown/dev/reference/api/path/shiftalong/en.md
+++ b/markdown/dev/reference/api/path/shiftalong/en.md
@@ -37,12 +37,12 @@ For most cases, the default will be fine.
   
   points.x1 = paths.example
     .shiftAlong(20)
-    .attr("data-text", "2cm")
+    .attr("data-text", "2 cm")
     .attr("data-text-class", "center fill-note")
     .attr("data-text-lineheight", 6)
   points.x2 = paths.example
     .shiftAlong(90)
-    .attr("data-text", "9cm")
+    .attr("data-text", "9 cm")
     .attr("data-text-class", "center fill-note")
     .attr("data-text-lineheight", 6)
   

--- a/markdown/dev/reference/api/point/shift/en.md
+++ b/markdown/dev/reference/api/point/shift/en.md
@@ -21,7 +21,7 @@ Point point.shift(float angle, float distance)
   points.A = new Point(90, 40)
     .setText("Point A", "right text-sm")
   points.B = points.A.shift(155, 70)
-    .setText("Point B is point A shifted 7cm\nat a 155 degree angle", "text-sm")
+    .setText("Point B is point A shifted 7 cm\nat a 155 degree angle", "text-sm")
     .attr("data-text-lineheight", 6)
   
   macro("ld", {

--- a/markdown/dev/reference/api/point/shiftoutwards/en.md
+++ b/markdown/dev/reference/api/point/shiftoutwards/en.md
@@ -20,7 +20,7 @@ Point point.shiftOutwards(Point target, float distance)
   points.A = new Point(90, 70).setText("Point A", "text-sm right")
   points.B = new Point(10, 10).setText("Point B", "text-sm")
   points.C = points.A.shiftOutwards(points.B, 30)
-    .setText("Point C is point A shifted 3cm\nbeyond point B", "text-sm")
+    .setText("Point C is point A shifted 3 cm\nbeyond point B", "text-sm")
     .attr("data-text-lineheight", 6)
   
   paths.direction = new Path()

--- a/markdown/dev/reference/api/point/shifttowards/en.md
+++ b/markdown/dev/reference/api/point/shifttowards/en.md
@@ -20,7 +20,7 @@ Point point.shiftTowards(Point target, float distance)
   points.A = new Point(90, 70).setText("Point A", "right text-sm")
   points.B = new Point(10, 10).setText("Point B", "text-sm")
   points.C = points.A.shiftTowards(points.B, 35)
-    .setText("Point C is point A shifted 3.5cm\nin the direction of point B", "center, text-sm")
+    .setText("Point C is point A shifted 3.5 cm\nin the direction of point B", "center, text-sm")
     .attr("data-text-lineheight", 6)
   
   paths.direction = new Path()

--- a/markdown/dev/reference/api/utils/stretchtoscale/en.md
+++ b/markdown/dev/reference/api/utils/stretchtoscale/en.md
@@ -15,7 +15,7 @@ float utils.stretchToScale(float stretch)
 
 The way people measure stretch intuitively is different from the way we handle stretch in code.
 
-When people say _25% stretch_ they mean that 10cm fabric gets stretched to 12.5cm fabric.
+When people say _25% stretch_ they mean that 10 cm fabric gets stretched to 12.5 cm fabric.
 In code and on our patterns, that means we need to scale things by 80%.
 
 This function does that by returning:

--- a/markdown/dev/reference/hooks/inserttext/en.md
+++ b/markdown/dev/reference/hooks/inserttext/en.md
@@ -37,16 +37,16 @@ Let's use an example to clarify things:
 ```js
 points.example
   .addText("seamAllowance")
-  .addText(": 1cm")
+  .addText(": 1 cm")
 ```
 
 For the example point above, the `insertText` hook will end up being called 3 times:
 
 - First it will pass `seamAllowance` to the plugin
-- Then it will pass `: 1cm` to the plugin
-- Finally it will pass `seamAllowance : 1cm` to the plugin
+- Then it will pass `: 1 cm` to the plugin
+- Finally it will pass `seamAllowance : 1 cm` to the plugin
 
-Having the `insertText` hook only run once with `Seam allowance: 1cm` would be problematic because
+Having the `insertText` hook only run once with `Seam allowance: 1 cm` would be problematic because
 the seam allowance may differ, or perhaps we're using imperial units, and so on.
 
 Instead, you can (and should) divide your text into chunks that need translating, and chunks that do not.

--- a/markdown/dev/reference/settings/margin/en.md
+++ b/markdown/dev/reference/settings/margin/en.md
@@ -4,7 +4,7 @@ title: margin
 
 The `margin` setting allows you to specify a part margin (in mm).
 Each part will have this margin applied when they are laid out on the pattern.
-The default is `2mm`.
+The default is `2 mm`.
 
 ## Signature
 
@@ -27,12 +27,12 @@ const pattern = new Aaron({
 ## Notes
 
 The _margin_ implies that:
-- At the edge of the SVG, the margin will be `margin * 1` (2mm by default)
-- Between parts, the margin will be `margin * 2` (4mm by default)
+- At the edge of the SVG, the margin will be `margin * 1` (2 mm by default)
+- Between parts, the margin will be `margin * 2` (4 mm by default)
 
 Setting the margin to zero (or below) will cause parts to overlap.
 
-In paperless mode, the margin will not go below 10mm.
+In paperless mode, the margin will not go below 10 mm.
 That is because text is not taken into account when calculating the bounding
 box of the part.  Since dimensions are typically the outermost elements in a
 paperless part, a too narrow margin would cause the dimension text to get cut

--- a/markdown/dev/reference/settings/paperless/en.md
+++ b/markdown/dev/reference/settings/paperless/en.md
@@ -41,4 +41,4 @@ and omit them if set to `false`.
 
 The `paperless` setting does automatically cause the grid to be included.
 
-Setting `paperless` to `true` will also cause the [margin](/reference/settings/margin) to not go below 10mm.
+Setting `paperless` to `true` will also cause the [margin](/reference/settings/margin) to not go below 10 mm.


### PR DESCRIPTION
This PR inserts a space character between numbers and SI units ("8 cm" instead of "8cm", for example).

This conforms to the SI and NIST guidelines:
https://www.bipm.org/en/publications/si-brochure
https://www.nist.gov/pml/owm/writing-si-metric-system-units#spacing

I'm writing a style guide that I am following for FreeSewing, and the guideline currently is:
- There should be a space character between numbers and SI units. For example, "5 cm" and "1.3 mm", rather than "5cm" and "1.3mm". (The exception is for CSS and SVG values. Their specifications say that the space character should not be used.)