### PR TITLE
fix(lab) Properly call Path attributes for X-ray mode.

### DIFF
--- a/sites/shared/components/workbench/draft/path.mjs
+++ b/sites/shared/components/workbench/draft/path.mjs
@@ -502,7 +502,7 @@ export const pathInfo = (props) => {
               <Tr>
                 <KeyTd>Attributes</KeyTd>
                 <ValTd>
-                  <Attributes list={bbox.attributes.list} />
+                  <Attributes list={props.path.attributes.list} />
                 </ValTd>
               </Tr>
             </tbody>


### PR DESCRIPTION
- Bug
When clicking on a path (hover red) in X-ray mode this error would appear and no information would appear.

![image](https://user-images.githubusercontent.com/16866285/216833870-be5b827c-1f72-43ae-8f81-bada3a07383d.png)

Upon inspection found that it was not calling the attributes from the path causing the error

- Fix

Changing `bbox` to `prop.path` so the Attributes are called from the Path. After making this change the information is now presented to the user,

![image](https://user-images.githubusercontent.com/16866285/216833980-fe8338c2-beef-48e8-82d0-83b5e0f5bc3f.png)
