### PR TITLE
fix(docs): Tutorials updates and corrections

### DIFF
--- a/markdown/dev/tutorials/getting-started-gitpod/en.md
+++ b/markdown/dev/tutorials/getting-started-gitpod/en.md
@@ -1,15 +1,16 @@
 ---
-title: Getting started with GitPod
+title: Getting started with Gitpod
 order: 10
 ---
 
-If you don't want to set up a dev environment, or just want to kick the
+If you don't want to set up a dev environment or if you just want to kick the
 tires like, right now, you can run our development environment in your browser via Gitpod:
 
 https://gitpod.io/#https://github.com/freesewing/freesewing
 
 <Tip>
-We recommend that you fork our repository so you can push changes to the repository.
+We recommend that you instead fork our repository and use Gitpod with
+your fork so you can make changes and push them to your repository on Gitpod.
 To do so, simple adapt the URL above as follows:
 
 https://gitpod.io/#url-to-your-fork

--- a/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
@@ -60,7 +60,7 @@ But if you're running Linux, you have git, right?
 
 #### Install yarn
 
-Our repository uses yarn workspaces. So you'll need yarn to work with it.
+Our repository uses yarn workspaces. So you'll need `yarn` to work with it.
 
 To install it run:
 
@@ -75,7 +75,7 @@ all the changes you want. To do so, visit https://github.com/freesewing/freesewi
 
 #### Clone the forked repository
 
-Now that you have your very own fork, time to clone it locally.
+Now that you have your very own fork, it's time to clone it locally.
 
 ```bash
 git clone <url to your fork>
@@ -105,7 +105,7 @@ yarn new design
 
 ## Creating a new plugin
 
-If you'd like to create a new plugin, run the following comand:
+If you'd like to create a new plugin, run the following command:
 
 ```sh
 yarn new plugin
@@ -113,13 +113,15 @@ yarn new plugin
 
 ## Stand-alone development
 
-With NodeJS installed, all you need to do to setup the stand-alone development environment is run this command:
+With Node.js installed, all you need to do to setup the stand-alone development environment is run this command:
 
 ```bash
 npx @freesewing/new-design@next
 ```
 
-<Fixme>Remove `@next` tag when v3 is released</Fixme>
+<Fixme compact>
+Remove `@next` tag when v3 is released
+</Fixme>
 
 After you've answered [some questions](#questions), it will take a while to set
 everything up.  When it's done, you will have a new folder with the development
@@ -152,6 +154,12 @@ If you're not certain what to pick, just mash some keys, it doesn't matter.
 
 #### What package manager to use
 
-Chose `npm` if you don't have `yarn` are when you're not sure what the heck `yarn` is.
+Choose `yarn`. Currently, `npm` does not work.
 
 </Note>
+
+<Fixme compact>
+The `npm` issue issue should be fixed by the time v3 is released.
+The _What package manager to use_ section will need to be updated at that
+time.
+</Fixme>

--- a/markdown/dev/tutorials/getting-started-linux/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/en.md
@@ -3,11 +3,11 @@ title: Getting started on Linux
 order: 15
 ---
 
-In this tutorial, we will setup Node JS and initialize the FreeSewing
+In this tutorial, we will setup Node.js and initialize the FreeSewing
 development environment on a Linux system.
 
 We'll cover the following steps:
 
-<ReadMore list />
+<ReadMore />
 
-<Tip>These instructions are also valid for BSD- or other unix systems</Tip>
+<Tip>These instructions are also valid for BSD or other Unix systems</Tip>

--- a/markdown/dev/tutorials/getting-started-linux/installing-node/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/installing-node/en.md
@@ -1,15 +1,15 @@
 ---
-title: Installing Node
+title: Installing Node.js
 order: 20
 ---
 
-Now we will use nvm to install Node JS. Run the following command:
+Now we will use `nvm` to install Node.js. Run the following command:
 
 ```bash
 nvm install lts/gallium
 ```
 
-This will install the so-called LTS version of Node 16 on your system.
+This will install the so-called LTS version of Node.js 16 on your system.
 
-LTS versions -- short for Long Term Support -- are good node versions
+LTS versions -- short for Long Term Support -- are good Node.js versions
 to use because they are stable and supported for a long time.

