### PR TITLE
fix(dev,lab): Add <title> elements to HTML pages

### DIFF
--- a/sites/dev/pages/404.js
+++ b/sites/dev/pages/404.js
@@ -8,9 +8,11 @@ import PageLink from 'shared/components/page-link'
 
 const Page404 = () => {
   const app = useApp()
+  const title = '404: Page not found'
+  const fullTitle = title + ' - FreeSewing.dev'
 
   return (
-    <Page app={app} title="404: Page not found" layout={Layout}>
+    <Page app={app} title={title} layout={Layout}>
       <Head>
         <meta property="og:title" content="Page not found" key="title" />
         <meta property="og:type" content="article" key="type" />
@@ -27,6 +29,7 @@ const Page404 = () => {
         <meta property="og:url" content={`https://freesewing.dev/`} key="url" />
         <meta property="og:locale" content="en_US" key="locale" />
         <meta property="og:site_name" content="freesewing.dev" key="site" />
+        <title>{fullTitle}</title>
       </Head>
       <div className="flex flex-col gap-4 mt-16 lg:mt-32 text-center">
         <h1>404: Page not found</h1>

--- a/sites/dev/pages/[...mdxslug].js
+++ b/sites/dev/pages/[...mdxslug].js
@@ -12,6 +12,7 @@ import jargon from 'site/jargon.mjs'
 const MdxPage = (props) => {
   // This hook is used for shared code and global state
   const app = useApp()
+  const fullTitle = props.page.title + ' - FreeSewing.dev'
 
   /*
    * Each page should be wrapped in the Page wrapper component
@@ -40,6 +41,7 @@ const MdxPage = (props) => {
         <meta property="og:url" content={`https://freesewing.dev/${props.page.slug}`} key="url" />
         <meta property="og:locale" content="en_US" key="locale" />
         <meta property="og:site_name" content="freesewing.dev" key="site" />
+        <title>{fullTitle}</title>
       </Head>
       <div className="grid grid-cols-3 lg:gap-4">
         {props.toc && (

--- a/sites/dev/pages/contact.js
+++ b/sites/dev/pages/contact.js
@@ -19,9 +19,10 @@ const No = () => (
 const ContactPage = () => {
   const app = useApp()
   const title = 'Contact information'
+  const fullTitle = title + ' - FreeSewing.dev'
 
   return (
-    <Page app={app} title="Contact information" slug="contact" crumbs={[[title, 'contact']]}>
+    <Page app={app} title={title} slug="contact" crumbs={[[title, 'contact']]}>
       <Head>
         <meta property="og:title" content={title} key="title" />
         <meta property="og:type" content="article" key="type" />
@@ -38,6 +39,7 @@ const ContactPage = () => {
         <meta property="og:url" content={`https://freesewing.dev/contact`} key="url" />
         <meta property="og:locale" content="en_US" key="locale" />
         <meta property="og:site_name" content="freesewing.dev" key="site" />
+        <title>{fullTitle}</title>
       </Head>
       <div className="grid grid-cols-3 lg:gap-4 text-xl">
         <div className="mb-8 w-full col-span-3 row-start-1 col-start-1 xl:col-span-1 xl:col-start-3">

--- a/sites/dev/pages/index.js
+++ b/sites/dev/pages/index.js
@@ -9,10 +9,12 @@ import Popout from 'shared/components/popout'
 import WebLink from 'shared/components/web-link'
 import PageLink from 'shared/components/page-link'
 
+const title = 'Welcome to FreeSewing.dev'
+
 const HomePage = () => {
   const app = useApp()
   return (
-    <Page app={app} title="Welcome to FreeSewing.dev" layout={Layout}>
+    <Page app={app} title={title} layout={Layout}>
       <Head>
         <meta property="og:title" content="FreeSewing.dev" key="title" />
         <meta property="og:type" content="article" key="type" />
@@ -29,6 +31,7 @@ const HomePage = () => {
         <meta property="og:url" content="https://freesewing.dev/" key="url" />
         <meta property="og:locale" content="en_US" key="locale" />
         <meta property="og:site_name" content="freesewing.dev" key="site" />
+        <title>{title}</title>
       </Head>
       <section
         style={{

--- a/sites/lab/page-templates/design-list.js
+++ b/sites/lab/page-templates/design-list.js
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
 import Layout from 'site/components/layouts/bare'
 import { PageTitle } from 'shared/components/layouts/default'
+import Head from 'next/head'
 
 const DesignLinks = ({ list, prefix = '' }) => {
   const { t } = useTranslation(['patterns'])
@@ -33,6 +34,7 @@ const PatternListPageTemplate = ({ section = false }) => {
   const { t } = useTranslation(['app'])
 
   const title = section ? app.navigation[section].__title : t('designs')
+  const fullTitle = title + ' - FreeSewing Lab'
 
   const sectionDesigns = (section = false) => {
     if (!section) {
@@ -46,6 +48,9 @@ const PatternListPageTemplate = ({ section = false }) => {
 
   return (
     <Page app={app} title={`FreeSewing Lab: ${title}`} layout={Layout}>
+      <Head>
+        <title>{fullTitle}</title>
+      </Head>
       <div className="max-w-7xl m-auto py-20 md:py-36 min-h-screen">
         <section className="px-8">
           <PageTitle

--- a/sites/lab/page-templates/workbench.mjs
+++ b/sites/lab/page-templates/workbench.mjs
@@ -3,18 +3,26 @@ import useApp from 'site/hooks/useApp.js'
 import WorkbenchWrapper from 'shared/components/wrappers/workbench.js'
 import { useRouter } from 'next/router'
 import Layout from 'site/components/layouts/lab'
+import Head from 'next/head'
+import { capitalize } from 'shared/utils.mjs'
 
 const WorkbenchPage = ({ design }) => {
   const app = useApp()
   const router = useRouter()
   const { preload, from } = router.query
+  const name = design.designConfig?.data.name
+  const shortName = name.substring(name.indexOf('/') + 1)
+  const title = capitalize(shortName)
+  const fullTitle = title + ' - FreeSewing Lab'
 
   return (
     <Page app={app}>
+      <Head>
+        <title>{fullTitle}</title>
+      </Head>
       <WorkbenchWrapper {...{ app, design, preload, from }} layout={Layout} />
     </Page>
   )
 }
 
 export default WorkbenchPage
-

--- a/sites/lab/page-templates/workbench.mjs
+++ b/sites/lab/page-templates/workbench.mjs
@@ -11,8 +11,8 @@ const WorkbenchPage = ({ design }) => {
   const router = useRouter()
   const { preload, from } = router.query
   const name = design.designConfig?.data.name
-  const shortName = name.substring(name.indexOf('/') + 1)
-  const title = name ? capitalize(shortName) : 'Lab'
+  const shortName = name ? name.substring(name.indexOf('/') + 1) : 'Lab'
+  const title = capitalize(shortName)
   const fullTitle = title + ' - FreeSewing Lab'
 
   return (

--- a/sites/lab/page-templates/workbench.mjs
+++ b/sites/lab/page-templates/workbench.mjs
@@ -12,7 +12,7 @@ const WorkbenchPage = ({ design }) => {
   const { preload, from } = router.query
   const name = design.designConfig?.data.name
   const shortName = name.substring(name.indexOf('/') + 1)
-  const title = capitalize(shortName)
+  const title = name ? capitalize(shortName) : 'Lab'
   const fullTitle = title + ' - FreeSewing Lab'
 
   return (

--- a/sites/lab/pages/index.js
+++ b/sites/lab/pages/index.js
@@ -6,11 +6,13 @@ import Layout from 'site/components/layouts/bare'
 import { useTranslation } from 'next-i18next'
 import { Icons } from 'shared/components/navigation/primary'
 
+const title = 'Welcome to the FreeSewing Lab'
+
 const HomePage = () => {
   const app = useApp()
   const { t } = useTranslation(['lab'])
   return (
-    <Page app={app} title="Welcome to FreeSewing.dev" layout={Layout}>
+    <Page app={app} title="{title}" layout={Layout}>
       <Head>
         <meta property="og:title" content="FreeSewing.dev" key="title" />
         <meta property="og:type" content="article" key="type" />
@@ -31,6 +33,7 @@ const HomePage = () => {
         <meta property="og:url" content="https://freesewing.dev/" key="url" />
         <meta property="og:locale" content="en_US" key="locale" />
         <meta property="og:site_name" content="freesewing.dev" key="site" />
+        <title>{title}</title>
       </Head>
       <section
         style={{


### PR DESCRIPTION
This is a partial fix for #3388 , for the dev and lab sites. (A separate PR will be filed for the org site.)

For freesewing.dev, the titles are the page titles with " - FreeSewing.dev" appended. For example: `Getting started with Gitpod - FreeSewing.dev` and `bartackFractionAlong - FreeSewing.dev`. The index page title is `Welcome to FreeSewing.dev`.

For lab.freesewing.dev, the titles for the lab are the capitalized design name or the design category text with " - FreeSewing Lab" appended. For example: `Simon - FreeSewing Lab` and `Block/Sloper Designs - FreeSewing Lab`. The index page title is `Welcome to the FreeSewing Lab`