### PR TITLE
(Feature) Add action to sync dependencies bumped by dependabot

### DIFF
--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -21,3 +21,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Run Sync Script
         run: node ./scripts/sync-dependencies.mjs {{github.ref_name}}
+      - name: Commit Changes
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "bumped {{github.ref_name}} changes in config/dependencies.yaml"
+          git push

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -1,9 +1,11 @@
 name: Sync Dependabot Bump
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
 
 jobs:
   sync:
-    if: ${{ github.actor == 'dependabot[bot]' }}
     name: Sync dependency files
     runs-on: ubuntu-latest
 

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -1,10 +1,9 @@
 name: Sync Dependabot Bump
-on:
-  pull_request:
-    branches: dependabot/npm_and_yarn/**
+on: pull_request
 
 jobs:
   sync:
+    if: ${{ github.actor == 'dependabot[bot]' }}
     name: Sync dependency files
     runs-on: ubuntu-latest
 

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -2,6 +2,8 @@ name: Sync Dependabot Bump
 on:
   pull_request:
     types: [opened, reopened, edited]
+permissions:
+  pull-requests: write
 
 
 jobs:

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -22,8 +22,9 @@ jobs:
         run: node ./scripts/sync-dependencies.mjs ${{github.head_ref}}
       - name: Commit Changes
         run: |
+          git status
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add .
-          git commit -m "bumped {{github.head_ref}} changes in config/dependencies.yaml"
+          git add -A
+          git commit -m "bumped ${{github.head_ref}} changes in config/dependencies.yaml"
           git push

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -27,6 +27,5 @@ jobs:
           git status
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add -A
-          git commit -m "bumped ${{ github.head_ref }} changes in config/dependencies.yaml"
+          git commit -am "bumped ${{ github.head_ref }} changes in config/dependencies.yaml"
           git push

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Run Sync Script
-        run: node ./scripts/sync-dependencies.mjs ${{github.ref_name}}
+        run: node ./scripts/sync-dependencies.mjs ${{github.head_ref}}
       - name: Commit Changes
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "bumped {{github.ref_name}} changes in config/dependencies.yaml"
+          git commit -m "bumped {{github.head_ref}} changes in config/dependencies.yaml"
           git push

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -27,5 +27,5 @@ jobs:
           git status
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -am "bumped ${{ github.head_ref }} changes in config/dependencies.yaml"
+          git commit -am "[dependabot skip] bumped ${{ github.head_ref }} changes in config/dependencies.yaml"
           git push

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Run Sync Script
-        run: node ./scripts/sync-dependencies.mjs {{github.ref_name}}
+        run: node ./scripts/sync-dependencies.mjs ${{github.ref_name}}
       - name: Commit Changes
         run: |
           git config user.name github-actions

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -1,0 +1,23 @@
+name: Sync Dependabot Bump
+on:
+  pull_request:
+    branches: dependabot/npm_and_yarn/**
+
+jobs:
+  sync:
+    name: Sync dependency files
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Run Sync Script
+        run: node ./scripts/sync-dependencies.mjs {{github.ref_name}}

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -1,19 +1,16 @@
 name: Sync Dependabot Bump
 on:
   pull_request:
-    types: [opened, reopened, edited]
-permissions:
-  pull-requests: write
+    types: [opened, synchronize]
 
+permissions:
+  contents: write
 
 jobs:
   sync:
+    if: ${{ github.actor == 'dependabot[bot]' }}
     name: Sync dependency files
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
 
     steps:
       - name: Checkout Repository
@@ -28,8 +25,9 @@ jobs:
         run: node ./scripts/sync-dependencies.mjs ${{ github.head_ref }}
       - name: Commit Changes
         run: |
+          git add .
           git status
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -am "[dependabot skip] bumped ${{ github.head_ref }} changes in config/dependencies.yaml"
+          git commit -m "[dependabot skip] bumped ${{ github.head_ref }} changes in config/dependencies.yaml"
           git push

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -14,17 +14,19 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Run Sync Script
-        run: node ./scripts/sync-dependencies.mjs ${{github.head_ref}}
+        run: node ./scripts/sync-dependencies.mjs ${{ github.head_ref }}
       - name: Commit Changes
         run: |
           git status
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add -A
-          git commit -m "bumped ${{github.head_ref}} changes in config/dependencies.yaml"
+          git commit -m "bumped ${{ github.head_ref }} changes in config/dependencies.yaml"
           git push

--- a/scripts/sync-dependencies.mjs
+++ b/scripts/sync-dependencies.mjs
@@ -16,6 +16,7 @@ const oldDepsRaw = readFileSync(depsFile, { encoding: 'utf8' })
 // we get the branch name handed to us by the github action,
 // and it has all the info we need about the dependency being updated
 const branchName = process.argv[2]
+console.log('processing updates from ', branchName)
 const versionRgx = /\d+\.\d+\.\d+$/
 const dependencyVersion = branchName.match(versionRgx)[0]
 const dependency = branchName

--- a/scripts/sync-dependencies.mjs
+++ b/scripts/sync-dependencies.mjs
@@ -1,0 +1,35 @@
+// when dependabot updates a dependency in a package.json,
+// we want to update it in our dependencies.yaml so the update doesn't get clobbered
+// This script is run by the github action in dependabot-sync.yml
+import process from 'node:process'
+import yaml from 'js-yaml'
+import { readFileSync, writeFileSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+// when dependabot updates a dependency in a package.json, we want to update it in our dependencies.yaml
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const depsFile = path.join(__dirname, '..', 'config/dependencies.yaml')
+const oldDepsRaw = readFileSync(depsFile, { encoding: 'utf8' })
+
+// we get the branch name handed to us by the github action,
+// and it has all the info we need about the dependency being updated
+const branchName = process.argv[2]
+const versionRgx = /\d+\.\d+\.\d+$/
+const dependencyVersion = branchName.match(versionRgx)[0]
+const dependency = branchName
+  .replace(`-${dependencyVersion}`, '')
+  .replace('dependabot/npm_and_yarn/', '')
+
+// because this is from dependabot,
+// and because we want all our versions synced
+// we simply find and replace the version wherever it is specified
+const rgx = new RegExp(`(?<='${dependency}':\\W{0,2}\\w*\\W?')\\d+\\.\\d+\\.\\d+(?=')`, 'g')
+const newDepsRaw = oldDepsRaw.replace(rgx, dependencyVersion)
+console.log(`Updating ${dependency} version to ${dependencyVersion} in config/dependencies.yaml`)
+
+// write the file
+writeFileSync(depsFile, newDepsRaw)
+console.log('Successfully updated config/dependencies.yaml')

--- a/scripts/sync-dependencies.mjs
+++ b/scripts/sync-dependencies.mjs
@@ -2,7 +2,6 @@
 // we want to update it in our dependencies.yaml so the update doesn't get clobbered
 // This script is run by the github action in dependabot-sync.yml
 import process from 'node:process'
-import yaml from 'js-yaml'
 import { readFileSync, writeFileSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'

--- a/scripts/sync-dependencies.mjs
+++ b/scripts/sync-dependencies.mjs
@@ -26,7 +26,7 @@ const dependency = branchName
 // because this is from dependabot,
 // and because we want all our versions synced
 // we simply find and replace the version wherever it is specified
-const rgx = new RegExp(`(?<='${dependency}':\\W{0,2}\\w*\\W?')\\d+\\.\\d+\\.\\d+(?=')`, 'g')
+const rgx = new RegExp(`(?<='@?${dependency}':\\W{0,2}\\w*\\W?')\\d+\\.\\d+\\.\\d+(?=')`, 'g')
 const newDepsRaw = oldDepsRaw.replace(rgx, dependencyVersion)
 console.log(`Updating ${dependency} version to ${dependencyVersion} in config/dependencies.yaml`)
 


### PR DESCRIPTION
A very simple action/script to automate the frustrating chore of updating `dependencies.yaml` on each dependabot branch before merging, and prevent the updates from being clobbered if one slips through the cracks.

I've tested the action in my fork and it works when dependabot opens a new PR or rebases an existing one.

I've identified at least one case where it does not work, which is the case where dependabot only changes the `yarn.lock`, because in that case there is nothing to update in the `dependencies.yaml`. Right now I'm letting it fail because, for the pull request it failed on, dependabot had also bumped a top level dependency in the lock file and I figured a red x could warn us that there might still be something to do before the PR can be merged.