### PR TITLE
fix(org): Add <title> elements to HTML pages

### DIFF
--- a/sites/org/pages/docs/[...mdxslug].js
+++ b/sites/org/pages/docs/[...mdxslug].js
@@ -13,6 +13,8 @@ import mdxPaths from 'site/prebuild/mdx.paths.js'
 const MdxPage = (props) => {
   // This hook is used for shared code and global state
   const app = useApp()
+  const title = props.page.title
+  const fullTitle = title + ' - FreeSewing.org'
 
   /*
    * Each page should be wrapped in the Page wrapper component
@@ -41,6 +43,7 @@ const MdxPage = (props) => {
         <meta property="og:url" content={`https://freesewing.dev/${props.page.slug}`} key="url" />
         <meta property="og:locale" content="en_US" key="locale" />
         <meta property="og:site_name" content="freesewing.dev" key="site" />
+        <title>{fullTitle}</title>
       </Head>
       <div className="flex flex-row-reverse flex-wrap xl:flex-nowrap justify-end">
         {props.toc && (

--- a/sites/org/pages/docs/index.js
+++ b/sites/org/pages/docs/index.js
@@ -4,9 +4,11 @@ import mdxLoader from 'shared/mdx/loader'
 import MdxWrapper from 'shared/components/wrappers/mdx'
 import ReadMore from 'shared/components/mdx/read-more.js'
 import { jargon } from 'site/jargon.mjs'
+import Head from 'next/head'
 
 const DocsPage = ({ title, mdx }) => {
   const app = useApp()
+  const fullTitle = title + ' - FreeSewing.org'
 
   // We don't need all MDX components here, just ReadMore
   const components = {
@@ -15,6 +17,9 @@ const DocsPage = ({ title, mdx }) => {
 
   return (
     <Page app={app} title={title}>
+      <Head>
+        <title>{fullTitle}</title>
+      </Head>
       <div className="w-full">
         <MdxWrapper mdx={mdx} app={app} components={components} />
       </div>

--- a/sites/org/pages/index.js
+++ b/sites/org/pages/index.js
@@ -5,14 +5,19 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 //import { useTranslation } from 'next-i18next'
 import Layout from 'site/components/layouts/bare'
 import PageLink from 'shared/components/page-link'
+import Head from 'next/head'
 
 const HomePage = () => {
   const app = useApp()
+  const title = 'Welcome to FreeSewing.org'
   // Not using translation for now
   //  const { t } = useTranslation(['homepage', 'ograph'])
 
   return (
-    <Page app={app} title="Welcome to FreeSewing.org" layout={Layout}>
+    <Page app={app} title={title} layout={Layout}>
+      <Head>
+        <title>{title}</title>
+      </Head>
       <div>
         <div className="max-w-xl m-auto my-32 px-6">
           <Popout fixme>


### PR DESCRIPTION
This is a partial fix for #3388 , for the FreeSewing.org site changes. A separate PR was filed for the remainder of #3388, for the dev and lab sites.

The titles are the page titles with " - FreeSewing.org" appended. For example: `Documentation - FreeSewing.org` and `Can I use FreeSewing patterns for commercial purposes? - FreeSewing.org`. The index page title is `Welcome to FreeSewing.org`

(I filed this as a separate PR since the org site is currently being updated, and I didn't want any possible issues to delay the PR for the more stable dev and lab sites.)
