### PR TITLE
fix(i18n): Add design categories

### DIFF
--- a/packages/i18n/src/locales/en/app.yaml
+++ b/packages/i18n/src/locales/en/app.yaml
@@ -341,3 +341,7 @@ darkTheme: Dark Theme
 hax0rTheme: Hax0r Theme
 lgbtqTheme: LGBTQ Theme
 transTheme: Trans Theme
+accessoryDesigns: Accessory Designs
+blockDesigns: Block/Sloper Designs
+garmentDesigns: Garment Designs
+utilityDesigns: Utility Designs


### PR DESCRIPTION
The v3 lab site changed the terminology used from "patterns" to "designs" instead of "patterns". This PR adds the 4 design categories to i18n translations.

