### PR TITLE
fix (TestThing) Fix menu and inital draft

### DIFF
--- a/sites/shared/components/workbench/menu/test-design-options/index.mjs
+++ b/sites/shared/components/workbench/menu/test-design-options/index.mjs
@@ -28,8 +28,6 @@ export const TestDesignOptions = (props) => {
   const { t } = useTranslation(['app'])
   const optionsMenu = optionsMenuStructure(props.design.patternConfig.options)
 
-  // FIXME: This menu is broken right now
-
   const measies = props.draft?.config?.measurements || []
 
   return (
@@ -42,7 +40,7 @@ export const TestDesignOptions = (props) => {
         <Ul className="pl-5 list-inside">
           {Object.entries(optionsMenu).map(([group, options]) =>
             typeof options === 'string' ? (
-              <Option
+              <SampleDesignOption
                 {...props}
                 type={options}
                 option={group}

--- a/sites/shared/components/workbench/sample.mjs
+++ b/sites/shared/components/workbench/sample.mjs
@@ -9,24 +9,29 @@ export const LabSample = ({ gist, draft, updateGist, unsetGist, showInfo, app, f
   let title = ''
   let patternProps
   const errors = []
+
+  draft.use(svgattrPlugin, {
+    class: 'freesewing pattern max-h-screen',
+  })
+
   if (gist.sample) {
     try {
-      draft.use(svgattrPlugin, {
-        class: 'freesewing pattern max-h-screen',
-      })
       draft = draft.sample()
       // Render as React
-      patternProps = draft.getRenderProps()
-      for (const logs of patternProps.logs) errors.push(...logs.error)
+      for (const logs of patternProps.logs.sets) errors.push(...logs.error)
     } catch (err) {
       console.log(err)
     }
-    if (gist.sample.type === 'option') {
-      title = t('testThing', {
-        thing: ' : ' + t('option') + ' : ' + gist.sample.option,
-      })
-    }
+
+    //FIXME this doesn't work for models
+    title = t('testThing', {
+      thing: ` : ${t(gist.sample.type)} : ${gist.sample[gist.sample.type]}`,
+    })
+  } else {
+    // don't error on first page landing
+    draft.draft()
   }
+  patternProps = draft.getRenderProps()
 
   return (
     <>

--- a/sites/shared/components/workbench/sample.mjs
+++ b/sites/shared/components/workbench/sample.mjs
@@ -17,6 +17,7 @@ export const LabSample = ({ gist, draft, updateGist, unsetGist, showInfo, app, f
   if (gist.sample) {
     try {
       draft = draft.sample()
+      patternProps = draft.getRenderProps()
       // Render as React
       for (const logs of patternProps.logs.sets) errors.push(...logs.error)
     } catch (err) {
@@ -30,8 +31,8 @@ export const LabSample = ({ gist, draft, updateGist, unsetGist, showInfo, app, f
   } else {
     // don't error on first page landing
     draft.draft()
+    patternProps = draft.getRenderProps()
   }
-  patternProps = draft.getRenderProps()
 
   return (
     <>

--- a/sites/shared/utils.mjs
+++ b/sites/shared/utils.mjs
@@ -170,12 +170,13 @@ export const optionsMenuStructure = (options) => {
   // Fixme: One day we should sort this based on the translation
   for (const option of orderBy(sorted, ['menu', 'name'], ['asc'])) {
     if (typeof option === 'object') {
-      if (option.menu) set(menu, option.name, optionType(option))
-      else if (typeof option.menu === 'undefined')
+      if (option.menu) set(menu, [option.menu, option.name], optionType(option))
+      else if (typeof option.menu === 'undefined') {
         console.log(
           `Warning: Option ${option.name} does not have a menu config. ` +
             'Either configure it, or set it to false to hide this option.'
         )
+      }
     }
   }
 


### PR DESCRIPTION
- Menu now works on TestThing view, with the added bonus that menu categories have been re-implemented
- Run a regular draft on first view load so that we don't show an error immediately
- Always show a page title