### PR TITLE
feature (ignored_builds) Add plugins and designs build trigger for lab

### DIFF
--- a/scripts/skip-build-base.mjs
+++ b/scripts/skip-build-base.mjs
@@ -1,7 +1,9 @@
 import process from 'node:process'
 import { execSync } from 'child_process'
 
-export const shouldSkipBuild = (siteName, checkFolders = '../shared .') => {
+const defaultFolders = ['../shared', '../../plugins', '../../designs', '.'].join(' ')
+
+export const shouldSkipBuild = (siteName, checkFolders = defaultFolders) => {
   console.log('Skip build script version 1.0.0')
 
   // Do not block production builds

--- a/scripts/skip-build-base.mjs
+++ b/scripts/skip-build-base.mjs
@@ -1,9 +1,7 @@
 import process from 'node:process'
 import { execSync } from 'child_process'
 
-const defaultFolders = ['../shared', '../../plugins', '../../designs', '.'].join(' ')
-
-export const shouldSkipBuild = (siteName, checkFolders = defaultFolders) => {
+export const shouldSkipBuild = (siteName, checkFolders = '../shared .') => {
   console.log('Skip build script version 1.0.0')
 
   // Do not block production builds

--- a/sites/lab/skip_build.mjs
+++ b/sites/lab/skip_build.mjs
@@ -1,3 +1,5 @@
 import { shouldSkipBuild } from '../../scripts/skip-build-base.mjs'
 
-shouldSkipBuild('Lab')
+const triggerFolders = ['../shared', '../../plugins', '../../designs', '.'].join(' ')
+
+shouldSkipBuild('Lab', triggerFolders)


### PR DESCRIPTION
Preview builds of lab will also be triggered on changes to designs and plugins now.

I think this is worthwhile for broader testing of designs within the community, and, especially because design changes are slower to be merged, having previews allows designers to direct people to a build that contains those changes