--- a/markdown/dev/tutorials/getting-started-linux/installing-nvm/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/installing-nvm/en.md
@@ -5,16 +5,16 @@ order: 10
 
 FreeSewing is built with [Node.js](https://nodejs.org/), a JavaScript runtime.
 
-You'll need to install Node JS on your system, and to do so, we'll
-use [nvm](https://github.com/nvm-sh/nvm), short for _Node version manager_.
+You'll need to install Node.js on your system, and to do so, we'll
+use [`nvm`](https://github.com/nvm-sh/nvm), short for _Node Version Manager_.
 
-Using nvm has a number of benefits in comparison with installing Node from
-the node.js website, or from a package provided by your linux distribution:
+Using `nvm` has a number of benefits in comparison with installing Node.js directly from
+the Node.js website, or from a package provided by your Linux distribution:
 
-- You can easily switch between different Node versions
+- You can easily switch between different Node.js versions
 - Everything gets installed in your home folder, avoiding permission problems
 
-To setup nvm, [follow the install instructions in the nvm
+To setup `nvm`, [follow the install instructions in the nvm
 README](https://github.com/nvm-sh/nvm#installing-and-updating).
 
 After installation is completed, try running the following command:
@@ -23,7 +23,7 @@ After installation is completed, try running the following command:
 nvm
 ```
 
-If all goes well, it should show you the nvm help.
+If all goes well, it should show you the `nvm` help.
 
 <Tip>
 

--- a/markdown/dev/tutorials/getting-started-linux/node-versions/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/node-versions/en.md
@@ -1,36 +1,36 @@
 ---
-title: Using a different Node version
+title: Using a different Node.js version
 order: 30
 ---
 
-Now that you've got Node setup, we can start setting up the FreeSewing
+Now that you've got Node.js setup, we can start setting up the FreeSewing
 development environment.
 
 But before doing so, let's look at how `nvm` can help you juggle different
-Node versions.
+Node.js versions.
 
 ### nvm ls
 
-To see the different Node versions on your system, run this command:
+To see the different Node.js versions on your system, run this command:
 
 ```bash
 nvm ls
 ```
 
-It will show you a list of local node versions.
-Either the version number, or an _alias_ that points to a specific version.
+It will show you a list of local Node.js versions,
+either the version number or an _alias_ that points to a specific version.
 You should see the `lts/*` alias in the list which is what we've just installed.
 
 ### nvm ls-remote
 
-To see all Node versions that are available, not just those you have locally,
+To see all Node.js versions that are available, not just those you have locally,
 run this command:
 
 ```bash
 nvm ls-remote
 ```
 
-Nvm will now spit out a long list of Node versions that you can install.
+It will spit out a long list of Node.js versions that you can install.
 
 ### nvm install
 
@@ -43,7 +43,7 @@ nvm install <version-or-alias>
 
 ### nvm use
 
-With multiple Node versions installed, `nvm` allows you to switch between different
+With multiple Node.js versions installed, `nvm` allows you to switch between different
 versions. Just tell it which version you want to use:
 
 ```bash

--- a/markdown/dev/tutorials/getting-started-mac/dev-setup/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/dev-setup/en.md
@@ -60,7 +60,7 @@ But if you're running Linux, you have git, right?
 
 #### Install yarn
 
-Our repository uses yarn workspaces. So you'll need yarn to work with it.
+Our repository uses yarn workspaces. So you'll need `yarn` to work with it.
 
 To install it run:
 
@@ -75,7 +75,7 @@ all the changes you want. To do so, visit https://github.com/freesewing/freesewi
 
 #### Clone the forked repository
 
-Now that you have your very own fork, time to clone it locally.
+Now that you have your very own fork, it's time to clone it locally.
 
 ```bash
 git clone <url to your fork>
@@ -105,7 +105,7 @@ yarn new design
 
 ## Creating a new plugin
 
-If you'd like to create a new plugin, run the following comand:
+If you'd like to create a new plugin, run the following command:
 
 ```sh
 yarn new plugin
@@ -113,13 +113,15 @@ yarn new plugin
 
 ## Stand-alone development
 
-With NodeJS installed, all you need to do to setup the stand-alone development environment is run this command:
+With Node.js installed, all you need to do to setup the stand-alone development environment is run this command:
 
 ```bash
 npx @freesewing/new-design@next
 ```
 
-<Fixme>Remove `@next` tag when v3 is released</Fixme>
+<Fixme compact>
+Remove `@next` tag when v3 is releasedi
+</Fixme>
 
 After you've answered [some questions](#questions), it will take a while to set
 everything up.  When it's done, you will have a new folder with the development
@@ -152,6 +154,12 @@ If you're not certain what to pick, just mash some keys, it doesn't matter.
 
 #### What package manager to use
 
-Chose `npm` if you don't have `yarn` are when you're not sure what the heck `yarn` is.
+Choose `yarn`. Currently, `npm` does not work.
 
 </Note>
+
+<Fixme compact>
+The `npm` issue issue should be fixed by the time v3 is released.
+The _What package manager to use_ section will need to be updated at that
+time.
+</Fixme>

--- a/markdown/dev/tutorials/getting-started-mac/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/en.md
@@ -3,8 +3,8 @@ title: Getting started on Mac
 order: 25
 ---
 
-In this tutorial, we will setup Node JS and initialize the FreeSewing
-development environment on a Mac system running OS X.
+In this tutorial, we will setup Node.js and initialize the FreeSewing
+development environment on a Mac system running macOS.
 
 <Tip>
 
@@ -15,4 +15,4 @@ application at `/Applications/Utilities/`.
 
 We'll cover the following steps:
 
-<ReadMore list />
+<ReadMore />

--- a/markdown/dev/tutorials/getting-started-mac/installing-node/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/installing-node/en.md
@@ -1,15 +1,15 @@
 ---
-title: Installing Node
+title: Installing Node.js
 order: 20
 ---
 
-Now we will use nvm to install Node JS. Run the following command:
+Now we will use `nvm` to install Node.js. Run the following command:
 
 ```bash
 nvm install lts/gallium
 ```
 
-This will install the so-called LTS version of Node 16 on your system.
+This will install the so-called LTS version of Node.js 16 on your system.
 
-LTS versions -- short for Long Term Support -- are good node versions
+LTS versions -- short for Long Term Support -- are good Node.js versions
 to use because they are stable and supported for a long time.

--- a/markdown/dev/tutorials/getting-started-mac/installing-nvm/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/installing-nvm/en.md
@@ -1,20 +1,20 @@
 ---
 title: Installing nvm
-order: 10
+order: 15
 ---
 
 FreeSewing is built with [Node.js](https://nodejs.org/), a JavaScript runtime.
 
-You'll need to install Node JS on your system, and to do so, we'll
-use [nvm](https://github.com/nvm-sh/nvm), short for _Node version manager_.
+You'll need to install Node.js on your system, and to do so, we'll
+use [`nvm`](https://github.com/nvm-sh/nvm), short for _Node Version Manager_.
 
-Using nvm has a number of benefits in comparison with installing Node from
-the node.js website, or from a package provided by your linux distribution:
+Using `nvm` has a number of benefits in comparison with installing Node.js from
+the Node.js website, or from a package provided by your Linux distribution:
 
-- You can easily switch between different Node versions
+- You can easily switch between different Node.js versions
 - Everything gets installed in your home folder, avoiding permission problems
 
-To setup nvm, [follow the install instructions in the nvm
+To setup `nvm`, [follow the install instructions in the nvm
 README](https://github.com/nvm-sh/nvm#installing-and-updating).
 
 After the installation, try running the following command:
@@ -23,7 +23,7 @@ After the installation, try running the following command:
 nvm
 ```
 
-If all goes well, it should show you the nvm help.
+If all goes well, it should show you the `nvm` help.
 
 <Tip>
 

--- a/markdown/dev/tutorials/getting-started-mac/installing-xcode/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/installing-xcode/en.md
@@ -13,5 +13,5 @@ Open the Terminal application, and type the following command:
 xcode-select --install
 ```
 
-A popup will appear asking you to confirm the installation.
+A pop-up will appear asking you to confirm the installation.
 Confirm, and go make a cup of coffee while the install does its thing.

--- a/markdown/dev/tutorials/getting-started-mac/node-versions/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/node-versions/en.md
@@ -1,36 +1,36 @@
 ---
-title: Using a different Node version
-order: 40
+title: Using a different Node.js version
+order: 30
 ---
 
-Now that you've got Node setup, we can start setting up the FreeSewing
+Now that you've got Node.js setup, we can start setting up the FreeSewing
 development environment.
 
 But before doing so, let's look at how `nvm` can help you juggle different
-Node versions.
+Node.js versions.
 
 ### nvm ls
 
-To see the different Node versions on your system, run this command:
+To see the different Node.js versions on your system, run this command:
 
 ```bash
 nvm ls
 ```
 
-It will show you a list of local node versions.
-Either the version number, or an _alias_ that points to a specific version.
+It will show you a list of local Node.js versions,
+either the version number or an _alias_ that points to a specific version.
 You should see the `lts/*` alias in the list which is what we've just installed.
 
 ### nvm ls-remote
 
-To see all Node versions that are available, not just those you have locally,
+To see all Node.js versions that are available, not just those you have locally,
 run this command:
 
 ```bash
 nvm ls-remote
 ```
 
-Nvm will now spit out a long list of Node versions that you can install.
+It will spit out a long list of Node.js versions that you can install.
 
 ### nvm install
 
@@ -43,7 +43,7 @@ nvm install <version-or-alias>
 
 ### nvm use
 
-With multiple Node versions installed, `nvm` allows you to switch between different
+With multiple Node.js versions installed, `nvm` allows you to switch between different
 versions. Just tell it which version you want to use:
 
 ```bash

--- a/markdown/dev/tutorials/getting-started-windows/en.md
+++ b/markdown/dev/tutorials/getting-started-windows/en.md
@@ -53,23 +53,23 @@ guide](https://github.com/nvm-sh/nvm#install--update-script).  Once installed
 you will need to activate NVM by either following the instructions printed to
 the screen or opening a new terminal.
 
-#### Install Node (and optionally Yarn)
+#### Install Node.js (and optionally Yarn)
 
-Now that you have NVM installed, you can install node. The latest version can be
+Now that you have NVM installed, you can install Node.js. The latest version can be
 installed using `nvm install default`. You can also install a specific version
 using `nvm install v16.17.0`. For the purposes of debugging it can be useful to
-have the same version of node installed as the main project uses, which you can
+have the same version of Node.js installed as the main project uses, which you can
 then activate using `nvm use <version>`. You can determine what version the
 FreeSewing project uses by checking
 [freesewing/freesewing/.node-version](https://github.com/freesewing/freesewing/blob/develop/.node-version).
 
-<Warning> At the time this guide was written the latest version of node/npm has
+<Warning> At the time this guide was written the latest version of Node.js/npm has
 a bug in the dependency resolution process which causes the freesewing project
 to fail to build. Use the latest LTS version (currently 16.17.0) or the specific
 version used by the main project to avoid this issue.  </Warning>
 
-Node comes with the Node Package Manager (npm) by default which can be used to
-set up the project. The default package manager uses a fairly simplistic aproach
+Node.js comes with the Node Package Manager (npm) by default which can be used to
+set up the project. The default package manager uses a fairly simplistic approach
 to dependency resolution which can make builds take a long time. Yarn is an
 alternative package manager which makes builds faster, especially for monolithic
 projects like FreeSewing. If you'd like to install yarn run `npm install yarn
@@ -114,8 +114,8 @@ your settings.json file to add an exemption for this file type:
 #### Install VSCode Remote
 
 In order to be able to use VSCode's IDE features (such as the built in terminal)
-and also make use of the node installation we set up in the previous steps you
-will need to install VSCode Remote so that VSCode can make use of the linux
+and also make use of the Node.js installation we set up in the previous steps you
+will need to install VSCode Remote so that VSCode can make use of the Linux
 environment. [Follow the getting started guide for VSCode
 Remote](https://code.visualstudio.com/docs/remote/wsl) (If you've been following
 this guide you have already done steps 1 and 2, you will only need to install
@@ -127,14 +127,14 @@ extension](https://aka.ms/vscode-remote/download/extension))
 
 ### Install NVM
 
-While node can be installed directly on Windows, we strongly recommend using a
+While Node.js can be installed directly on Windows, we strongly recommend using a
 version manager such as [Node Version Manager for
 Windows](https://github.com/coreybutler/nvm-windows/releases/latest). That link
 will take you to the latest release which provides an installer you can download
 and run. Once nvm-windows is installed you will be able to continue with the
 rest of this process.
 
-### Install Node (and optionally Yarn)
+### Install Node.js (and optionally Yarn)
 
 Open a Powershell terminal or command prompt. Run `nvm ls available` to show
 versions that can be installed. Choose the appropriate version (you should use
@@ -142,17 +142,17 @@ the same version as the freesewing project or latest LTS version) then run `nvm
 install 16.17.0` and `nvm use 16.17.0` (where `16.17.0` is the full version
 string of the version you wish to use) to activate the newly installed version.
 You will receive a prompt for elevated permissions and will need to accept it in
-order to activate the new version of node.
+order to activate the new version of Node.js.
 
 <Warning> 
-At the time this guide was written the latest version of node/npm has
+At the time this guide was written the latest version of Node.js/npm has
 a bug in the dependency resolution process which causes the freesewing project
 to fail to build. Use the latest LTS version (currently 16.17.0) or the specific
 version used by the main project to avoid this issue.  
 </Warning>
 
-Node comes with the Node Package Manager (npm) by default which can be used to
-set up the project. The default package manager uses a fairly simplistic aproach
+Node.js comes with the Node Package Manager (npm) by default which can be used to
+set up the project. The default package manager uses a fairly simplistic approach
 to dependency resolution which can make builds take a long time. Yarn is an
 alternative package manager which makes builds faster, especially for monolithic
 projects like FreeSewing. If you'd like to install yarn run (`npm install yarn
@@ -188,9 +188,15 @@ If you're not certain what to pick, just mash some keys, it doesn't matter.
 
 #### What package manager to use
 
-Choose `npm` if you don't have `yarn` or when you're not sure what the heck `yarn` is.
+Choose `yarn`. Currently, `npm` does not work.
 
 </Note>
+
+<Fixme compact>
+The `npm` issue issue should be fixed by the time v3 is released.
+The _What package manager to use_ section will need to be updated at that
+time.
+</Fixme>
 
 ## Start the development environment
 

--- a/markdown/dev/tutorials/pattern-design/adding-measurements/en.md
+++ b/markdown/dev/tutorials/pattern-design/adding-measurements/en.md
@@ -45,7 +45,7 @@ This change will also get picked up by the development environment, and you'll n
 ![This screen tells you that you are missing some required measurements](./required-measurements.png)
 
 Since it's just one measurement, let's simply enter a value by hand.
-For example `38` as 38cm is a realistic head circumference measurement for a baby.
+For example `38` as 38 cm is a realistic head circumference measurement for a baby.
 
 Enter `38` in the box, and click on **Draft Design** in the sidebar under the **View** heading.
 This brings you back to our work in progress:

--- a/markdown/dev/tutorials/pattern-design/avoiding-overlap/en.md
+++ b/markdown/dev/tutorials/pattern-design/avoiding-overlap/en.md
@@ -151,7 +151,7 @@ function draftBib({
    *
    * We're using increments of 1 degree 
    * until the `tipRightBottomStart` point 
-   * is 1mm beyond the center of our bib.
+   * is 1 mm beyond the center of our bib.
    */
   while (points.tipRightBottomStart.x > -1) {
     for (const p of rotateThese) points[p] = points[p].rotate(1, points.edgeLeft)

--- a/markdown/dev/tutorials/pattern-design/completing-our-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/completing-our-pattern/en.md
@@ -55,7 +55,7 @@ Snippets are little re-useable things to embellish your pattern with.
 Things like buttons or buttonholes, a logo, or snaps.
 
 To use them, much like points and paths, we need to destructure both
-the `Snippet` constructure as well as the `snippets` object to hold
+the `Snippet` constructor as well as the `snippets` object to hold
 our snippets:
 
 ```mjs

--- a/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
@@ -9,7 +9,7 @@ that is the `head` measurements multiplied by the `neckRatio` option.
 That might involve some trial and error. But since the neck opening will be symmetric
 both horizontal and vertical, we only need to construct one quadrant.
 
-## Desructuring measurements and options
+## Destructuring measurements and options
 
 We'll be adding some points to our pattern to do just that. But we want to have
 access to our measurements and options to do so. For this, we first destructure

--- a/markdown/dev/tutorials/pattern-design/draft-method/en.md
+++ b/markdown/dev/tutorials/pattern-design/draft-method/en.md
@@ -21,7 +21,7 @@ does.
 
 If you're not familiar with the `({ part })` syntax you see above, this is a
 technique called *parameter destructuring* or more generally, [object
-desctructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)
+destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)
 
 The draft method receives only 1 parameter: An object that holds everything you
 need to draft your method.  Destructuring is a way to *pull things out of the

--- a/markdown/dev/tutorials/pattern-design/drawing-the-straps/en.md
+++ b/markdown/dev/tutorials/pattern-design/drawing-the-straps/en.md
@@ -9,7 +9,7 @@ and create one single path that follows our bib outline.
 And as we now have one path to draw the bib, we can (and should)
 remove the earlier paths we drew to see what we are doing.
 
-The `round` macro we added earlier is still required to calcuate the points we
+The `round` macro we added earlier is still required to calculate the points we
 need to construct the half-circle. But we don't want it to draw the half-circle
 path. As it happens, that is the default behaviour, so we merely have to remove
 it's `hidden: false` property.

--- a/markdown/dev/tutorials/pattern-design/en.md
+++ b/markdown/dev/tutorials/pattern-design/en.md
@@ -232,10 +232,10 @@ FreeSewing is a JavaScript library that can run in the browser, on
 [Node.js](https://nodejs.org/), or a variety of other runtimes such as Deno,
 AWS Lambda, and so on.
 
-For development, we'll use NodeJS. If you don't have Node.js on your system,
+For development, we'll use Node.js. If you don't have Node.js on your system,
 follow the link above and install it on your system.
 
-<Tip compact>You need NodeJS 16 or higher to use FreeSewing</Tip>
+<Tip compact>You need Node.js 16 or higher to use FreeSewing</Tip>
 
 When you're done, you can test whether it works by running:
 
@@ -243,4 +243,4 @@ When you're done, you can test whether it works by running:
 node -v
 ```
 
-If you get the node version number, you're all set.
+If you get the Node.js version number, you're all set.

--- a/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/fitting-the-neck-opening/en.md
@@ -68,7 +68,7 @@ If the delta is negative, our path is too short and we increase the tweak
 factor.
 
 We keep on doing this until `Math.abs(delta)` is less than 1. Meaning that we
-are within 1mm of our target value.
+are within 1 mm of our target value.
 
 Now that we're happy with the length of our quarter neck opening, let's
 construct the entire neck opening.

--- a/markdown/dev/tutorials/pattern-design/structure/en.md
+++ b/markdown/dev/tutorials/pattern-design/structure/en.md
@@ -20,16 +20,16 @@ If you'd like to learn about those other files and folders, here's what they do:
 - `lab`: Holds [React][react] hooks and components specific to the development environment
 - `node_modules`: Holds installed dependencies
 - `pages`: Holds [NextJS][next] client-side routes, aka pages
-- `public`: Holds pregenerated translation files
+- `public`: Holds pre-generated translation files
 - `shared`: Holds files from FreeSewing's shared codebase for frontend development
 
 ### files
 
 - `next.config.mjs`: The [NextJS][next] configuration file
 - `next-i18next.config.js`: The configuration file for [next-i18next][i81n] which handles translation within NextJS
-- `package.json`: Every NodeJS project has a [package.json][pkg] file which holds important metadata and lists dependencies
+- `package.json`: Every Node.js project has a [package.json][pkg] file which holds important metadata and lists dependencies
 - `package-lock.json`: This *lockfile* will only exist if you use the npm package manager
-- `postcss.config.js`: Configuration file for [PostCSS][postcss], a tool to transform CSS with Javascript
+- `postcss.config.js`: Configuration file for [PostCSS][postcss], a tool to transform CSS with JavaScript
 - `tailwind.config.js`: Configuration file for the [TailwindCSS][tailwind] framework
 - `yarn.lock`: This *lockfile* will only exist if you use [the yarn package manager][yarn]
 

--- a/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
+++ b/markdown/dev/tutorials/pattern-design/testing-your-pattern/en.md
@@ -70,7 +70,7 @@ option](test-option-neckratio.png)
 
 ### widthRatio
 
-The `widthRatio` option will determine the width of our bib.  For a the same
+The `widthRatio` option will determine the width of our bib.  For the same
 `head` measurement, varying this option should result in increasingly wider
 bibs.
 
@@ -133,7 +133,7 @@ somehow his suit still fits.
 
 The purpose of the antperson test is to bring out areas in your pattern where
 you made assumptions that will not properly scale.  Many drafting books will
-tell you to _add 3cm there_ or _measure 2 inch to the right_. Those
+tell you to _add 3 cm there_ or _measure 2 inch to the right_. Those
 instructions don't scale, and you should avoid them.
 
 The best patterns will pass the antperson test with 2 patterns exactly the


### PR DESCRIPTION
This is the first half of Tutorials documentation updates. It is mostly spellcheck fixes and spelling standardizations (like "Node.js" instead of "Node" or "NodeJS").

I also changed the documentation to tell stand-alone developers to use `yarn` instead of `npm`, since `npm` currently does not work. I added a `<Fixme>` tag to remind us to update this when the `npm` issue is fixed.

(I will have another PR for Tutorials after I review the documentation for content.)