### PR TITLE
Dependabot sync action runs reconfigure after syncing updates

### DIFF
--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -23,6 +23,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Run Sync Script
         run: node ./scripts/sync-dependencies.mjs ${{ github.head_ref }}
+      - name: Run reconfigure
+        run: yarn reconfigure
       - name: Commit Changes
         run: |
           git add .

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -23,8 +23,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Run Sync Script
         run: node ./scripts/sync-dependencies.mjs ${{ github.head_ref }}
-      - name: Run reconfigure
+      - name: Reconfigure
         run: yarn reconfigure
+      - name: Bootstrap
+        run: npx lerna bootstrap
       - name: Commit Changes
         run: |
           git add .


### PR DESCRIPTION
Because we are tying a bunch of related packages' versions together in `dependencies.yaml`, but each dependabot pull request only updates one package, the sync should make sure that anything that's version is changed in `dependencies.yaml` is also updated in `yarn.lock` and in their various `package.json`s, so we have to run `yarn reconfigure` and `npx lerna bootstrap` to make sure that happens