### PR TITLE
fix(new-design): React 18 dependency updates

### DIFF
--- a/packages/new-design/templates/shared/package.json.mustache
+++ b/packages/new-design/templates/shared/package.json.mustache
@@ -75,7 +75,7 @@
     "react-copy-to-clipboard": "^5.0.4",
     "react-hotkeys-hook": "^3.4.4",
     "react-swipeable": "^6.2.0",
-    "react-timeago": "^6.2.1",
+    "react-timeago": "^7.1.0",
     "mocha": "^9.1.1",
     "chai": "^4.2.0",
     "autoprefixer": "^10.4.0",
@@ -99,7 +99,13 @@
     "tag": "next"
   },
   "engines": {
-    "node": ">=14.0.0",
-    "npm": ">=6"
+    "node": ">=16.0.0",
+    "npm": ">=8"
+  },
+  "overrides": {
+    "react-zoom-pan-pinch": {
+      "react": "$react",
+      "react-dom": "$react-dom"
+    }
   }
 }

--- a/packages/new-design/templates/shared/package.json.mustache
+++ b/packages/new-design/templates/shared/package.json.mustache
@@ -100,7 +100,7 @@
   },
   "engines": {
     "node": ">=16.0.0",
-    "npm": ">=8"
+    "npm": ">=8.3.0"
   },
   "overrides": {
     "react-zoom-pan-pinch": {


### PR DESCRIPTION
When `npm` is selected, installation of `@freesewing/new-design@next` fails due to `react-zoom-pan-pinch` and `react-timeago` dependencies requiring React 17 and not working with React 18. 

For the `package.json` installed by the `new-design` package, this PR:
- Bumps engines Node.js to 16 and `npm` to 8.3.0.
- Bumps `react-timeago` dependency to 7.1.0.
- Adds dependency overrides for `react-zoom-pan-pinch` to allow it to work with React 18.

[`react-zoom-pan-pinch`](https://github.com/prc5/react-zoom-pan-pinch) development has stalled, and there is no updated release for React 18. One possible fix/workaround would have been to use the forked [`@pronestor/react-zoom-pan-pinch`](https://www.npmjs.com/package/@pronestor/react-zoom-pan-pinch) package that does work with React 18. However, imports in our source code would also need to be updated to use this other package. So, the easiest workaround seems to be to add the dependency overrides for `npm`.

Override functionality was introduced in `npm` 8.3.0, which is why that is the new minimum version, rather than just `>=8`.

The `react-timeago` dependency was already updated to 7.1.0 in our sites `package.json` files, so it looks like the update was just overlooked for `new-design`.