### PR TITLE
fix(docs): Change examples to actually use the documented method

### DIFF
--- a/markdown/dev/reference/api/path/attr/en.md
+++ b/markdown/dev/reference/api/path/attr/en.md
@@ -5,15 +5,15 @@ title: Path.attr()
 This `Path.attr()` method can be used to add attributes to the Path object.
 It calls `this.attributes.add()` under the hood, and returns the Path object.
 
-If the third parameter is set to `true` it will call `this.attributes.set()` 
+If the third parameter is set to `true` it will call `this.attributes.set()`
 instead, thereby overwriting the value of the attribute.
 
 ## Signature
 
 ```js
 Path path.attr(
-  string name, 
-  mixed value, 
+  string name,
+  mixed value,
   bool overwrite = false
 )
 ```
@@ -34,7 +34,7 @@ Path path.attr(
   paths.example = new Path()
     .move(points.from)
     .curve(points.cp1, points.cp2, points.to)
-    .setClass("canvas")
+    .attr("class", "canvas")
     .setText("FreeSewing rocks", "text-xs center")
 
   return part
@@ -45,7 +45,7 @@ Path path.attr(
 
 ## Notes
 
-Methods like 
+Methods like
 [`Path.addClass`](/reference/api/path/addclass),
 [`Path.setClass`](/reference/api/path/setclass),
 [`Path.addText`](/reference/api/path/addtext), and

--- a/markdown/dev/reference/api/path/length/en.md
+++ b/markdown/dev/reference/api/path/length/en.md
@@ -14,7 +14,7 @@ float path.length()
 
 <Example caption="Example of the Path.length() method">
 ```js
-({ Point, points, Path, paths, macro, utils, part }) => {
+({ Point, points, Path, paths, macro, utils, units, part }) => {
 
   points.A = new Point(45, 60)
   points.B = new Point(10, 30)
@@ -30,11 +30,25 @@ float path.length()
     .move(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
 
-  const lengthAB = paths.AB.length()
-  const lengthBC = paths.BC.length()
+  const lengthABC = paths.AB.length() + paths.BC.length()
 
-  paths.AB.addText(utils.round(lengthAB) + " mm")
-  paths.BC.addText(utils.round(lengthBC) + " mm")
+  macro("pd", {
+     path: new Path().move(points.B).line(points.A),
+     d: 10
+   })
+
+   macro("pd", {
+     path: new Path().move(points.B).curve(points.BCp2, points.CCp1, points.C),
+     d: -10
+   })
+
+  points.label = new Point(25, 40)
+    .addText('Total length = ' + units(lengthABC))
+
+  // Set a path to prevent clipping
+  paths.noclip = new Path()
+    .move(new Point(10, -15))
+    .move(new Point(90, 60))
 
   return part
 }

--- a/markdown/dev/reference/api/path/length/en.md
+++ b/markdown/dev/reference/api/path/length/en.md
@@ -14,36 +14,29 @@ float path.length()
 
 <Example caption="Example of the Path.length() method">
 ```js
-({ Point, points, Path, paths, macro, part }) => {
+({ Point, points, Path, paths, macro, utils, part }) => {
 
   points.A = new Point(45, 60)
   points.B = new Point(10, 30)
   points.BCp2 = new Point(40, 20)
   points.C = new Point(90, 30)
   points.CCp1 = new Point(50, -30)
-  
-  paths.example = new Path()
+
+  paths.AB = new Path()
     .move(points.A)
     .line(points.B)
+
+  paths.BC = new Path()
+    .move(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
-  
-  macro("pd", {
-    path: paths.example,
-    d: -20
-  })
-  
-  macro("pd", {
-    path: new Path().move(points.B).line(points.A),
-    d: 10
-  })
-  
-  macro("pd", {
-    path: new Path().move(points.B).curve(points.BCp2, points.CCp1, points.C),
-    d: -10
-  })
+
+  const lengthAB = paths.AB.length()
+  const lengthBC = paths.BC.length()
+
+  paths.AB.addText(utils.round(lengthAB) + " mm")
+  paths.BC.addText(utils.round(lengthBC) + " mm")
 
   return part
 }
 ```
 </Example>
-


### PR DESCRIPTION
The `Path.attr()` and `Path.length()` API documentation examples didn't actually use the `Path.attr()` or `Path.lengthI()` methods. This PR fixes that.

The new `Path.length()` example:
![Screenshot 2022-12-30 at 7 41 55 AM](https://user-images.githubusercontent.com/109869956/210087813-fd9910b7-6fc4-46aa-9a59-1b1ce5316d77.png)
