### PR TITLE
fix(docs): Trim trailing whitespace and blank lines

### DIFF
--- a/markdown/dev/reference/api/path/_curve/en.md
+++ b/markdown/dev/reference/api/path/_curve/en.md
@@ -46,5 +46,3 @@ as the two following calls yield the same result:
 path.curve(point1, point1, point2)
 path._curve(point1, point2)
 ```
-
-

--- a/markdown/dev/reference/api/path/addclass/en.md
+++ b/markdown/dev/reference/api/path/addclass/en.md
@@ -40,4 +40,3 @@ as the two following calls yield the same result:
 path.attr('class', 'fabric')
 path.addClass('fabric')
 ```
-

--- a/markdown/dev/reference/api/path/addtext/en.md
+++ b/markdown/dev/reference/api/path/addtext/en.md
@@ -44,4 +44,4 @@ path.addText('Hello')
 
 The difference with [Path.setText()](/reference/api/path/addtext) is that this
 method will add to the existing text whereas `Path.setText()` will overwrite
-existing text on the path, 
+existing text on the path,

--- a/markdown/dev/reference/api/path/aspathstring/en.md
+++ b/markdown/dev/reference/api/path/aspathstring/en.md
@@ -13,5 +13,5 @@ string path.asPathString()
 
 ## Notes
 
-This method is mostly aimed at people looking to implement their own rendering 
+This method is mostly aimed at people looking to implement their own rendering
 methods, or integrate with SVG processing tools.

--- a/markdown/dev/reference/api/path/clean/en.md
+++ b/markdown/dev/reference/api/path/clean/en.md
@@ -33,7 +33,7 @@ Path path.clean()
   points.D = new Point(90, 10)
   points.E = new Point(90, 20)
   points.F = new Point(90, 30)
-  
+
   paths.a = new Path()
     .move(points.A)
     .line(points.C)
@@ -58,4 +58,3 @@ Path path.clean()
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/clone/en.md
+++ b/markdown/dev/reference/api/path/clone/en.md
@@ -21,12 +21,12 @@ Path path.clone()
   points.BCp2 = new Point(40, 20)
   points.C = new Point(90, 30)
   points.CCp1 = new Point(50, -30)
