### PR TITLE
Example of using the new code-adjacent translation approach in a React component

### DIFF
--- a/sites/org/components/footer/footer.en.yaml
+++ b/sites/org/components/footer/footer.en.yaml
@@ -1,0 +1,7 @@
+cc: Content on FreeSewing.org is available under a Creative Commons license
+mit: The FreeSewing source code is available on Github under the MIT license
+sponsors: FreeSewing is sponsored by these awesome companies
+algolia: Search powered by Algolia
+crowdin: Translation powered by Crowdin
+bugsnag: Error handling by Bugsnag
+vercel: Builds & Hosting by Vercel

--- a/sites/org/components/footer/footer.nl.yaml
+++ b/sites/org/components/footer/footer.nl.yaml
@@ -1,0 +1,3 @@
+cc: De inhoud op FreeSewing.org is beschikbaar onder de Creative Commons licentie
+mit: De FreeSewing broncode is beschikbaar op Github onder de MIT licentie
+sponsors: FreeSewing wordt gesponsored door deze fantastische firmas

--- a/sites/org/components/footer/index.js
+++ b/sites/org/components/footer/index.js
@@ -5,6 +5,8 @@ import CcByLogo from 'shared/components/logos/cc-by.js'
 import Ribbon from 'shared/components/ribbon.js'
 import Link from 'next/link'
 import { WordMark } from 'shared/components/wordmark.js'
+import { useTranslation } from 'next-i18next'
+import { freeSewingConfig } from 'site/freesewing.config.js'
 
 import HelpIcon from 'shared/components/icons/help.js'
 import DiscordIcon from 'shared/components/icons/discord.js'
@@ -77,7 +79,18 @@ const social = {
   },
 }
 
-const Footer = ({ app }) => {
+/*
+ * This named export lets people know
+ * what translation namespaces this component relies on
+ */
+export const namespaces = ['footer']
+
+/*
+ * Named exports are better than default exports
+ */
+export const Footer = ({ app }) => {
+  const { t } = useTranslation(namespaces)
+
   return (
     <footer className="bg-neutral">
       <Ribbon loading={app.loading} theme={app.theme} />
@@ -91,13 +104,15 @@ const Footer = ({ app }) => {
             <div className="flex flex-row gap-2 justify-center items-center mt-8">
               <CcByLogo className="w-8 lg:w-12" />
               <p className="text-neutral-content text-right basis-4/5 lg:basis-3/4 leading-5">
-                {translations.cc}
+                {t('cc')}
               </p>
             </div>
             <div className="flex flex-row gap-2 justify-center items-center mt-4">
               <OsiLogo className="w-8 lg:w-12" />
               <p className="text-neutral-content text-right basis-4/5 lg:basis-3/4 leading-5">
-                {translations.mit}
+                <a href={freeSewingConfig.monorepo} className="hover:pointer hover:underline px-1">
+                  {t('mit')}
+                </a>
               </p>
             </div>
           </div>
@@ -128,7 +143,7 @@ const Footer = ({ app }) => {
           {/* Sponsors */}
           <div className="border rounded-xl p-8 border-dashed border-base-100/25 mt-20">
             <p className="text-center text-neutral-content leading-5">
-              {translations.sponsors}
+              {t('sponsors')}
               <br />
             </p>
             <div className="py-4 flex flex-row gap-8 flex-wrap 2xl:flex-nowrap justify-around text-neutral-content">
@@ -177,5 +192,3 @@ const Footer = ({ app }) => {
     </footer>
   )
 }
-
-export default Footer

--- a/sites/org/components/footer/index.js
+++ b/sites/org/components/footer/index.js
@@ -21,36 +21,6 @@ const link = 'text-secondary font-bold hover:pointer hover:underline px-1'
 const accent = 'text-accent font-bold text-base px-1 block sm:inline'
 const freesewing = 'px-1 text-base font-bold block sm:inline'
 
-// Keep these translations in the component because they're only used here
-const translations = {
-  cc: (
-    <span>
-      Content on FreeSewing.org is available under{' '}
-      <a className={link} href="https://creativecommons.org/licenses/by/4.0/">
-        a Creative Commons license
-      </a>
-    </span>
-  ),
-  mit: (
-    <span>
-      The FreeSewing source code is{' '}
-      <a href="https://github.com/freesewing/freesewing" className={link}>
-        available on Github
-      </a>{' '}
-      under{' '}
-      <a href="https://opensource.org/licenses/MIT" className={link}>
-        the MIT license
-      </a>
-    </span>
-  ),
-  sponsors: (
-    <>
-      <span className={freesewing}>FreeSewing</span> is sponsored by these{' '}
-      <span className={accent}>awesome companies</span>
-    </>
-  ),
-}
-
 const icon = { className: 'w-8 lg:w-12 h-8 lg:h-12' }
 const social = {
   Discord: {

--- a/sites/org/components/wrappers/layout.js
+++ b/sites/org/components/wrappers/layout.js
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import Header from 'site/components/header'
-import Footer from 'site/components/footer'
+import { Footer } from 'site/components/footer/index.js'
 import Search from 'site/components/search'
 
 const LayoutWrapper = ({ app, children = [], footer, search, setSearch, noSearch = false }) => {

--- a/sites/shared/prebuild/i18n.mjs
+++ b/sites/shared/prebuild/i18n.mjs
@@ -127,7 +127,7 @@ const fixData = (rawData) => {
     data[namespace] = { en: nsdata.en }
     // Complete other locales
     for (const lang of locales.filter((loc) => loc !== 'en')) {
-      if (typeof data[namespace][lang] === 'undefined') data[namespace][lang] = nsdata.en
+      if (typeof nsdata[lang] === 'undefined') data[namespace][lang] = nsdata.en
       else {
         for (const key of Object.keys(data[namespace].en)) {
           if (typeof nsdata[lang][key] === 'undefined') nsdata[lang][key] = nsdata.en[key]


### PR DESCRIPTION
This doesn't do much, just replaced the hard-coded translations with the new approach as outlined in #3418 

Oh, and a small fix in the prebuild script