### PR TITLE
fix(plugintest): Adjust title bounding box to prevent clipping

### DIFF
--- a/designs/plugintest/src/plugin-title.mjs
+++ b/designs/plugintest/src/plugin-title.mjs
@@ -15,7 +15,7 @@ const pluginTitle = ({ points, Point, paths, Path, macro, options, store, part }
       scale: options.titleScale,
     })
     // Prevent clipping of text
-    paths.box = new Path().move(new Point(0, -20)).line(new Point(120, 20)).attr('class', 'hidden')
+    paths.box = new Path().move(new Point(10, -45)).line(new Point(120, 35)).attr('class', 'hidden')
   }
 
   return part


### PR DESCRIPTION
The old boundary box was causing part of the title contents to be hidden.

Before:
![Screenshot 2023-02-15 at 10 26 54 AM](https://user-images.githubusercontent.com/109869956/219119889-1c8b99d5-8acc-4ea7-9e56-233f157780a2.png)

After:
![Screenshot 2023-02-15 at 10 26 22 AM](https://user-images.githubusercontent.com/109869956/219119876-58ab323e-fb70-41e4-97fd-3cb66a8c959a.png)