-  
+
   paths.example = new Path()
     .move(points.A)
     .line(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
-  
+
   paths.clone = paths.example
     .clone()
     .setClass("note lashed stroke-xl")
@@ -36,4 +36,3 @@ Path path.clone()
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/close/en.md
+++ b/markdown/dev/reference/api/path/close/en.md
@@ -21,7 +21,7 @@ Path path.close()
   points.from = new Point(10, 20)
   points.cp2 = new Point(60, 30)
   points.to = new Point(90, 20)
-  
+
   paths.line = new Path()
     .move(points.from)
     ._curve(points.cp2, points.to)
@@ -33,4 +33,3 @@ Path path.close()
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/curve/en.md
+++ b/markdown/dev/reference/api/path/curve/en.md
@@ -23,7 +23,7 @@ Path path.curve(Point cp1, Point cp2, Point to)
   points.cp1 = new Point(40, 0)
   points.cp2 = new Point(60, 40)
   points.to = new Point(90, 20)
-  
+
   paths.line = new Path()
     .move(points.from)
     .curve(points.cp1, points.cp2, points.to)
@@ -33,4 +33,3 @@ Path path.curve(Point cp1, Point cp2, Point to)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/divide/en.md
+++ b/markdown/dev/reference/api/path/divide/en.md
@@ -25,14 +25,14 @@ array path.divide()
   points.CCp1 = new Point(50, -30)
   points.D = new Point(50, 80)
   points.DCp1 = new Point(140, 50)
-  
+
   paths.example = new Path()
     .move(points.A)
     .line(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
     .curve(points.DCp1, points.DCp1, points.D)
     .close()
-  
+
   let style = "stroke-width: 4; stroke-opacity: 0.5;"
   let i = 0
   for (let p of paths.example.divide()) {
@@ -46,4 +46,3 @@ array path.divide()
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/edge/en.md
+++ b/markdown/dev/reference/api/path/edge/en.md
@@ -28,14 +28,14 @@ Returns the Point object at the edge of the path you specify. Edge must be one o
   points.CCp1 = new Point(50, -30)
   points.D = new Point(-60, 90)
   points.E = new Point(90, 190)
-  
+
   paths.demo = new Path()
     .move(points.A)
     .line(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
     .curve(points.E, points.D, points.A)
     .close()
-  
+
   for (let i of [
     "topLeft",
     "topRight",

--- a/markdown/dev/reference/api/path/end/en.md
+++ b/markdown/dev/reference/api/path/end/en.md
@@ -35,4 +35,3 @@ Point path.end()
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/hide/en.md
+++ b/markdown/dev/reference/api/path/hide/en.md
@@ -2,7 +2,7 @@
 title: Path.hide()
 ---
 
-The `Path.hide()` hides the path so it does not appear in the output. 
+The `Path.hide()` hides the path so it does not appear in the output.
 
 ## Signature
 
@@ -21,13 +21,12 @@ Path path.hide()
   points.top = new Point(50, 0)
   points.left = new Point (20,50)
   points.right = new Point (80,50)
-  
+
   paths.a = new Path().move(points.top).line(points.right).setText('a')
   paths.b = new Path().move(points.right).line(points.left).setText('b').hide()
   paths.c = new Path().move(points.left).line(points.top).setText('c')
-  
+
   return part
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/insop/en.md
+++ b/markdown/dev/reference/api/path/insop/en.md
@@ -23,13 +23,13 @@ Path path.insop(string id, Path path)
   points.dartTip = new Point(50, 50)
   points.dartRight = new Point(60, 10)
   points.right = new Point(90, 10)
-  
+
   paths.withoutDart = new Path()
     .move(points.left)
     .line(points.dartLeft)
     .noop('dart')
     .line(points.right)
-  
+
   paths.withDart = paths.withoutDart
     .clone()
     .insop(
@@ -45,7 +45,6 @@ Path path.insop(string id, Path path)
 ```
 </Example>
 
-## Notes 
+## Notes
 
 This is often used to insert darts into a path.
-

--- a/markdown/dev/reference/api/path/intersects/en.md
+++ b/markdown/dev/reference/api/path/intersects/en.md
@@ -23,7 +23,7 @@ array|false path.intersects(Path path)
   points.CCp1 = new Point(50, -30)
   points.D = new Point(50, 130)
   points.DCp1 = new Point(150, 30)
-  
+
   points._A = new Point(55, 40)
   points._B = new Point(0, 55)
   points._BCp2 = new Point(40, -20)
@@ -31,7 +31,7 @@ array|false path.intersects(Path path)
   points._CCp1 = new Point(50, -30)
   points._D = new Point(40, 120)
   points._DCp1 = new Point(180, 40)
-  
+
   paths.demo1 = new Path()
     .move(points.A)
     .line(points.B)
@@ -42,7 +42,7 @@ array|false path.intersects(Path path)
     .line(points._B)
     .curve(points._BCp2, points._CCp1, points._C)
     .curve(points._DCp1, points._DCp1, points._D)
-  
+
   for (let p of paths.demo1.intersects(paths.demo2)) {
     snippets[getId()] = new Snippet('notch', p)
   }

--- a/markdown/dev/reference/api/path/intersectsx/en.md
+++ b/markdown/dev/reference/api/path/intersectsx/en.md
@@ -24,21 +24,21 @@ array|false path.intersectsX(float x)
   points.CCp1 = new Point(50, -30)
   points.D = new Point(50, 130)
   points.DCp1 = new Point(150, 30)
-  
+
   points.top = new Point(60, -10)
   points.bot = new Point(60, 140)
-  
+
   paths.line = new Path()
     .move(points.top)
     .line(points.bot)
     .attr("class", "lining dashed")
-  
+
   paths.demo = new Path()
     .move(points.A)
     .line(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
     .curve(points.DCp1, points.DCp1, points.D)
-  
+
   for (let p of paths.demo.intersectsX(60)) {
     snippets[getId()] = new Snippet("notch", p)
   }
@@ -47,4 +47,3 @@ array|false path.intersectsX(float x)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/intersectsy/en.md
+++ b/markdown/dev/reference/api/path/intersectsy/en.md
@@ -47,4 +47,3 @@ array|false path.intersectsY(float y)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/join/en.md
+++ b/markdown/dev/reference/api/path/join/en.md
@@ -22,17 +22,17 @@ Path path.join(path other)
   points.BCp2 = new Point(40, 20)
   points.C = new Point(90, 30)
   points.CCp1 = new Point(50, -30)
-  
+
   paths.path1 = new Path()
     .move(points.A)
     .line(points.B)
     .setClass("various")
-  
+
   paths.path2 = new Path()
     .move(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
     .setClass("note")
-  
+
   paths.joint = paths.path1
     .join(paths.path2)
     .setClass("lining dotted")
@@ -46,4 +46,3 @@ Path path.join(path other)
 ## Notes
 
 You cannot join a closed path to another path
-

--- a/markdown/dev/reference/api/path/line/en.md
+++ b/markdown/dev/reference/api/path/line/en.md
@@ -21,7 +21,7 @@ Path path.line(Point to)
 
   points.from = new Point(10, 10)
   points.to = new Point(90, 10)
-  
+
   paths.line = new Path()
     .move(points.from)
     .line(points.to)
@@ -31,4 +31,3 @@ Path path.line(Point to)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/move/en.md
+++ b/markdown/dev/reference/api/path/move/en.md
@@ -19,7 +19,7 @@ Path path.move(Point to)
 
   points.to = new Point(50, 20)
     .setText("Path.move()", "text-xs fill-note center")
-  
+
   paths.noline = new Path().move(points.to)
 
   // Prevents clipping

--- a/markdown/dev/reference/api/path/noop/en.md
+++ b/markdown/dev/reference/api/path/noop/en.md
@@ -25,13 +25,13 @@ Path path.noop(string id)
   points.dartTip = new Point(50, 50)
   points.dartRight = new Point(60, 10)
   points.right = new Point(90, 10)
-  
+
   paths.withoutDart = new Path()
     .move(points.left)
     .line(points.dartLeft)
     .noop('dart')
     .line(points.right)
-  
+
   paths.withDart = paths.withoutDart
     .clone()
     .insop(
@@ -46,4 +46,3 @@ Path path.noop(string id)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/offset/en.md
+++ b/markdown/dev/reference/api/path/offset/en.md
@@ -22,24 +22,24 @@ Path path.offset(float distance)
   points.BCp2 = new Point(40, 20)
   points.C = new Point(90, 30)
   points.CCp1 = new Point(50, -30)
-  
+
   paths.example = new Path()
     .move(points.A)
     .line(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
     .line(points.A)
     .close()
-  
+
   paths.offset = paths.example
     .offset(-10)
     .attr("class", "interfacing")
-  
+
   paths.lineOffset = new Path()
     .move(points.A)
     .line(points.B)
     .offset(-5)
     .attr("class", "various")
-  
+
   paths.curveOffset = new Path()
     .move(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
@@ -50,4 +50,3 @@ Path path.offset(float distance)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/reverse/en.md
+++ b/markdown/dev/reference/api/path/reverse/en.md
@@ -26,12 +26,12 @@ copy, without the attributes.
   points.BCp2 = new Point(40, 20)
   points.C = new Point(90, 30)
   points.CCp1 = new Point(50, -30)
-  
+
   paths.example = new Path()
     .move(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
     .setText("FreeSewing rocks", "text-xs fill-note center")
-  
+
   paths.reverse = paths.example.reverse(true)
 
   return part
@@ -39,11 +39,9 @@ copy, without the attributes.
 ```
 </Example>
 
-## Notes 
+## Notes
 
 The reversed path is a shallow copy.
 It will in other words not inherit the attributes of the original path.
 
 If you want a deep copy, including the attributes, use `Path.reverse(true)`.
-
-

--- a/markdown/dev/reference/api/path/roughlength/en.md
+++ b/markdown/dev/reference/api/path/roughlength/en.md
@@ -20,11 +20,11 @@ Number path.roughLength()
   points.BCp2 = new Point(40, 20)
   points.C = new Point(120, 30)
   points.CCp1 = new Point(50, -30)
-  
+
   paths.example = new Path()
     .move(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
-  
+
   macro("pd", {
     path: paths.example,
     d: -10,
@@ -35,7 +35,7 @@ Number path.roughLength()
     d: 10,
     text: `Path.length() = ${units(paths.example.length())}`
   })
-  
+
 
   return part
 }

--- a/markdown/dev/reference/api/path/setclass/en.md
+++ b/markdown/dev/reference/api/path/setclass/en.md
@@ -40,4 +40,3 @@ as the two following calls yield the same result:
 path.attr('class', 'fabric', true)
 path.addClass('fabric')
 ```
-

--- a/markdown/dev/reference/api/path/sethidden/en.md
+++ b/markdown/dev/reference/api/path/sethidden/en.md
@@ -22,13 +22,12 @@ Path path.setHidden(bool hidden = false)
   points.top = new Point(50, 0)
   points.left = new Point (20,50)
   points.right = new Point (80,50)
-  
+
   paths.a = new Path().move(points.top).line(points.right).setText('a')
   paths.b = new Path().move(points.right).line(points.left).setText('b').setHidden(true)
   paths.c = new Path().move(points.left).line(points.top).setText('c')
-  
+
   return part
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/settext/en.md
+++ b/markdown/dev/reference/api/path/settext/en.md
@@ -45,4 +45,3 @@ path.setText('Hello')
 The difference with [Path.addText()](/reference/api/path/addtext) is that this
 method will overwrite existing text on the path, whereas `Path.addText()` will
 add to the existing text.
-

--- a/markdown/dev/reference/api/path/shiftalong/en.md
+++ b/markdown/dev/reference/api/path/shiftalong/en.md
@@ -29,12 +29,12 @@ For most cases, the default will be fine.
   points.BCp2 = new Point(40, 20)
   points.C = new Point(90, 30)
   points.CCp1 = new Point(50, -30)
-  
+
   paths.example = new Path()
     .move(points.A)
     .line(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
-  
+
   points.x1 = paths.example
     .shiftAlong(20)
     .attr("data-text", "2 cm")
@@ -45,7 +45,7 @@ For most cases, the default will be fine.
     .attr("data-text", "9 cm")
     .attr("data-text-class", "center fill-note")
     .attr("data-text-lineheight", 6)
-  
+
   snippets.x1 = new Snippet("notch", points.x1)
   snippets.x2 = new Snippet("notch", points.x2)
 

--- a/markdown/dev/reference/api/path/shiftfractionalong/en.md
+++ b/markdown/dev/reference/api/path/shiftfractionalong/en.md
@@ -29,19 +29,19 @@ For most cases, the default will be fine.
   points.BCp2 = new Point(40, 20)
   points.C = new Point(90, 30)
   points.CCp1 = new Point(50, -30)
-  
+
   paths.example = new Path()
     .move(points.A)
     .line(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
-  
+
   points.x1 = paths.example
     .shiftFractionAlong(0.2)
     .setText("0.2", "center")
   points.x2 = paths.example
     .shiftFractionAlong(0.9)
     .setText("0.9", "center")
-  
+
   snippets.xl = new Snippet("notch", points.x1)
   snippets.x2 = new Snippet("notch", points.x2)
 
@@ -49,4 +49,3 @@ For most cases, the default will be fine.
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/smurve/en.md
+++ b/markdown/dev/reference/api/path/smurve/en.md
@@ -26,7 +26,7 @@ Path path.smurve(Point cp2, Point end)
 
   points.bCp2 = new Point(50,50)
   points.bTo = new Point(10,50)
-  
+
   paths.smurve = new Path()
     .move(points.aFrom)
     .curve(points.aCp1, points.aCp2,points.aTo)
@@ -38,4 +38,3 @@ Path path.smurve(Point cp2, Point end)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/smurve_/en.md
+++ b/markdown/dev/reference/api/path/smurve_/en.md
@@ -27,7 +27,7 @@ Path path.smurve_(Point cp2, Point end)
   points.aTo = new Point(100, 10)
 
   points.bTo = new Point(10,50)
-  
+
   paths.smurve = new Path()
     .move(points.aFrom)
     .curve(points.aCp1, points.aCp2,points.aTo)
@@ -39,4 +39,3 @@ Path path.smurve_(Point cp2, Point end)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/split/en.md
+++ b/markdown/dev/reference/api/path/split/en.md
@@ -24,16 +24,16 @@ array path.split(Point splitPoint)
   points.CCp1 = new Point(50, -30)
   points.D = new Point(50, 130)
   points.DCp1 = new Point(150, 30)
-  
+
   paths.demo = new Path()
     .move(points.D)
     .curve(points.DCp1, points.DCp1, points.C)
     .curve(points.CCp1, points.BCp2, points.B)
     .line(points.A)
-  
+
   points.split = paths.demo.shiftFractionAlong(0.75)
   snippets.split = new Snippet("notch", points.split)
-  
+
   let halves = paths.demo.split(points.split)
   for (let i in halves) {
     paths[i] = halves[i]
@@ -45,4 +45,3 @@ array path.split(Point splitPoint)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/start/en.md
+++ b/markdown/dev/reference/api/path/start/en.md
@@ -35,4 +35,3 @@ Point path.start()
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/translate/en.md
+++ b/markdown/dev/reference/api/path/translate/en.md
@@ -23,14 +23,14 @@ Path path.translate(float deltaX, float deltaY)
   points.BCp2 = new Point(40, 20)
   points.C = new Point(90, 30)
   points.CCp1 = new Point(50, -30)
-  
+
   paths.A = new Path()
     .move(points.A)
     .line(points.B)
     .curve(points.BCp2, points.CCp1, points.C)
-  
+
   paths.B = paths.A.translate(60, 30)
-  
+
   points.step1 = points.B.shift(0, 60)
   points.step2 = points.step1.shift(-90, 30)
   macro("ld", {
@@ -48,4 +48,3 @@ Path path.translate(float deltaX, float deltaY)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/path/trim/en.md
+++ b/markdown/dev/reference/api/path/trim/en.md
@@ -43,11 +43,11 @@ Path path.trim()
         .line(points["base" + i])
     }
   }
-  
+
   paths.offset = paths.example
     .offset(10)
     .setClass("lining dotted stroke-sm")
-  
+
   paths.trimmed = paths.offset
     .trim()
     .setClass("various stroke-xl")

--- a/markdown/dev/reference/api/path/unhide/en.md
+++ b/markdown/dev/reference/api/path/unhide/en.md
@@ -23,13 +23,12 @@ Path path.unhide()
   points.top = new Point(50, 0)
   points.left = new Point (20,50)
   points.right = new Point (80,50)
-  
+
   paths.a = new Path().move(points.top).line(points.right).setText('a')
   paths.b = new Path().move(points.right).line(points.left).setText('b').hide().unhide()
   paths.c = new Path().move(points.left).line(points.top).setText('c')
-  
+
   return part
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/addcircle/en.md
+++ b/markdown/dev/reference/api/point/addcircle/en.md
@@ -10,7 +10,7 @@ will call `Point.attr()` as circles are added by setting attributes. Refer to
 
 ```js
 Point point.addCircle(
-  number radius, 
+  number radius,
   string className
 )
 ```
@@ -41,5 +41,3 @@ Point point.addCircle(
 }
 ```
 </Example>
-
-

--- a/markdown/dev/reference/api/point/addtext/en.md
+++ b/markdown/dev/reference/api/point/addtext/en.md
@@ -10,7 +10,7 @@ text](/howtos/code/adding-text) for more details.
 
 ```js
 Point point.addText(
-  string text, 
+  string text,
   string className
 )
 ```
@@ -41,4 +41,3 @@ Point point.addText(
 ## Notes
 
 Remember to [use translation keys, not text](/guides/best-practices/use-translation-keys)
-

--- a/markdown/dev/reference/api/point/angle/en.md
+++ b/markdown/dev/reference/api/point/angle/en.md
@@ -25,8 +25,8 @@ float point.angle(Point pointB)
     .setText(
       points.sun.angle(points.moon)+"°",
       "text-sm fill-note center"
-    ) 
-  
+    )
+
   paths.line = new Path()
     .move(points.sun)
     .line(points.moon)
@@ -36,4 +36,3 @@ float point.angle(Point pointB)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/attr/en.md
+++ b/markdown/dev/reference/api/point/attr/en.md
@@ -10,8 +10,8 @@ the attribute instead of adding it.
 
 ```js
 Point point.attr(
-  string name, 
-  mixed value, 
+  string name,
+  mixed value,
   bool overwrite = false
 )
 ```
@@ -36,7 +36,7 @@ If the third parameter is set to `true` it will call [`this.attributes.set()`](/
     .move(points.anchor)
     .line(points.anchor.shift(0, 80))
     .addClass('hidden')
-  
+
   return part
 }
 ```

--- a/markdown/dev/reference/api/point/clone/en.md
+++ b/markdown/dev/reference/api/point/clone/en.md
@@ -43,4 +43,3 @@ Point point.clone()
 The [`Point.copy()`](/reference/api/point/copy/) method will only copy the
 point's coordinates, whereas this `Point.clone()` method will also copy its
 attributes.
-

--- a/markdown/dev/reference/api/point/dist/en.md
+++ b/markdown/dev/reference/api/point/dist/en.md
@@ -19,18 +19,17 @@ float point.dist(Point point)
 
   points.from = new Point(10, 10)
   points.to = new Point(80, 70)
-  
+
   points.text = points.from
     .shiftFractionTowards(points.to, 0.6)
     .setText(units(points.from.dist(points.to)), 'text-sm fill-note center')
-  
+
   paths.line = new Path()
     .move(points.from)
     .line(points.to)
     .setClass('dashed')
-  
+
   return part
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/dx/en.md
+++ b/markdown/dev/reference/api/point/dx/en.md
@@ -19,7 +19,7 @@ float point.dx(Point point)
 
   points.from = new Point(10, 10)
   points.to = new Point(76.6, 10)
-      
+
   paths.line = new Path()
     .move(points.from)
     .line(points.to)
@@ -30,4 +30,3 @@ float point.dx(Point point)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/dy/en.md
+++ b/markdown/dev/reference/api/point/dy/en.md
@@ -19,7 +19,7 @@ float point.dy(Point point)
 
   points.from = new Point(10, 40)
   points.to = new Point(10, 10)
-      
+
   paths.line = new Path()
     .move(points.from)
     .line(points.to)
@@ -35,4 +35,3 @@ float point.dy(Point point)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/flipx/en.md
+++ b/markdown/dev/reference/api/point/flipx/en.md
@@ -27,7 +27,7 @@ Point point.flipX(Point mirror = false)
   points.in3 = new Point(55, 70)
   points.trunkOut = new Point(55, 80)
   points.trunkIn = new Point(50, 80)
-  
+
   points._out1 = points.out1.flipX(points.top)
   points._in1 = points.in1.flipX(points.top)
   points._out2 = points.out2.flipX(points.top)
@@ -35,9 +35,9 @@ Point point.flipX(Point mirror = false)
   points._out3 = points.out3.flipX(points.top)
   points._in3 = points.in3.flipX(points.top)
   points._trunkOut = points.trunkOut.flipX(points.top)
-  
+
   points.bottom = new Point(50, 80)
-  
+
   paths.tree = new Path()
     .move(points.top)
     .line(points.out1)
@@ -55,7 +55,7 @@ Point point.flipX(Point mirror = false)
     .line(points._in1)
     .line(points._out1)
     .close()
-  
+
   paths.mirror = new Path()
     .move(points.top)
     .line(points.bottom)
@@ -65,4 +65,3 @@ Point point.flipX(Point mirror = false)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/flipy/en.md
+++ b/markdown/dev/reference/api/point/flipy/en.md
@@ -31,10 +31,10 @@ Point point.flipY(Point mirror = false)
   points.houseRoofRight = new Point(85, 35)
   points.houseWallRight = new Point(85, 50)
   points.end = new Point(95, 50)
-  
+
   points.mirror = new Point(0, 60)
   points.mirrorLineEnd = new Point(95, 60)
-  
+
   points._start = points.start.flipY(points.mirror)
   points._churchTowerWallLeft = points.churchTowerWallLeft.flipY(points.mirror)
   points._churchTowerRoofLeft = points.churchTowerRoofLeft.flipY(points.mirror)
@@ -50,7 +50,7 @@ Point point.flipY(Point mirror = false)
   points._houseRoofRight = points.houseRoofRight.flipY(points.mirror)
   points._houseWallRight = points.houseWallRight.flipY(points.mirror)
   points._end = points.end.flipY(points.mirror)
-  
+
   paths.skylineTop = new Path()
     .move(points.start)
     .line(points.churchTowerWallLeft)
@@ -70,4 +70,3 @@ Point point.flipY(Point mirror = false)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/rotate/en.md
+++ b/markdown/dev/reference/api/point/rotate/en.md
@@ -33,4 +33,3 @@ Point point.rotate(float angle, Point center)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/setcircle/en.md
+++ b/markdown/dev/reference/api/point/setcircle/en.md
@@ -16,7 +16,7 @@ how circles are handled.
 
 ```js
 Point point.setCircle(
-  number radius, 
+  number radius,
   string className
 )
 ```
@@ -48,5 +48,3 @@ Point point.setCircle(
 }
 ```
 </Example>
-
-

--- a/markdown/dev/reference/api/point/settext/en.md
+++ b/markdown/dev/reference/api/point/settext/en.md
@@ -10,7 +10,7 @@ text](/howtos/code/adding-text) for more details.
 
 ```js
 Point point.setText(
-  string text, 
+  string text,
   string className
 )
 ```

--- a/markdown/dev/reference/api/point/shift/en.md
+++ b/markdown/dev/reference/api/point/shift/en.md
@@ -23,7 +23,7 @@ Point point.shift(float angle, float distance)
   points.B = points.A.shift(155, 70)
     .setText("Point B is point A shifted 7 cm\nat a 155 degree angle", "text-sm")
     .attr("data-text-lineheight", 6)
-  
+
   macro("ld", {
     from: points.B,
     to: points.A,
@@ -34,4 +34,3 @@ Point point.shift(float angle, float distance)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/shiftfractiontowards/en.md
+++ b/markdown/dev/reference/api/point/shiftfractiontowards/en.md
@@ -29,18 +29,18 @@ Point point.shiftFractionTowards(Point target, float fraction)
       "center text-sm"
     )
     .attr("data-text-lineheight", 6)
-  
+
   paths.direction = new Path()
     .move(points.A)
     .line(points.B)
     .setClass("note dashed")
-  
+
   macro("ld", {
     from: points.C,
     to: points.A,
     d: -10
   })
-  
+
   macro("ld", {
     from: points.B,
     to: points.A,

--- a/markdown/dev/reference/api/point/shiftoutwards/en.md
+++ b/markdown/dev/reference/api/point/shiftoutwards/en.md
@@ -22,12 +22,12 @@ Point point.shiftOutwards(Point target, float distance)
   points.C = points.A.shiftOutwards(points.B, 30)
     .setText("Point C is point A shifted 3 cm\nbeyond point B", "text-sm")
     .attr("data-text-lineheight", 6)
-  
+
   paths.direction = new Path()
     .move(points.A)
     .line(points.C)
     .addClass("note dashed")
-  
+
   macro("ld", {
     from: points.C,
     to: points.B,
@@ -38,4 +38,3 @@ Point point.shiftOutwards(Point target, float distance)
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/point/shifttowards/en.md
+++ b/markdown/dev/reference/api/point/shifttowards/en.md
@@ -22,12 +22,12 @@ Point point.shiftTowards(Point target, float distance)
   points.C = points.A.shiftTowards(points.B, 35)
     .setText("Point C is point A shifted 3.5 cm\nin the direction of point B", "center, text-sm")
     .attr("data-text-lineheight", 6)
-  
+
   paths.direction = new Path()
     .move(points.A)
     .line(points.B)
     .addClass("note dashed")
-  
+
   macro("ld", {
     from: points.C,
     to: points.A,
@@ -45,5 +45,3 @@ Point point.shiftTowards(Point target, float distance)
 If you need to move a point a percentage instead of a specific distance, use
 [`Point.shiftFractionTowards()`](/reference/api/point/shiftfractiontowards/)
 instead.
-
-

--- a/markdown/dev/reference/api/point/sitsroughlyon/en.md
+++ b/markdown/dev/reference/api/point/sitsroughlyon/en.md
@@ -44,5 +44,3 @@ bool point.sitsRoughlyOn(Point check)
 The difference between this method and
 [`Point.sitsOn()`](/reference/api/point/sitson/) is that this one rounds things
 down to the nearest integer (thus mm) before checking.
-
-

--- a/markdown/dev/reference/api/point/translate/en.md
+++ b/markdown/dev/reference/api/point/translate/en.md
@@ -17,7 +17,7 @@ In other words, this will:
 - Add `deltaX` to the point's X-coordinate
 - Add `deltaY` to the point's Y-coordinate
 
-Positive values for `deltaX` will move the point to the right. 
+Positive values for `deltaX` will move the point to the right.
 Positive values for `deltaY` will move the point downwards.
 
 ## Example
@@ -34,10 +34,10 @@ Positive values for `deltaY` will move the point downwards.
     )
     .attr("data-text-dy", -6)
     .attr("data-text-lineheight", 6)
-  
+
   snippets.A = new Snippet("x", points.A)
   snippets.B = new Snippet("x", points.B)
-  
+
   macro("ld", {
     from: points.A,
     to: points.B,
@@ -49,4 +49,3 @@ Positive values for `deltaY` will move the point downwards.
 }
 ```
 </Example>
-


### PR DESCRIPTION
Just some clean-up in the Points and Paths API docs.