### PR TITLE
fix(dev/shared): .mjs filename and named exports changes

### DIFF
--- a/sites/dev/hooks/useApp.mjs
+++ b/sites/dev/hooks/useApp.mjs
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import set from 'lodash.set'
 import { useTheme } from 'shared/hooks/useTheme.mjs'
 // Prebuild navigation
-import prebuildNavigation from 'site/prebuild/navigation.js'
+import { prebuildNavigation } from 'site/prebuild/navigation.mjs'
 
 export const useApp = () => {
   // No translation for freesewing.dev

--- a/sites/shared/components/workbench/edit/index.mjs
+++ b/sites/shared/components/workbench/edit/index.mjs
@@ -2,7 +2,7 @@ import yaml from 'js-yaml'
 import { defaultGist } from 'shared/components/workbench/gist.mjs'
 import { validateGist } from './gist-validator.mjs'
 import { useEffect, useState, useRef } from 'react'
-import Popout from 'shared/components/popout.mjs'
+import { Popout } from 'shared/components/popout.mjs'
 import { useTranslation } from 'next-i18next'
 import { capitalize } from '@freesewing/core'
 


### PR DESCRIPTION
Fixes for dev and lab Vercel build failures.

dev build failure:
```
12:38:17.596 | ./hooks/useApp.mjs
12:38:17.596 | Module not found: Can't resolve 'site/prebuild/navigation.js'
```

lab build failure:
```
12:35:06.555 | ../shared/components/workbench/edit/index.mjs
12:35:06.556 | Attempted import error: 'shared/components/popout.mjs' does not contain a default export (imported as 'Popout').
```