### PR TITLE
fix(prettier): Ignore .yaml, .gif, .ico, and .jpg files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,13 @@
 # Since we generate a bunch of YAML and MarkDown files programatically
 # It triggers this constant fight between prettier and YAML/MD formatting
 # So let's not
+*.yaml
 *.yml
 *.md
 *.mustache
+*.gif
+*.ico
+*.jpg
 *.png
 *.svg
 *.prisma


### PR DESCRIPTION
I assume that we want `.yaml` files ignored, since `.yml` was already included.