### PR TITLE
fix(charlie): Fix length of back inseam to match front

### DIFF
--- a/designs/charlie/src/front.mjs
+++ b/designs/charlie/src/front.mjs
@@ -31,9 +31,8 @@ function draftCharlieFront({
   // Helper method to draw the outline path
   const drawPath = () => {
     let outseam = drawOutseam()
-    return new Path()
-      .move(points.floorIn)
-      .curve(points.kneeInCp2, points.forkCp1, points.fork)
+    return frontInseamPath
+      .clone()
       .curve(points.crotchSeamCurveCp1, points.crotchSeamCurveCp2, points.crotchSeamCurveStart)
       .line(points.styleWaistIn)
       .line(points.slantTop)
@@ -45,11 +44,19 @@ function draftCharlieFront({
     points.waistOut.x < points.seatOut.x
       ? new Path()
           .move(points.styleWaistOut)
-          .curve(points.seatOut, points.kneeOutCp1, points.floorOut)
+          .curve(points.seatOut, points.kneeOutCp1, points.kneeOut)
+          .line(points.floorOut)
       : new Path()
           .move(points.styleWaistOut)
           ._curve(points.seatOutCp1, points.seatOut)
-          .curve(points.seatOutCp2, points.kneeOutCp1, points.floorOut)
+          .curve(points.seatOutCp2, points.kneeOutCp1, points.kneeOut)
+          .line(points.floorOut)
+
+  // Helper object holding the inseam path
+  const frontInseamPath = new Path()
+    .move(points.floorIn)
+    .line(points.kneeIn)
+    .curve(points.kneeInCp2, points.forkCp1, points.fork)
 
   // Draw fly J-seam
   const flyBottom = utils.curveIntersectsY(
@@ -167,6 +174,10 @@ function draftCharlieFront({
   store.set('waistbandFront', points.styleWaistIn.dist(points.slantTop))
   store.set('waistbandFly', points.styleWaistIn.dist(points.flyTop))
   store.set('legWidthFront', points.floorIn.dist(points.floorOut))
+
+  // Store inseam and outseam lengths
+  store.set('frontInseamLength', frontInseamPath.length())
+  store.set('frontOutseamLength', drawOutseam().length())
 
   if (complete) {
     points.titleAnchor = new Point(points.knee.x, points.fork.y)


### PR DESCRIPTION
This is the fix for #3258 for the inseam so now the back and front matches. The change was to use the `fitKnee=true` calculations instead of the incorrect `fitKnee=false`.

The PR contains an incomplete fix for the outseam, and they still do not match back and front. Additional work will need to be done to fully fix the outseam.

I had been waiting for PR #3309 to be merged in order to file this PR. However, that PR seems to be delayed, so I am going ahead and filing this now.