### PR TITLE
fix (#3539) add wrap flag to iconWrapper

### DIFF
--- a/sites/shared/components/icons.mjs
+++ b/sites/shared/components/icons.mjs
@@ -5,20 +5,24 @@ export const IconWrapper = ({
   stroke = 2,
   children = null,
   fill = false,
-}) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill={fill ? 'currentColor' : 'none'}
-    viewBox="0 0 24 24"
-    strokeWidth={stroke}
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className={className + ' icon'}
-  >
-    {children}
-  </svg>
-)
+  wrapped = true,
+}) =>
+  wrapped ? (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill={fill ? 'currentColor' : 'none'}
+      viewBox="0 0 24 24"
+      strokeWidth={stroke}
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className + ' icon'}
+    >
+      {children}
+    </svg>
+  ) : (
+    <> {children} </>
+  )
 
 export const BioIcon = (props) => (
   <IconWrapper {...props}>

--- a/sites/shared/components/workbench/layout/draft/buttons.mjs
+++ b/sites/shared/components/workbench/layout/draft/buttons.mjs
@@ -66,7 +66,7 @@ export const Buttons = ({ transform, flip, rotate, resetPart, rotate90 }) => {
       <Button
         onClickCb={resetPart}
         transform={`translate(${rectSize / -2}, ${rectSize / -2})`}
-        Icon={ClearIcon}
+        Icon={() => <ClearIcon wrapped={false} />}
       >
         {t('toolbar.resetPart')}
       </Button>


### PR DESCRIPTION
allow IconWrapper component to optionally return an unwrapped version of the icon path for use within svg objects

This resolves #3539 because it means sizing is handled by the buttons component instead of the svg that the icon is wrapped in