### PR TITLE
fix(core): utils.curvesIntersect correctly has 3 different return types, not 2

### DIFF
--- a/markdown/dev/reference/api/utils/curvesintersect/en.md
+++ b/markdown/dev/reference/api/utils/curvesintersect/en.md
@@ -8,16 +8,22 @@ described by 4 points each.
 ## Signature
 
 ```js
-array | false utils.curvesIntersect(
-  Point startA, 
+array | Point | false utils.curvesIntersect(
+  Point startA,
   Point Cp1A,
   Point Cp2A,
   Point endA,
-  Point startB, 
+  Point startB,
   Point Cp1B,
   Point Cp2B,
   Point endB)
 ```
+
+This returns `false` if no intersections are found,
+a [Point](/reference/api/point) object if
+a single intersection is found, and an array
+of [Point](/reference/api/point) objects if
+multiple intersections are found.
 
 ## Example
 
@@ -29,7 +35,7 @@ array | false utils.curvesIntersect(
   points.Acp = new Point(310, 40)
   points.B = new Point(110, 70)
   points.Bcp = new Point(-210, 40)
-  
+
   points.C = new Point(20, -5)
   points.Ccp = new Point(60, 300)
   points.D = new Point(100, 85)
@@ -40,8 +46,8 @@ array | false utils.curvesIntersect(
   paths.curveB = new Path()
     .move(points.C)
     .curve(points.Ccp, points.Dcp, points.D)
-  
-  for (const p of utils.curvesIntersect(
+
+  const intersections = utils.curvesIntersect(
     points.A,
     points.Acp,
     points.Bcp,
@@ -50,8 +56,15 @@ array | false utils.curvesIntersect(
     points.Ccp,
     points.Dcp,
     points.D
-  )) {
-    snippets[getId()] = new Snippet("notch", p)
+    )
+
+  if (intersections) {
+    if (intersections instanceof Array) {
+      for (const p of intersections)
+        snippets[getId()] = new Snippet('notch', p)
+    } else {
+      snippets[getId()] = new Snippet('notch', intersections)
+    }
   }
 
   return part

--- a/packages/core/src/utils.mjs
+++ b/packages/core/src/utils.mjs
@@ -229,7 +229,9 @@ export function curveIntersectsY(from, cp1, cp2, to, y) {
  * @param {Point} cp1B - Control Point at the start of the second curve
  * @param {Point} cp2B - Control Point at the end of the second curve
  * @param {Point} toB - End Point of the fsecond curve
- * @return {Array} intersections - An Array of Point objects of all intersections between the curves
+ * @return {Array} intersections - An Array of Point objects of all intersections between the curves, when there are more than 1 intersection
+ * @return {Point} intersection - A Point object of the intersection when there is exactly 1 intersection
+ * @return {Boolean} - false when there are no intersections
  */
 export function curvesIntersect(fromA, cp1A, cp2A, toA, fromB, cp1B, cp2B, toB) {
   let precision = 0.005 // See https://github.com/Pomax/bezierjs/issues/99
@@ -263,6 +265,7 @@ export function curvesIntersect(fromA, cp1A, cp2A, toA, fromB, cp1B, cp2B, toB) 
       }
       if (!dupe) unique.push(i)
     }
+    if (unique.length === 1) return unique[0]
     return unique
   }
 }

--- a/packages/core/src/utils.mjs
+++ b/packages/core/src/utils.mjs
@@ -265,8 +265,7 @@ export function curvesIntersect(fromA, cp1A, cp2A, toA, fromB, cp1B, cp2B, toB) 
       }
       if (!dupe) unique.push(i)
     }
-    if (unique.length === 1) return unique[0]
-    return unique
+    return unique.length === 1 ? unique.shift() : unique
   }
 }
 


### PR DESCRIPTION
This is a fix in core and an accompanying documentation fix, for `utils.curvesIntersect()`. 

My understanding is that `utils.curvesIntersect()` is intended to return an `Array` of `Points` if more than 1 intersection exists, a `Point` if exactly 1 intersection exists, and `false` if no intersections exist. 

However:
1. The code was returning an `Array` containing a single `Point` under some circumstances.
2. The code comment for the method said that it returned only an `Array`. It didn't mention the other 2 returns.
3. The documentation signature mentioned that the method returned only an `Array` or `false`. It didn't mention the `Point` return.
4. The documentation didn't mention or explain the expected behavior regarding the 3 different return types.
5. The documentation example was written as if only an `Array` was expected to be returned.

Issues 2, 3, 4, and 5 were causing confusion, where I was unsure whether my understanding of the `utils.curvesIntersect()` intended behavior was correct. (I am still not 100% sure if I am correct. I made my assumption based on how `utils.curveIntersectsX()` and `utils.curveIntersectsY()` behave.)

This PR addresses all of the issues.