### PR TITLE
(fix) Clean up prefixing issues in plugins

### DIFF
--- a/plugins/plugin-cutonfold/src/index.mjs
+++ b/plugins/plugin-cutonfold/src/index.mjs
@@ -34,7 +34,7 @@ export const plugin = {
       so = {
         offset: 15,
         margin: 5,
-        prefix: '',
+        prefix: 'cutonfold',
         ...so,
       }
       if (typeof setCutOnFold === 'function') {
@@ -42,20 +42,20 @@ export const plugin = {
         if (so.grainline) setGrain(so.from.angle(so.to))
       }
       if (complete) {
-        points[so.prefix + 'CutonfoldFrom'] = so.from.shiftFractionTowards(so.to, so.margin / 100)
-        points[so.prefix + 'CutonfoldTo'] = so.to.shiftFractionTowards(so.from, so.margin / 100)
-        points[so.prefix + 'CutonfoldVia1'] = points[so.prefix + 'CutonfoldFrom']
+        points[so.prefix + 'From'] = so.from.shiftFractionTowards(so.to, so.margin / 100)
+        points[so.prefix + 'To'] = so.to.shiftFractionTowards(so.from, so.margin / 100)
+        points[so.prefix + 'Via1'] = points[so.prefix + 'From']
           .shiftTowards(so.from, so.offset * scale)
-          .rotate(-90, points[so.prefix + 'CutonfoldFrom'])
-        points[so.prefix + 'CutonfoldVia2'] = points[so.prefix + 'CutonfoldTo']
+          .rotate(-90, points[so.prefix + 'From'])
+        points[so.prefix + 'Via2'] = points[so.prefix + 'To']
           .shiftTowards(so.to, so.offset * scale)
-          .rotate(90, points[so.prefix + 'CutonfoldTo'])
+          .rotate(90, points[so.prefix + 'To'])
         const text = so.grainline ? 'cutOnFoldAndGrainline' : 'cutOnFold'
         paths[so.prefix + 'Cutonfold'] = new Path()
-          .move(points[so.prefix + 'CutonfoldFrom'])
-          .line(points[so.prefix + 'CutonfoldVia1'])
-          .line(points[so.prefix + 'CutonfoldVia2'])
-          .line(points[so.prefix + 'CutonfoldTo'])
+          .move(points[so.prefix + 'From'])
+          .line(points[so.prefix + 'Via1'])
+          .line(points[so.prefix + 'Via2'])
+          .line(points[so.prefix + 'To'])
           .attr('class', 'note')
           .attr('marker-start', 'url(#cutonfoldFrom)')
           .attr('marker-end', 'url(#cutonfoldTo)')

--- a/plugins/plugin-cutonfold/src/index.mjs
+++ b/plugins/plugin-cutonfold/src/index.mjs
@@ -42,20 +42,20 @@ export const plugin = {
         if (so.grainline) setGrain(so.from.angle(so.to))
       }
       if (complete) {
-        points['cutonfoldFrom' + so.prefix] = so.from.shiftFractionTowards(so.to, so.margin / 100)
-        points['cutonfoldTo' + so.prefix] = so.to.shiftFractionTowards(so.from, so.margin / 100)
-        points['cutonfoldVia1' + so.prefix] = points['cutonfoldFrom' + so.prefix]
+        points[so.prefix + 'CutonfoldFrom'] = so.from.shiftFractionTowards(so.to, so.margin / 100)
+        points[so.prefix + 'CutonfoldTo'] = so.to.shiftFractionTowards(so.from, so.margin / 100)
+        points[so.prefix + 'CutonfoldVia1'] = points[so.prefix + 'CutonfoldFrom']
           .shiftTowards(so.from, so.offset * scale)
-          .rotate(-90, points['cutonfoldFrom' + so.prefix])
-        points['cutonfoldVia2' + so.prefix] = points['cutonfoldTo' + so.prefix]
+          .rotate(-90, points[so.prefix + 'CutonfoldFrom'])
+        points[so.prefix + 'CutonfoldVia2'] = points[so.prefix + 'CutonfoldTo']
           .shiftTowards(so.to, so.offset * scale)
-          .rotate(90, points['cutonfoldTo' + so.prefix])
+          .rotate(90, points[so.prefix + 'CutonfoldTo'])
         const text = so.grainline ? 'cutOnFoldAndGrainline' : 'cutOnFold'
-        paths['cutonfold' + so.prefix] = new Path()
-          .move(points['cutonfoldFrom' + so.prefix])
-          .line(points['cutonfoldVia1' + so.prefix])
-          .line(points['cutonfoldVia2' + so.prefix])
-          .line(points['cutonfoldTo' + so.prefix])
+        paths[so.prefix + 'Cutonfold'] = new Path()
+          .move(points[so.prefix + 'CutonfoldFrom'])
+          .line(points[so.prefix + 'CutonfoldVia1'])
+          .line(points[so.prefix + 'CutonfoldVia2'])
+          .line(points[so.prefix + 'CutonfoldTo'])
           .attr('class', 'note')
           .attr('marker-start', 'url(#cutonfoldFrom)')
           .attr('marker-end', 'url(#cutonfoldTo)')

--- a/plugins/plugin-gore/src/index.mjs
+++ b/plugins/plugin-gore/src/index.mjs
@@ -8,7 +8,7 @@ export const plugin = {
       const from = so.from
       const gores = Number(so.gores)
       const radius = Number(so.radius) //radius of the sphere
-      const prefix = so.prefix
+      const prefix = (so.prefix || '') + 'gore'
       const extraLength = Number(so.extraLength) //the length of the straight section after a complete semisphere
 
       points[prefix + 'p1'] = from.shift(0, (radius * Math.PI) / 2 + extraLength)

--- a/plugins/plugin-gore/src/index.mjs
+++ b/plugins/plugin-gore/src/index.mjs
@@ -8,7 +8,7 @@ export const plugin = {
       const from = so.from
       const gores = Number(so.gores)
       const radius = Number(so.radius) //radius of the sphere
-      const prefix = (so.prefix || '') + 'gore'
+      const prefix = so.prefix || 'gore'
       const extraLength = Number(so.extraLength) //the length of the straight section after a complete semisphere
 
       points[prefix + 'p1'] = from.shift(0, (radius * Math.PI) / 2 + extraLength)

--- a/plugins/plugin-round/src/index.mjs
+++ b/plugins/plugin-round/src/index.mjs
@@ -12,7 +12,7 @@ export const plugin = {
       let to = so.to
       let via = so.via
       let radius = so.radius
-      let prefix = so.prefix
+      let prefix = (so.prefix || '') + 'round'
       let angle1 = from.angle(via)
       let angle2 = via.angle(to)
       if ((Math.round(angle1) - Math.round(angle2)) % 90 !== 0)

--- a/plugins/plugin-round/src/index.mjs
+++ b/plugins/plugin-round/src/index.mjs
@@ -12,7 +12,7 @@ export const plugin = {
       let to = so.to
       let via = so.via
       let radius = so.radius
-      let prefix = (so.prefix || '') + 'round'
+      let prefix = so.prefix || 'round'
       let angle1 = from.angle(via)
       let angle2 = via.angle(to)
       if ((Math.round(angle1) - Math.round(angle2)) % 90 !== 0)


### PR DESCRIPTION
resolves #3198, adds an additional prefix to eliminate generic point names in gore and round plugins
resolves #3197 uses prefix as a prefix instead of suffix in cutonfold macro