### PR TITLE
feature (Pattern Config Resolution) Resolve Part Configurations Progressively

### DIFF
--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -62,6 +62,9 @@ core:
   dev:
     'eslint': &eslint '8.34.0'
     'nyc': '15.1.0'
+    'mocha': *mocha
+    'chai': *chai
+    'sinon': &sinon '^15.0.1'
 diana:
   peer:
     '@freesewing/brian': *freesewing

--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -53,7 +53,7 @@ charlie:
 core:
   _:
     'bezier-js': '6.1.0'
-    'bin-pack': '1.0.2'
+    'bin-pack-with-constraints': '1.0.1'
     'hooks': '0.3.2'
     'lodash.get': &_get '4.4.2'
     'lodash.set': &_set '4.3.2'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {},
   "dependencies": {
     "bezier-js": "6.1.0",
-    "bin-pack": "1.0.2",
+    "bin-pack-with-constraints": "1.0.1",
     "hooks": "0.3.2",
     "lodash.get": "4.4.2",
     "lodash.set": "4.3.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,10 @@
   },
   "devDependencies": {
     "eslint": "8.34.0",
-    "nyc": "15.1.0"
+    "nyc": "15.1.0",
+    "mocha": "10.0.0",
+    "chai": "4.2.0",
+    "sinon": "^15.0.1"
   },
   "files": [
     "dist/*",

--- a/packages/core/src/pattern-config.mjs
+++ b/packages/core/src/pattern-config.mjs
@@ -9,8 +9,6 @@ import { __addNonEnumProp } from './utils.mjs'
 export function getPluginName(plugin) {
   const toCheck = Array.isArray(plugin) ? plugin[0] : plugin
   return toCheck.name || toCheck.plugin?.name || false
-
-  return false
 }
 
 /////////////////
@@ -362,8 +360,13 @@ PatternConfig.prototype.__resolvePartDependencies = function (depChain) {
 
         // if the dependency isn't registered, register it
         if (!this.parts[dot.name]) {
-          // add the part's configuration
+          // add the part's configuration. this will recursively add the part's dependencies to all parts in the chain
           this.__addPart([dot, ...depChain])
+        } else {
+          // if it's already registered, recursion won't happen, but we still need to add its resolved dependencies to all parts in the chain
+          this.resolvedDependencies[dot.name].forEach((r) => {
+            depChain.forEach((c) => this.__addDependency('resolvedDependencies', c.name, r))
+          })
         }
       })
     }

--- a/packages/core/src/pattern-config.mjs
+++ b/packages/core/src/pattern-config.mjs
@@ -41,15 +41,17 @@ export function PatternConfig(pattern) {
   this.parts = {}
   /** @type {Object} which parts are hidden */
   this.partHide = {}
-  /** @type {Object} which parts hide all their dependencies */
-  this.partHideAll = {}
 
-  /** to track which parts have already been resolved */
-  __addNonEnumProp(this, '__resolvedParts', {})
   /** @type {Object} to track when to overwrite options */
   __addNonEnumProp(this, '__mutated', {
     optionDistance: {},
     partDistance: {},
+  })
+
+  /** @type {Object} tracking for dependency hiding */
+  __addNonEnumProp(this, '__hiding', {
+    all: {},
+    deps: {},
   })
 }
 
@@ -101,7 +103,7 @@ PatternConfig.prototype.logPartDistances = function () {
 
 /**
  * Return a configuration in the structure expected by the pattern
- * @return {Object} contains parts, plugins, measurements, options, optionalMeasurements, resolvedDependencies, directDependencies, inject, draftOrder, partHide, and partHideAll
+ * @return {Object} contains parts, plugins, measurements, options, optionalMeasurements, resolvedDependencies, directDependencies, inject, draftOrder, partHide
  */
 PatternConfig.prototype.asConfig = function () {
   return {
@@ -115,7 +117,6 @@ PatternConfig.prototype.asConfig = function () {
     inject: this.inject,
     draftOrder: this.__resolveDraftOrder(),
     partHide: this.partHide,
-    partHideAll: this.partHideAll,
   }
 }
 
@@ -147,9 +148,11 @@ PatternConfig.prototype.__addPart = function (depChain) {
       )
   }
 
-  // Hide when hideAll is set
+  // Handle various hiding possibilities
+  if (part.hide || part.hideAll) this.partHide[part.name] = true
+  if (part.hideDependencies) this.__hiding.deps[part.name] = true
   if (part.hideAll) {
-    this.partHide[part.name] = true
+    this.__hiding.all[part.name] = true
   }
 
   // resolve its dependencies
@@ -167,9 +170,6 @@ PatternConfig.prototype.__addPart = function (depChain) {
  * @return this
  */
 PatternConfig.prototype.__addPartConfig = function (part) {
-  // don't resolve a part that's already been resolved
-  if (this.__resolvedParts[part.name]) return this
-
   return this.__addPartOptions(part) // add options
     .__addPartMeasurements(part, false) // add required measurements
     .__addPartMeasurements(part, true) // add optional measurements
@@ -465,14 +465,13 @@ PatternConfig.prototype.__resolveDraftOrder = function () {
  * @return {Pattern} this - The Pattern instance
  */
 PatternConfig.prototype.__setFromHide = function (part, depName) {
-  if (
-    part.hideDependencies ||
-    part.hideAll ||
-    this.partHide[part.name] ||
-    this.partHideAll[part.name]
-  ) {
+  if (part.hideDependencies || this.__hiding.deps[part.name]) {
     this.partHide[depName] = true
-    this.partHideAll[depName] = true
+    this.__hiding.deps[depName] = true
+  }
+  if (part.hideAll || this.__hiding.all[part.name]) {
+    this.partHide[depName] = true
+    this.__hiding.all[depName] = true
   }
 
   return this
@@ -488,9 +487,8 @@ PatternConfig.prototype.__setFromHide = function (part, depName) {
  * @return {Pattern} this - The Pattern instance
  */
 PatternConfig.prototype.__setAfterHide = function (part, depName) {
-  if (this.partHide[part.name] || this.partHideAll[part.name]) {
+  if (this.__hiding.all[part.name]) {
     this.partHide[depName] = true
-    this.partHideAll[depName] = true
   }
 
   return this

--- a/packages/core/src/pattern-config.mjs
+++ b/packages/core/src/pattern-config.mjs
@@ -65,7 +65,7 @@ const DISTANCE_DEBUG = false
  * @param  {Object} part a part configuration
  * @return {boolean}      whether the part is valid
  */
-PatternConfig.prototype.validatePart = function (part) {
+PatternConfig.prototype.isPartValid = function (part) {
   if (typeof part?.draft !== 'function') {
     this.store.log.error(`Part must have a draft() method`)
     return false
@@ -84,7 +84,7 @@ PatternConfig.prototype.validatePart = function (part) {
  * @param {Object} part
  */
 PatternConfig.prototype.addPart = function (part) {
-  if (this.validatePart(part)) this.__addPart([part])
+  if (this.isPartValid(part)) this.__addPart([part])
 
   return this
 }
@@ -134,9 +134,9 @@ PatternConfig.prototype.__addPart = function (depChain) {
   const part = depChain[0]
   // the longer the chain, the deeper the part is down it
   const distance = depChain.length
-  if (!this.parts[part.name]) {
-    this.parts[part.name] = Object.freeze(part)
-  }
+  if (!this.parts[part.name]) this.parts[part.name] = Object.freeze(part)
+  else return
+
   // if it hasn't been registered with a distance, do that now
   if (typeof this.__mutated.partDistance[part.name] === 'undefined') {
     this.__mutated.partDistance[part.name] = distance

--- a/packages/core/src/pattern-config.mjs
+++ b/packages/core/src/pattern-config.mjs
@@ -465,11 +465,11 @@ PatternConfig.prototype.__resolveDraftOrder = function () {
  * @return {Pattern} this - The Pattern instance
  */
 PatternConfig.prototype.__setFromHide = function (part, depName) {
-  if (part.hideDependencies || this.__hiding.deps[part.name]) {
+  if (this.__hiding.deps[part.name]) {
     this.partHide[depName] = true
     this.__hiding.deps[depName] = true
   }
-  if (part.hideAll || this.__hiding.all[part.name]) {
+  if (this.__hiding.all[part.name]) {
     this.partHide[depName] = true
     this.__hiding.all[depName] = true
   }
@@ -489,6 +489,7 @@ PatternConfig.prototype.__setFromHide = function (part, depName) {
 PatternConfig.prototype.__setAfterHide = function (part, depName) {
   if (this.__hiding.all[part.name]) {
     this.partHide[depName] = true
+    this.__hiding.all[depName] = true
   }
 
   return this

--- a/packages/core/src/pattern-draft-queue.mjs
+++ b/packages/core/src/pattern-draft-queue.mjs
@@ -1,42 +1,73 @@
+/**
+ * A queue for handling the draft order of pattern parts
+ * Unlike most queues, traversing this queue is non-destructive
+ * so that the queue can be traversed many times.
+ * The goal is to allow the queue to be manipulated while being traversed
+ * @class
+ * @param {Pattern} pattern the pattern that will use the queue
+ */
 export function PatternDraftQueue(pattern) {
+  // save the config resolver
   this.__configResolver = pattern.__configResolver
+  // get the draft order in its current state
   this.queue = this.__resolveDraftOrder()
+  // start at 0
   this.start()
 }
 
+/** Go back to the beginning of the queue */
 PatternDraftQueue.prototype.start = function () {
   this.queueIndex = 0
 }
 
+/**
+ * Add a part to end of the queue. Useful for queueing up parts a draft time
+ * @param {string} partName the name to the part to add
+ */
 PatternDraftQueue.prototype.addPart = function (partName) {
   if (!this.contains(partName)) this.queue.push(partName)
   return this
 }
 
+/**
+ * Check whether the queue has a next part without moving the queue index
+ * @return {Boolean} whether there is a next part in the queue
+ */
 PatternDraftQueue.prototype.hasNext = function () {
   return this.queueIndex < this.queue.length
 }
 
+/**
+ * Get the next part in the queue without moving the queue index
+ * @return {string} the next part in the queue
+ */
 PatternDraftQueue.prototype.peek = function () {
   return this.queue[this.queueIndex]
 }
 
+/**
+ * Get the next part in the queue and move the queue index
+ * @return {string} the next part in the queue
+ */
 PatternDraftQueue.prototype.next = function () {
   const next = this.peek()
   this.queueIndex++
   return next
 }
 
+/**
+ * Check whether a part is already queued
+ * @param  {string} partName the name of the part
+ * @return {boolean}          whether the part is in the queue
+ */
 PatternDraftQueue.prototype.contains = function (partName) {
   return this.queue.indexOf(partName) !== -1
 }
 
 /**
  * Resolves the draft order based on the configuation
- *
  * @private
- * @param {object} graph - The object of resolved dependencies, used to call itself recursively
- * @return {Pattern} this - The Pattern instance
+ * @return A list of parts in the order they should be drafted
  */
 PatternDraftQueue.prototype.__resolveDraftOrder = function () {
   const partDistances = this.__configResolver.__mutated.partDistance

--- a/packages/core/src/pattern-draft-queue.mjs
+++ b/packages/core/src/pattern-draft-queue.mjs
@@ -9,7 +9,7 @@ PatternDraftQueue.prototype.start = function () {
 }
 
 PatternDraftQueue.prototype.addPart = function (partName) {
-  this.queue.push(partName)
+  if (!this.contains(partName)) this.queue.push(partName)
   return this
 }
 
@@ -25,6 +25,10 @@ PatternDraftQueue.prototype.next = function () {
   const next = this.peek()
   this.queueIndex++
   return next
+}
+
+PatternDraftQueue.prototype.contains = function (partName) {
+  return this.queue.indexOf(partName) !== -1
 }
 
 /**

--- a/packages/core/src/pattern-draft-queue.mjs
+++ b/packages/core/src/pattern-draft-queue.mjs
@@ -1,0 +1,42 @@
+export function PatternDraftQueue(pattern) {
+  this.__configResolver = pattern.__configResolver
+  this.queue = this.__resolveDraftOrder()
+  this.start()
+}
+
+PatternDraftQueue.prototype.start = function () {
+  this.queueIndex = 0
+}
+
+PatternDraftQueue.prototype.addPart = function (partName) {
+  this.queue.push(partName)
+  return this
+}
+
+PatternDraftQueue.prototype.hasNext = function () {
+  return this.queueIndex < this.queue.length
+}
+
+PatternDraftQueue.prototype.peek = function () {
+  return this.queue[this.queueIndex]
+}
+
+PatternDraftQueue.prototype.next = function () {
+  const next = this.peek()
+  this.queueIndex++
+  return next
+}
+
+/**
+ * Resolves the draft order based on the configuation
+ *
+ * @private
+ * @param {object} graph - The object of resolved dependencies, used to call itself recursively
+ * @return {Pattern} this - The Pattern instance
+ */
+PatternDraftQueue.prototype.__resolveDraftOrder = function () {
+  const partDistances = this.__configResolver.__mutated.partDistance
+  return Object.keys(this.__configResolver.parts).sort(
+    (p1, p2) => partDistances[p2] - partDistances[p1]
+  )
+}

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -1,5 +1,5 @@
 import { Attributes } from './attributes.mjs'
-import pack from 'bin-pack'
+import pack from 'bin-pack-with-constraints'
 import { __addNonEnumProp, __macroName } from './utils.mjs'
 import { Part } from './part.mjs'
 import { Stack } from './stack.mjs'
@@ -72,6 +72,7 @@ Pattern.prototype.addPart = function (part, resolveImmediately = true) {
     this.__configResolver.isPartValid(part) &&
     !this.designConfig.parts.find((p) => p.name == part.name)
   ) {
+    this.store.log.debug(`Adding Part \`${part.name}\` at runtime`)
     this.designConfig.parts.push(part)
     if (resolveImmediately) {
       if (this.__configResolver.addPart(part) && typeof this.draftQueue !== 'undefined')
@@ -922,7 +923,7 @@ Pattern.prototype.__pack = function () {
     }
   }
   if (this.settings[0].layout === true) {
-    let size = pack(bins, { inPlace: true })
+    let size = pack(bins, { inPlace: true, maxWidth: this.settings[0].maxWidth })
     for (let bin of bins) {
       this.autoLayout.stacks[bin.id] = { move: {} }
       let stack = this.stacks[bin.id]

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -67,8 +67,11 @@ export function Pattern(designConfig = {}) {
  * It might be useful to not resolve immediately if a number of parts will be added over multiple calls
  * @return {object} this - The Pattern instance
  */
-Pattern.prototype.addPart = function (part, resolveImmediately = false) {
-  if (this.__configResolver.isPartValid(part) && this.designConfig.parts.indexOf(part) === -1) {
+Pattern.prototype.addPart = function (part, resolveImmediately = true) {
+  if (
+    this.__configResolver.isPartValid(part) &&
+    !this.designConfig.parts.find((p) => p.name == part.name)
+  ) {
     this.designConfig.parts.push(part)
     if (resolveImmediately) {
       if (this.__configResolver.addPart(part) && typeof this.draftQueue !== 'undefined')

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -497,13 +497,13 @@ Pattern.prototype.__init = function () {
  * @return {bool} hidden - true if the part is hidden, or false if not
  */
 Pattern.prototype.__isPartHidden = function (partName) {
+  const partHidden = this.parts?.[this.activeSet]?.[partName]?.hidden || false
   if (Array.isArray(this.settings[this.activeSet || 0].only)) {
-    if (this.settings[this.activeSet || 0].only.includes(partName)) return false
+    if (this.settings[this.activeSet || 0].only.includes(partName)) return partHidden
   }
   if (this.config.partHide?.[partName]) return true
-  if (this.parts?.[this.activeSet]?.[partName]?.hidden) return true
 
-  return false
+  return partHidden
 }
 
 /**

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -500,10 +500,7 @@ Pattern.prototype.__isPartHidden = function (partName) {
   if (Array.isArray(this.settings[this.activeSet || 0].only)) {
     if (this.settings[this.activeSet || 0].only.includes(partName)) return false
   }
-  if (this.config.parts?.[partName]?.hide) return true
-  if (this.config.parts?.[partName]?.hideAll) return true
   if (this.config.partHide?.[partName]) return true
-  if (this.config.partHideAll?.[partName]) return true
   if (this.parts?.[this.activeSet]?.[partName]?.hidden) return true
 
   return false

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -73,11 +73,14 @@ export function Pattern(designConfig) {
  * @param {object} part - The part to add
  * @return {object} this - The Pattern instance
  */
-Pattern.prototype.addPart = function (part) {
+Pattern.prototype.addPart = function (part, resolveImmediately = false) {
   if (typeof part?.draft === 'function') {
     if (part.name) {
       this.designConfig.parts.push(part)
-      this.__initialized = false
+      if (resolveImmediately) {
+        this.store.log.debug(`Perfoming runtime resolution of new part ${part.name}`)
+        this.__resolvePart([part])
+      } else this.__initialized = false
     } else this.store.log.error(`Part must have a name`)
   } else this.store.log.error(`Part must have a draft() method`)
 

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -11,7 +11,7 @@ import { Store } from './store.mjs'
 import { Hooks } from './hooks.mjs'
 import { version } from '../data.mjs'
 import { __loadPatternDefaults } from './config.mjs'
-import { PatternConfig, getPluginName } from './patternConfig.mjs'
+import { PatternConfig, getPluginName } from './pattern-config.mjs'
 import cloneDeep from 'lodash.clonedeep'
 
 //////////////////////////////////////////////
@@ -814,11 +814,7 @@ Pattern.prototype.__needs = function (partName, set = 0) {
   // Walk the only parts, checking each one for a match in its dependencies
   for (const part of only) {
     if (part === partName) return true
-    if (this.config.resolvedDependencies[part]) {
-      for (const dependency of this.config.resolvedDependencies[part]) {
-        if (dependency === partName) return true
-      }
-    }
+    if (this.config.resolvedDependencies[part]?.indexOf(partName) !== -1) return true
   }
 
   return false

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -920,6 +920,7 @@ Pattern.prototype.__pack = function () {
     }
   }
   if (this.settings[0].layout === true) {
+    // some plugins will add a width constraint to the settings, but we can safely pass undefined if not
     let size = pack(bins, { inPlace: true, maxWidth: this.settings[0].maxWidth })
     for (let bin of bins) {
       this.autoLayout.stacks[bin.id] = { move: {} }
@@ -950,6 +951,11 @@ Pattern.prototype.__pack = function () {
   return this
 }
 
+/**
+ * Gets the configuration for the config resolver and sets it on the pattern
+ * @private
+ * @return  {Pattern} this - The Pattern instance
+ */
 Pattern.prototype.__resolveConfig = function () {
   this.config = this.__configResolver.asConfig()
   return this

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -965,8 +965,6 @@ Pattern.prototype.__resolveConfig = function () {
  * Resolves parts and their dependencies
  *
  * @private
- * @param {int} count - The count is used to call itself recursively
- * @param {int} distance - Keeps track of how far the dependency is from the pattern
  * @return {Pattern} this - The Pattern instance
  */
 Pattern.prototype.__resolveParts = function () {

--- a/packages/core/src/patternConfig.mjs
+++ b/packages/core/src/patternConfig.mjs
@@ -1,0 +1,419 @@
+import { __addNonEnumProp } from './utils.mjs'
+
+export function getPluginName(plugin) {
+  if (Array.isArray(plugin)) {
+    if (plugin[0].name) return plugin[0].name
+    if (plugin[0].plugin.name) return plugin[0].plugin.name
+  } else {
+    if (plugin.name) return plugin.name
+    if (plugin.plugin?.name) return plugin.plugin.name
+  }
+
+  return false
+}
+
+export function PatternConfig(pattern) {
+  this.pattern = pattern
+  this.store = pattern.store
+  __addNonEnumProp(this, 'plugins', { ...(pattern.designConfig.plugins || {}) })
+  __addNonEnumProp(this, 'options', { ...(pattern.designConfig.options || {}) })
+  __addNonEnumProp(this, 'measurements', [...(pattern.designConfig.measurements || [])])
+  __addNonEnumProp(this, 'optionalMeasurements', [
+    ...(pattern.designConfig.optionalMeasurements || []),
+  ])
+  __addNonEnumProp(this, 'inject', {})
+  __addNonEnumProp(this, 'directDependencies', {})
+  __addNonEnumProp(this, 'resolvedDependencies', {})
+  __addNonEnumProp(this, 'parts', {})
+  __addNonEnumProp(this, '__resolvedParts', {})
+  __addNonEnumProp(this, '__mutated', {
+    optionDistance: {},
+    partDistance: {},
+    partHide: {},
+    partHideAll: {},
+  })
+}
+
+const DISTANCE_DEBUG = false
+
+PatternConfig.prototype.validatePart = function (part) {
+  if (typeof part?.draft !== 'function') {
+    this.store.log.error(`Part must have a draft() method`)
+    return false
+  }
+
+  if (!part.name) {
+    this.store.log.error(`Part must have a name`)
+    return false
+  }
+
+  return true
+}
+PatternConfig.prototype.addPart = function (part) {
+  if (this.validatePart(part)) this.__resolvePart([part])
+
+  return this
+}
+
+PatternConfig.prototype.logPartDistances = function () {
+  for (const partName in this.parts) {
+    let qualifier = DISTANCE_DEBUG ? 'final' : ''
+    this.store.log.debug(
+      `⚪️  \`${partName}\` ${qualifier} options priority is __${this.__mutated.partDistance[partName]}__`
+    )
+  }
+}
+
+PatternConfig.prototype.asConfig = function () {
+  return {
+    parts: this.parts,
+    plugins: this.plugins,
+    measurements: this.measurements,
+    options: this.options,
+    optionalMeasurements: this.optionalMeasurements,
+    resolvedDependencies: this.resolvedDependencies,
+    directDependencies: this.directDependencies,
+    inject: this.inject,
+    draftOrder: this.__resolveDraftOrder(),
+    partHide: this.__mutated.partHide,
+    partHideAll: this.__mutated.partHideAll,
+  }
+}
+
+PatternConfig.prototype.__resolvePart = function (depChain, distance = 0) {
+  const part = depChain[0]
+  if (distance === 0) {
+    this.parts[part.name] = Object.freeze(part)
+  }
+  distance++
+  if (typeof this.__mutated.partDistance[part.name] === 'undefined') {
+    this.__mutated.partDistance[part.name] = distance
+
+    if (DISTANCE_DEBUG)
+      this.store.log.debug(
+        `Base partDistance for \`${part.name}\` is __${this.__mutated.partDistance[part.name]}__`
+      )
+  }
+
+  // Hide when hideAll is set
+  if (part.hideAll) {
+    this.__mutated.partHide[part.name] = true
+  }
+
+  this.__resolvePartDependencies(depChain, distance)
+
+  // add the part's config
+  this.__addPartConfig(part)
+}
+
+/**
+ * Resolves/Adds a part's design configuration to the pattern config
+ *
+ * @private
+ * @param {Part} part - The part of which to resolve the config
+ * @param {onject} config - The global config
+ * @param {Store} store - The store, used for logging
+ * @return {object} config - The mutated global config
+ */
+PatternConfig.prototype.__addPartConfig = function (part) {
+  if (this.__resolvedParts[part.name]) return this
+
+  // Add parts, using set to keep them unique in the array
+  // this.designConfig.parts = [...new Set(this.designConfig.parts).add(part)]
+
+  return this.__addPartOptions(part)
+    .__addPartMeasurements(part, true)
+    .__addPartMeasurements(part, false)
+    .__addPartPlugins(part)
+}
+
+/**
+ * Resolves/Adds a part's configured options to the global config
+ *
+ * @private
+ * @param {Part} part - The part of which to resolve the config
+ * @return {Pattern} this - The Pattern instance
+ */
+PatternConfig.prototype.__addPartOptions = function (part) {
+  if (!part.options) return this
+
+  const partDistance = this.__mutated.partDistance?.[part.name] || 0
+  for (const optionName in part.options) {
+    const option = part.options[optionName]
+    const optionDistance = this.__mutated.optionDistance[optionName]
+    if (optionDistance && DISTANCE_DEBUG)
+      this.store.log.debug(
+        `optionDistance for __${optionName}__  is __${optionDistance}__ and partDistance for \`${part.name}\` is __${partDistance}__`
+      )
+    if (!optionDistance || optionDistance > partDistance) {
+      this.__mutated.optionDistance[optionName] = partDistance
+      // Keep design parts immutable in the pattern or risk subtle bugs
+      this.options[optionName] = Object.freeze(option)
+      this.store.log.debug(
+        optionDistance
+          ? `🟣  __${optionName}__ option overwritten by \`${part.name}\``
+          : `🔵  __${optionName}__ option loaded from part \`${part.name}\``
+      )
+      this.__loadOptionDefault(optionName, option)
+    }
+  }
+
+  return this
+}
+
+/**
+ * Resolves/Adds a part's configured measurements to the global config
+ *
+ * @private
+ * @param {Part} part - The part of which to resolve the config
+ * @param {array} list - The list of resolved measurements
+ * @return {Pattern} this - The Pattern instance
+ */
+PatternConfig.prototype.__addPartMeasurements = function (part, optional = false) {
+  const listType = optional ? 'optionalMeasurements' : 'measurements'
+  if (part[listType]) {
+    part[listType].forEach((m) => {
+      const isInReqList = this.measurements.indexOf(m) !== -1
+      const optInd = this.optionalMeasurements.indexOf(m)
+      const isInOptList = optInd !== -1
+
+      if (isInReqList) return
+      if (optional && !isInOptList) this.optionalMeasurements.push(m)
+      if (!optional) {
+        this.measurements.push(m)
+
+        if (isInOptList) this.optionalMeasurements.splice(optInd, 1)
+      }
+
+      this.store.log.debug(
+        `🟠  __${m}__ measurement is ${optional ? 'optional' : 'required'} in \`${part.name}\``
+      )
+    })
+  }
+
+  return this
+}
+
+/**
+ * Resolves/Adds a part's configured plugins to the global config
+ *
+ * @private
+ * @param {Part} part - The part of which to resolve the config
+ * @return {Pattern} this - The Pattern instance
+ */
+PatternConfig.prototype.__addPartPlugins = function (part) {
+  if (!part.plugins) return this
+
+  const plugins = this.plugins
+  // Side-step immutability of the part object to ensure plugins is an array
+  let partPlugins = part.plugins
+  if (!Array.isArray(partPlugins)) partPlugins = [partPlugins]
+  // Go through list of part plugins
+  for (let plugin of partPlugins) {
+    const name = getPluginName(plugin)
+    this.store.log.debug(
+      plugin.plugin
+        ? `🔌  Resolved __${name}__ conditional plugin in \`${part.name}\``
+        : `🔌  Resolved __${name}__ plugin in \`${part.name}\``
+    )
+    // Handle [plugin, data] scenario
+    if (Array.isArray(plugin)) {
+      const pluginObj = { ...plugin[0], data: plugin[1] }
+      plugin = pluginObj
+    }
+    if (!plugins[name]) {
+      // New plugin, so we load it
+      plugins[name] = plugin
+      this.store.log.info(
+        plugin.condition
+          ? `New plugin conditionally added: \`${name}\``
+          : `New plugin added: \`${name}\``
+      )
+    } else {
+      // Existing plugin, takes some more work
+      if (plugin.plugin && plugin.condition) {
+        // Multiple instances of the same plugin with different conditions
+        // will all be added, so we need to change the name.
+        if (plugins[name]?.condition) {
+          plugins[name + '_'] = plugin
+          this.store.log.info(
+            `Plugin \`${name}\` was conditionally added again. Renaming to ${name}_.`
+          )
+        } else
+          this.store.log.info(
+            `Plugin \`${name}\` was requested conditionally, but is already added explicitly. Not loading.`
+          )
+      }
+      // swap from a conditional if needed
+      else if (plugins[name].condition) {
+        plugins[name] = plugin
+        this.store.log.info(`Plugin \`${name}\` was explicitly added. Changing from conditional.`)
+      }
+    }
+  }
+
+  return this
+}
+
+PatternConfig.prototype.__loadOptionDefault = function (optionName, option) {
+  this.pattern.settings.forEach((set) => {
+    if (typeof set.options[optionName] !== 'undefined') return
+    if (typeof option === 'object') {
+      if (typeof option.pct !== 'undefined') set.options[optionName] = option.pct / 100
+      else if (typeof option.mm !== 'undefined') set.options[optionName] = option.mm
+      else if (typeof option.deg !== 'undefined') set.options[optionName] = option.deg
+      else if (typeof option.count !== 'undefined') set.options[optionName] = option.count
+      else if (typeof option.bool !== 'undefined') set.options[optionName] = option.bool
+      else if (typeof option.dflt !== 'undefined') set.options[optionName] = option.dflt
+      else {
+        let err = 'Unknown option type: ' + JSON.stringify(option)
+        this.store.log.error(err)
+        throw new Error(err)
+      }
+    } else set.options[optionName] = option
+  })
+}
+
+PatternConfig.prototype.__resolvePartDependencyChain = function (depChain, dependency, depType) {
+  const part = depChain[0]
+
+  this.parts[dependency.name] = Object.freeze(dependency)
+  this.__addDependency('directDependencies', part, dependency)
+
+  depChain.forEach((c) => this.__addDependency('resolvedDependencies', c, dependency))
+
+  switch (depType) {
+    case 'from':
+      this.__setFromHide(part, part.name, dependency.name)
+      this.inject[part.name] = dependency.name
+      break
+    case 'after':
+      this.__setAfterHide(part, part.name, dependency.name)
+  }
+}
+
+PatternConfig.prototype.__resolveMutatedPartDistance = function (partName) {
+  const proposed_dependent_part_distance = this.__mutated.partDistance[partName] + 1
+  let didChange = false
+  if (!this.directDependencies[partName]) return false
+  this.directDependencies[partName].forEach((dependency) => {
+    if (
+      typeof this.__mutated.partDistance[dependency] === 'undefined' ||
+      this.__mutated.partDistance[dependency] < proposed_dependent_part_distance
+    ) {
+      didChange = true
+      this.__mutated.partDistance[dependency] = proposed_dependent_part_distance
+      this.__resolveMutatedPartDistance(dependency)
+    }
+    if (DISTANCE_DEBUG)
+      this.store.log.debug(
+        `partDistance for \`${dependency}\` is __${this.__mutated.partDistance[dependency]}__`
+      )
+  })
+
+  return didChange
+}
+
+const depTypes = ['from', 'after']
+PatternConfig.prototype.__resolvePartDependencies = function (depChain, distance) {
+  // Resolve part Dependencies. first from then after
+  const part = depChain[0]
+  this.resolvedDependencies[part.name] = this.resolvedDependencies[part.name] || []
+
+  depTypes.forEach((d) => {
+    if (part[d]) {
+      if (DISTANCE_DEBUG) this.store.log.debug(`Processing \`${part.name}\` "${d}:"`)
+
+      const depsOfType = Array.isArray(part[d]) ? part[d] : [part[d]]
+
+      depsOfType.forEach((dot) => {
+        let count = Object.keys(this.parts).length
+        // if any changes resulted from resolving this part mutation
+        this.__resolvePartDependencyChain(depChain, dot, d)
+        // if a new part was added, resolve the part
+        const newCount = Object.keys(this.parts).length
+        if (count < newCount) {
+          this.__resolvePart([dot, ...depChain], distance)
+          count = newCount
+        }
+      })
+    }
+  })
+
+  this.__resolveMutatedPartDistance(part.name)
+}
+
+/**
+ * Adds a part as a simple dependency
+ *
+ * @private
+ * @param {string} name - The name of the dependency
+ * @param {object} part - The part configuration
+ * @param {object} dep - The dependency configuration
+ * @return {object} this - The Pattern instance
+ */
+PatternConfig.prototype.__addDependency = function (dependencyList, part, dep) {
+  this[dependencyList][part.name] = this[dependencyList][part.name] || []
+  if (dependencyList == 'resolvedDependencies' && DISTANCE_DEBUG)
+    this.store.log.debug(`add ${dep.name} to ${part.name} dependencyResolution`)
+  if (this[dependencyList][part.name].indexOf(dep.name) === -1)
+    this[dependencyList][part.name].push(dep.name)
+}
+
+/**
+ * Resolves the draft order based on the configuation
+ *
+ * @private
+ * @param {object} graph - The object of resolved dependencies, used to call itself recursively
+ * @return {Pattern} this - The Pattern instance
+ */
+PatternConfig.prototype.__resolveDraftOrder = function () {
+  this.__draftOrder = Object.keys(this.parts).sort(
+    (p1, p2) => this.__mutated.partDistance[p2] - this.__mutated.partDistance[p1]
+  )
+
+  return this.__draftOrder
+}
+
+/**
+ * Sets visibility of a dependency based on its config
+ *
+ * @private
+ * @param {Part} part - The part of which this is a dependency
+ * @param {string} name - The name of the part
+ * @param {string} depName - The name of the dependency
+ * @param {int} set - The index of the set in the list of settings
+ * @return {Pattern} this - The Pattern instance
+ */
+PatternConfig.prototype.__setFromHide = function (part, name, depName) {
+  if (
+    part.hideDependencies ||
+    part.hideAll ||
+    this.__mutated.partHide[name] ||
+    this.__mutated.partHideAll[name]
+  ) {
+    this.__mutated.partHide[depName] = true
+    this.__mutated.partHideAll[depName] = true
+  }
+
+  return this
+}
+
+/**
+ * Sets visibility of an 'after' dependency based on its config
+ *
+ * @private
+ * @param {Part} part - The part of which this is a dependency
+ * @param {string} name - The name of the part
+ * @param {string} depName - The name of the dependency
+ * @param {int} set - The index of the set in the list of settings
+ * @return {Pattern} this - The Pattern instance
+ */
+PatternConfig.prototype.__setAfterHide = function (part, name, depName) {
+  if (this.__mutated.partHide[name] || this.__mutated.partHideAll[name]) {
+    this.__mutated.partHide[depName] = true
+    this.__mutated.partHideAll[depName] = true
+  }
+
+  return this
+}

--- a/packages/core/src/store.mjs
+++ b/packages/core/src/store.mjs
@@ -38,6 +38,7 @@ export function Store(methods = []) {
       logs.warning.push(...data)
     },
     error: function (...data) {
+      if (typeof window !== 'undefined') console.error(...data)
       logs.error.push(...data)
     },
   }

--- a/packages/core/tests/pattern-init.test.mjs
+++ b/packages/core/tests/pattern-init.test.mjs
@@ -238,6 +238,10 @@ describe('Pattern', () => {
       }
     })
 
+    it(
+      'Pattern.__init() should resolve nested dependencies for multiple parts that depend on the same part'
+    )
+
     // I am aware this does too much for one unit test, but this is to simplify TDD
     // we can split it up later
     it('Pattern.__init() should resolve nested injections', () => {

--- a/packages/core/tests/pattern-init.test.mjs
+++ b/packages/core/tests/pattern-init.test.mjs
@@ -238,9 +238,31 @@ describe('Pattern', () => {
       }
     })
 
-    it(
-      'Pattern.__init() should resolve nested dependencies for multiple parts that depend on the same part'
-    )
+    it('Pattern.__init() should resolve nested dependencies for multiple parts that depend on the same part', () => {
+      const partD = {
+        name: 'test.partD',
+        from: partB,
+        draft: ({ part }) => part,
+      }
+
+      const Pattern = new Design({
+        data: {
+          name: 'test',
+          version: '1.2.3',
+        },
+        parts: [partC, partD],
+      })
+      const pattern = new Pattern()
+      pattern.__init()
+      expect(pattern.config.resolvedDependencies['test.partD']).to.have.members([
+        'test.partA',
+        'test.partB',
+      ])
+      expect(pattern.config.resolvedDependencies['test.partC']).to.have.members([
+        'test.partA',
+        'test.partB',
+      ])
+    })
 
     // I am aware this does too much for one unit test, but this is to simplify TDD
     // we can split it up later

--- a/packages/core/tests/pattern-init.test.mjs
+++ b/packages/core/tests/pattern-init.test.mjs
@@ -324,10 +324,10 @@ describe('Pattern', () => {
       expect(pattern.config.options.optionR.list[1]).to.equal('green')
       expect(pattern.config.options.optionR.list[2]).to.equal('blue')
       // Dependencies
-      expect(pattern.__dependencies.partB[0]).to.equal('partA')
-      expect(pattern.__dependencies.partC[0]).to.equal('partB')
-      expect(pattern.__dependencies.partR[0]).to.equal('partC')
-      expect(pattern.__dependencies.partR[1]).to.equal('partA')
+      expect(pattern.__dependencies.partB).to.include('partA')
+      expect(pattern.__dependencies.partC).to.include('partB')
+      expect(pattern.__dependencies.partR).to.include('partC')
+      expect(pattern.__dependencies.partR).to.include('partA')
       // Inject
       expect(pattern.__inject.partB).to.equal('partA')
       expect(pattern.__inject.partC).to.equal('partB')

--- a/packages/core/tests/pattern-init.test.mjs
+++ b/packages/core/tests/pattern-init.test.mjs
@@ -589,7 +589,7 @@ describe('Pattern', () => {
       expect(pattern.hooks.preRender.length).to.equal(2)
     })
 
-    it('Pattern.__init() should load conditional plugin', () => {
+    it('Pattern.__init() should load conditional plugin if condition is met', () => {
       const plugin = {
         name: 'example',
         version: 1,
@@ -611,7 +611,7 @@ describe('Pattern', () => {
       expect(pattern.hooks.preRender.length).to.equal(1)
     })
 
-    it('Pattern.__init() should not load conditional plugin', () => {
+    it('Pattern.__init() should not load conditional plugin if condition is not mett', () => {
       const plugin = {
         name: 'example',
         version: 1,
@@ -664,6 +664,38 @@ describe('Pattern', () => {
       const design = new Design({ parts: [part] })
       const pattern = new design()
       pattern.draft()
+      expect(pattern.hooks.preRender.length).to.equal(1)
+    })
+
+    it('Pattern.__init() should load a conditional plugin multiple times with different conditions', () => {
+      const plugin1 = {
+        name: 'example1',
+        version: 1,
+        hooks: {
+          preRender: function (svg) {
+            svg.attributes.add('freesewing:plugin-example', 1)
+          },
+        },
+      }
+
+      const condition1 = () => true
+      const condition2 = () => false
+      const part = {
+        name: 'test.part',
+        plugins: [{ plugin: plugin1, condition: condition1 }],
+        draft: (part) => part,
+      }
+      const part2 = {
+        name: 'test.part2',
+        plugins: [{ plugin: plugin1, condition: condition2 }],
+        draft: (part) => part,
+      }
+      const design = new Design({ parts: [part, part2] })
+      const pattern = new design()
+      pattern.__init()
+      expect(pattern.config.plugins).to.be.an('object').that.has.all.keys('example1', 'example1_')
+      expect(pattern.config.plugins.example1.plugin).to.deep.equal(plugin1)
+      expect(pattern.config.plugins.example1_.plugin).to.deep.equal(plugin1)
       expect(pattern.hooks.preRender.length).to.equal(1)
     })
 
@@ -758,6 +790,191 @@ describe('Pattern', () => {
       pattern.use(plugin)
       pattern.draft()
       expect(count).to.equal(2)
+    })
+
+    describe('Hiding parts', () => {
+      const blankDraft = ({ part }) => part
+      const afterPart = {
+        name: 'afterPart',
+        draft: blankDraft,
+      }
+      const fromPart = {
+        name: 'fromPart',
+        draft: blankDraft,
+      }
+      describe('{hide: true}', () => {
+        const mainPart = {
+          name: 'mainPart',
+          after: afterPart,
+          from: fromPart,
+          hide: true,
+          draft: blankDraft,
+        }
+
+        const Test = new Design({
+          name: 'test',
+          parts: [mainPart],
+        })
+
+        const pattern = new Test()
+        pattern.__init()
+
+        it('Should hide the part', () => {
+          expect(pattern.__isPartHidden('mainPart')).to.be.true
+        })
+
+        it("Should not hide the part's dependencies", () => {
+          expect(pattern.__isPartHidden('fromPart')).to.be.false
+          expect(pattern.__isPartHidden('afterPart')).to.be.false
+        })
+
+        describe('Nested Parts', () => {
+          const mainPart = {
+            name: 'mainPart',
+            after: afterPart,
+            from: fromPart,
+            draft: blankDraft,
+          }
+          const grandChild = {
+            name: 'grandChild',
+            from: mainPart,
+            hide: true,
+            draft: blankDraft,
+          }
+          const Test = new Design({
+            name: 'test',
+            parts: [grandChild],
+          })
+
+          const pattern = new Test()
+          pattern.__init()
+
+          it('should not hide nested `from` dependencies', () => {
+            expect(pattern.__isPartHidden('fromPart')).to.be.false
+            expect(pattern.__isPartHidden('mainPart')).to.be.false
+          })
+
+          it('should not hide nested `after` dependencies', () => {
+            expect(pattern.__isPartHidden('afterPart')).to.be.false
+          })
+        })
+      })
+
+      describe('{hideDependencies: true}', () => {
+        const mainPart = {
+          name: 'mainPart',
+          hideDependencies: true,
+          after: afterPart,
+          from: fromPart,
+          draft: blankDraft,
+        }
+        const Test = new Design({
+          name: 'test',
+          parts: [mainPart],
+        })
+
+        const pattern = new Test()
+        pattern.__init()
+
+        it('Should not hide the part', () => {
+          expect(pattern.__isPartHidden('mainPart')).to.be.false
+        })
+        it("Should hide the part's `from` dependencies", () => {
+          expect(pattern.__isPartHidden('fromPart')).to.be.true
+        })
+        it("Should not hide the part's `after` dependencies", () => {
+          expect(pattern.__isPartHidden('afterPart')).to.be.false
+        })
+
+        describe('Nested Parts', () => {
+          const mainPart = {
+            name: 'mainPart',
+            after: afterPart,
+            from: fromPart,
+            draft: blankDraft,
+          }
+          const grandChild = {
+            name: 'grandChild',
+            from: mainPart,
+            hideDependencies: true,
+            draft: blankDraft,
+          }
+          const Test = new Design({
+            name: 'test',
+            parts: [grandChild],
+          })
+
+          const pattern = new Test()
+          pattern.__init()
+
+          it('should hide nested `from` dependencies', () => {
+            expect(pattern.__isPartHidden('fromPart')).to.be.true
+            expect(pattern.__isPartHidden('mainPart')).to.be.true
+          })
+
+          it('should not hide nested `after` dependencies', () => {
+            expect(pattern.__isPartHidden('afterPart')).to.be.false
+          })
+        })
+      })
+
+      describe('{hideAll: true}', () => {
+        const mainPart = {
+          name: 'mainPart',
+          hideAll: true,
+          after: afterPart,
+          from: fromPart,
+          draft: blankDraft,
+        }
+        const Test = new Design({
+          name: 'test',
+          parts: [mainPart],
+        })
+
+        const pattern = new Test()
+        pattern.__init()
+
+        it('Should hide the part', () => {
+          expect(pattern.__isPartHidden('mainPart')).to.be.true
+        })
+        it("Should hide the part's `from` dependencies", () => {
+          expect(pattern.__isPartHidden('fromPart')).to.be.true
+        })
+        it("Should hide the part's `after` dependencies", () => {
+          expect(pattern.__isPartHidden('afterPart')).to.be.true
+        })
+
+        describe('Nested Parts', () => {
+          const mainPart = {
+            name: 'mainPart',
+            after: afterPart,
+            from: fromPart,
+            draft: blankDraft,
+          }
+          const grandChild = {
+            name: 'grandChild',
+            from: mainPart,
+            hideAll: true,
+            draft: blankDraft,
+          }
+          const Test = new Design({
+            name: 'test',
+            parts: [grandChild],
+          })
+
+          const pattern = new Test()
+          pattern.__init()
+
+          it('should hide nested `from` dependencies', () => {
+            expect(pattern.__isPartHidden('fromPart')).to.be.true
+            expect(pattern.__isPartHidden('mainPart')).to.be.true
+          })
+
+          it('should hide nested `after` dependencies', () => {
+            expect(pattern.__isPartHidden('afterPart')).to.be.true
+          })
+        })
+      })
     })
 
     it('Should check whether created parts get the pattern context', () => {

--- a/packages/core/tests/pattern-init.test.mjs
+++ b/packages/core/tests/pattern-init.test.mjs
@@ -111,7 +111,7 @@ describe('Pattern', () => {
       parts: [partC],
     })
     const pattern = new Pattern()
-    pattern.draft()
+    pattern.__init()
 
     it('Pattern.__init() should resolve all measurements', () => {
       expect(
@@ -153,8 +153,8 @@ describe('Pattern', () => {
     })
 
     it('Pattern.__init() should set config data in the store', () => {
-      expect(pattern.setStores[0].get('data.name')).to.equal('test')
-      expect(pattern.setStores[0].get('data.version')).to.equal('1.2.3')
+      expect(pattern.store.get('data.name')).to.equal('test')
+      expect(pattern.store.get('data.version')).to.equal('1.2.3')
     })
 
     it('Pattern.__init() should resolve dependencies', () => {
@@ -179,6 +179,63 @@ describe('Pattern', () => {
       expect(pattern.config.draftOrder[0]).to.equal('test.partA')
       expect(pattern.config.draftOrder[1]).to.equal('test.partB')
       expect(pattern.config.draftOrder[2]).to.equal('test.partC')
+    })
+
+    it('Pattern.__init() should overwrite options from dependencies', () => {
+      const partD = {
+        name: 'test.partD',
+        from: partB,
+        options: {
+          optB: { deg: 25, min: 15, max: 45 },
+        },
+        draft: ({ part }) => part,
+      }
+
+      const Pattern = new Design({
+        data: {
+          name: 'test',
+          version: '1.2.3',
+        },
+        parts: [partD],
+      })
+      const pattern = new Pattern()
+      pattern.__init()
+      for (const [key, value] of Object.entries(partD.options.optB)) {
+        expect(pattern.config.options.optB[key]).to.equal(value)
+      }
+    })
+
+    it('Pattern.__init() should overwrite options from complex dependencies', () => {
+      const partD = {
+        name: 'test.partD',
+        from: partB,
+        options: {
+          optB: { deg: 25, min: 15, max: 45 },
+        },
+        draft: ({ part }) => part,
+      }
+
+      const partE = {
+        name: 'test.partE',
+        from: partD,
+        options: {
+          optB: { deg: 10, min: 15, max: 50 },
+        },
+        draft: ({ part }) => part,
+      }
+
+      const Pattern = new Design({
+        data: {
+          name: 'test',
+          version: '1.2.3',
+        },
+        parts: [partC, partE],
+      })
+      const pattern = new Pattern()
+      pattern.__init()
+      for (const [key, value] of Object.entries(partE.options.optB)) {
+        expect(pattern.config.options.optB[key]).to.equal(value)
+      }
     })
 
     // I am aware this does too much for one unit test, but this is to simplify TDD

--- a/packages/core/tests/pattern-init.test.mjs
+++ b/packages/core/tests/pattern-init.test.mjs
@@ -32,12 +32,12 @@ describe('Pattern', () => {
       expect(typeof pattern.Snippet).to.equal('function')
       expect(typeof pattern.Attributes).to.equal('function')
       expect(typeof pattern.macros).to.equal('object')
-      expect(typeof pattern.__designParts).to.equal('object')
-      expect(typeof pattern.__inject).to.equal('object')
-      expect(typeof pattern.__dependencies).to.equal('object')
-      expect(typeof pattern.__resolvedDependencies).to.equal('object')
-      expect(typeof pattern.__hide).to.equal('object')
-      expect(Array.isArray(pattern.__draftOrder)).to.equal(true)
+      // expect(typeof pattern.__designParts).to.equal('object')
+      // expect(typeof pattern.config.inject).to.equal('object')
+      // expect(typeof pattern.config.directDependencies).to.equal('object')
+      // expect(typeof pattern.__resolvedDependencies).to.equal('object')
+      // expect(typeof pattern.__hide).to.equal('object')
+      // expect(Array.isArray(pattern.__draftOrder)).to.equal(true)
       expect(pattern.width).to.equal(0)
       expect(pattern.height).to.equal(0)
       expect(pattern.is).to.equal('')
@@ -145,7 +145,7 @@ describe('Pattern', () => {
     })
 
     it('Pattern.__init() should resolve parts', () => {
-      expect(pattern.designConfig.parts.length).to.equal(3)
+      expect(Object.keys(pattern.config.parts)).to.have.lengthOf(3)
     })
 
     it('Pattern.__init() should resolve plugins', () => {
@@ -324,14 +324,14 @@ describe('Pattern', () => {
       expect(pattern.config.options.optionR.list[1]).to.equal('green')
       expect(pattern.config.options.optionR.list[2]).to.equal('blue')
       // Dependencies
-      expect(pattern.__dependencies.partB).to.include('partA')
-      expect(pattern.__dependencies.partC).to.include('partB')
-      expect(pattern.__dependencies.partR).to.include('partC')
-      expect(pattern.__dependencies.partR).to.include('partA')
+      expect(pattern.config.directDependencies.partB).to.include('partA')
+      expect(pattern.config.directDependencies.partC).to.include('partB')
+      expect(pattern.config.directDependencies.partR).to.include('partC')
+      expect(pattern.config.directDependencies.partR).to.include('partA')
       // Inject
-      expect(pattern.__inject.partB).to.equal('partA')
-      expect(pattern.__inject.partC).to.equal('partB')
-      expect(pattern.__inject.partR).to.equal('partA')
+      expect(pattern.config.inject.partB).to.equal('partA')
+      expect(pattern.config.inject.partC).to.equal('partB')
+      expect(pattern.config.inject.partR).to.equal('partA')
       // Draft order
       expect(pattern.config.draftOrder[0]).to.equal('partA')
       expect(pattern.config.draftOrder[1]).to.equal('partB')
@@ -472,12 +472,12 @@ describe('Pattern', () => {
       expect(pattern.config.options.optionD.list[1]).to.equal('green')
       expect(pattern.config.options.optionD.list[2]).to.equal('blue')
       // Dependencies
-      expect(pattern.__dependencies.partB[0]).to.equal('partA')
-      expect(pattern.__dependencies.partC[0]).to.equal('partB')
-      expect(pattern.__dependencies.partD[0]).to.equal('partC')
+      expect(pattern.config.directDependencies.partB[0]).to.equal('partA')
+      expect(pattern.config.directDependencies.partC[0]).to.equal('partB')
+      expect(pattern.config.directDependencies.partD[0]).to.equal('partC')
       // Inject
-      expect(pattern.__inject.partB).to.equal('partA')
-      expect(pattern.__inject.partC).to.equal('partB')
+      expect(pattern.config.inject.partB).to.equal('partA')
+      expect(pattern.config.inject.partC).to.equal('partB')
       // Draft order
       expect(pattern.config.draftOrder[0]).to.equal('partA')
       expect(pattern.config.draftOrder[1]).to.equal('partB')

--- a/packages/core/tests/pattern-other.test.mjs
+++ b/packages/core/tests/pattern-other.test.mjs
@@ -54,11 +54,14 @@ describe('Pattern', () => {
       name: 'test',
       draft: ({ part }) => part,
     }
-    const design = new Design({ parts: [test] })
+    const you = {
+      name: 'you',
+      draft: ({ part }) => part,
+    }
+    const design = new Design({ parts: [test, you] })
     const pattern = new design({ only: ['you'] })
     pattern.draft()
-    expect(pattern.setStores[0].logs.debug.length).to.equal(4)
-    expect(pattern.setStores[0].logs.debug[3]).to.equal(
+    expect(pattern.setStores[0].logs.debug).to.include(
       'Part `test` is not needed. Skipping draft and setting hidden to `true`'
     )
   })

--- a/packages/core/tests/pattern-runtime-parts.test.mjs
+++ b/packages/core/tests/pattern-runtime-parts.test.mjs
@@ -22,6 +22,11 @@ describe('Pattern', () => {
       draft: ({ part }) => part,
     }
 
+    describe('with runtime: true, resolveImmediately: true', () => {
+      it('adds the part to the current draft cycle')
+      it('does not add the part to subsequent draft cycles')
+    })
+
     describe('with resolveImmediately: true', () => {
       it('Should add the part to parts object', () => {
         const design = new Design({ parts: [part1] })

--- a/packages/core/tests/pattern-runtime-parts.test.mjs
+++ b/packages/core/tests/pattern-runtime-parts.test.mjs
@@ -1,5 +1,6 @@
 import chai from 'chai'
 import { Design } from '../src/index.mjs'
+import sinon from 'sinon'
 
 const expect = chai.expect
 
@@ -21,11 +22,6 @@ describe('Pattern', () => {
       from: part2,
       draft: ({ part }) => part,
     }
-
-    describe('with runtime: true, resolveImmediately: true', () => {
-      it('adds the part to the current draft cycle')
-      it('does not add the part to subsequent draft cycles')
-    })
 
     describe('with resolveImmediately: true', () => {
       it('Should add the part to parts object', () => {
@@ -151,6 +147,51 @@ describe('Pattern', () => {
 
         pattern.addPart(part3, true)
         expect(pattern.config.options.opt1).to.equal(opt1)
+      })
+
+      describe('during drafting', () => {
+        it('adds the part to the draft queue', () => {
+          const design = new Design({ parts: [part1] })
+          const pattern = new design()
+          pattern.use({
+            name: 'draftTimePartPlugin',
+            hooks: {
+              postPartDraft: (pattern) => {
+                const newPart = {
+                  name: 'newPartTest',
+                  draft: ({ part }) => part,
+                }
+
+                pattern.addPart(newPart)
+              },
+            },
+          })
+
+          pattern.draft()
+          expect(pattern.draftQueue.contains('newPartTest')).to.be.true
+        })
+        it('drafts the part', () => {
+          const design = new Design({ parts: [part1] })
+          const pattern = new design()
+          const part2Draft = ({ part }) => part
+          const draftSpy = sinon.spy(part2Draft)
+          pattern.use({
+            name: 'draftTimePartPlugin',
+            hooks: {
+              postPartDraft: (pattern) => {
+                const newPart = {
+                  name: 'newPartTest',
+                  draft: draftSpy,
+                }
+
+                pattern.addPart(newPart)
+              },
+            },
+          })
+
+          pattern.draft()
+          expect(draftSpy.calledOnce).to.be.true
+        })
       })
     })
 

--- a/packages/core/tests/pattern-runtime-parts.test.mjs
+++ b/packages/core/tests/pattern-runtime-parts.test.mjs
@@ -1,0 +1,101 @@
+import chai from 'chai'
+import { Design } from '../src/index.mjs'
+
+const expect = chai.expect
+
+describe('Pattern', () => {
+  describe('.addPart()', () => {
+    const part1 = {
+      name: 'test',
+      draft: ({ part }) => part,
+    }
+
+    const part2 = {
+      name: 'test2',
+      from: part1,
+      draft: ({ part }) => part,
+    }
+
+    const part3 = {
+      name: 'test3',
+      after: part2,
+      draft: ({ part }) => part,
+    }
+
+    describe('with resolveImmediately: true', () => {
+      it('Should add the part to the internal part object', () => {
+        const design = new Design({ parts: [part1] })
+        const pattern = new design()
+        pattern.__init()
+        pattern.addPart(part2, true)
+        expect(pattern.__designParts.test2).to.equal(part2)
+      })
+
+      it('Should resolve injected dependencies for the new part', () => {
+        const design = new Design({ parts: [part1] })
+        const pattern = new design()
+        pattern.__init()
+        pattern.addPart(part2, true)
+        expect(pattern.__inject.test2).to.equal('test')
+      })
+
+      it('Should resolve all dependencies for the new part', () => {
+        const design = new Design({ parts: [part1] })
+        const pattern = new design()
+        pattern.__init()
+        pattern.addPart(part3, true)
+        expect(pattern.config.resolvedDependencies.test3).to.have.members(['test', 'test2'])
+        expect(pattern.__designParts.test2).to.equal(part2)
+      })
+
+      it('Should add a the measurements for the new part', () => {
+        const design = new Design({ parts: [part1] })
+        const pattern = new design()
+        pattern.__init()
+
+        const part2 = {
+          name: 'test2',
+          measurements: ['neck'],
+          draft: ({ part }) => part,
+        }
+
+        pattern.addPart(part2, true)
+        expect(pattern.config.measurements).to.include('neck')
+      })
+
+      it('Should add the plugins for the new part', () => {
+        const design = new Design({ parts: [part1] })
+        const pattern = new design()
+        pattern.__init()
+
+        const plugin = { name: 'testPlugin' }
+        const part2 = {
+          name: 'test2',
+          plugins: [plugin],
+          draft: ({ part }) => part,
+        }
+
+        pattern.addPart(part2, true)
+        expect(pattern.config.plugins.testPlugin).to.equal(plugin)
+      })
+
+      it('Should add the options for the new part', () => {
+        const design = new Design({ parts: [part1] })
+        const pattern = new design()
+        pattern.__init()
+
+        const opt1 = { pct: 10, min: 0, max: 50 }
+        const part2 = {
+          name: 'test2',
+          options: {
+            opt1,
+          },
+          draft: ({ part }) => part,
+        }
+
+        pattern.addPart(part2, true)
+        expect(pattern.config.options.opt1).to.equal(opt1)
+      })
+    })
+  })
+})

--- a/packages/core/tests/pattern-runtime-parts.test.mjs
+++ b/packages/core/tests/pattern-runtime-parts.test.mjs
@@ -12,31 +12,31 @@ describe('Pattern', () => {
 
     const part2 = {
       name: 'test2',
-      from: part1,
+      after: part1,
       draft: ({ part }) => part,
     }
 
     const part3 = {
       name: 'test3',
-      after: part2,
+      from: part2,
       draft: ({ part }) => part,
     }
 
     describe('with resolveImmediately: true', () => {
-      it('Should add the part to the internal part object', () => {
+      it('Should add the part to parts object', () => {
         const design = new Design({ parts: [part1] })
         const pattern = new design()
         pattern.__init()
         pattern.addPart(part2, true)
-        expect(pattern.__designParts.test2).to.equal(part2)
+        expect(pattern.config.parts.test2).to.equal(part2)
       })
 
       it('Should resolve injected dependencies for the new part', () => {
         const design = new Design({ parts: [part1] })
         const pattern = new design()
         pattern.__init()
-        pattern.addPart(part2, true)
-        expect(pattern.__inject.test2).to.equal('test')
+        pattern.addPart(part3, true)
+        expect(pattern.config.inject.test3).to.equal('test2')
       })
 
       it('Should resolve all dependencies for the new part', () => {
@@ -45,7 +45,7 @@ describe('Pattern', () => {
         pattern.__init()
         pattern.addPart(part3, true)
         expect(pattern.config.resolvedDependencies.test3).to.have.members(['test', 'test2'])
-        expect(pattern.__designParts.test2).to.equal(part2)
+        expect(pattern.config.parts.test2).to.equal(part2)
       })
 
       it('Should add a the measurements for the new part', () => {
@@ -79,7 +79,7 @@ describe('Pattern', () => {
         expect(pattern.config.plugins.testPlugin).to.equal(plugin)
       })
 
-      it('Should add the options for the new part', () => {
+      it('Should resolve the options for the new part', () => {
         const design = new Design({ parts: [part1] })
         const pattern = new design()
         pattern.__init()
@@ -96,6 +96,61 @@ describe('Pattern', () => {
         pattern.addPart(part2, true)
         expect(pattern.config.options.opt1).to.equal(opt1)
       })
+
+      it('Should resolve the dependency options for the new part', () => {
+        const design = new Design({ parts: [part1] })
+        const pattern = new design()
+        pattern.__init()
+
+        const opt1 = { pct: 10, min: 0, max: 50 }
+        const part2 = {
+          name: 'test2',
+          options: {
+            opt1,
+          },
+          draft: ({ part }) => part,
+        }
+
+        const part3 = {
+          name: 'test3',
+          from: part2,
+          draft: ({ part }) => part,
+        }
+
+        pattern.addPart(part3, true)
+        expect(pattern.config.options.opt1).to.equal(opt1)
+      })
+
+      it('Should resolve the overwritten options for the new part', () => {
+        const design = new Design({ parts: [part1] })
+        const pattern = new design()
+        pattern.__init()
+
+        const opt1 = { pct: 10, min: 0, max: 50 }
+        const part2 = {
+          name: 'test2',
+          options: {
+            opt1: { pct: 15, min: 10, max: 55 },
+          },
+          draft: ({ part }) => part,
+        }
+
+        const part3 = {
+          name: 'test3',
+          from: part2,
+          options: {
+            opt1,
+          },
+          draft: ({ part }) => part,
+        }
+
+        pattern.addPart(part3, true)
+        expect(pattern.config.options.opt1).to.equal(opt1)
+      })
+    })
+
+    describe('with resolveImmediately: false', () => {
+      it('does not create duplications in the configuration')
     })
   })
 })

--- a/packages/core/tests/snap.test.mjs
+++ b/packages/core/tests/snap.test.mjs
@@ -42,6 +42,7 @@ describe('Snapped options', () => {
           snap: [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144],
         },
       },
+      draft: ({ part }) => part,
     }
     const design = new Design({ parts: [part] })
     const patternA = new design({ options: { test: 0.13 }, measurements }).draft()
@@ -67,6 +68,7 @@ describe('Snapped options', () => {
           },
         },
       },
+      draft: ({ part }) => part,
     }
     const design = new Design({ parts: [part] })
     const patternA = new design({ options: { test: 0.13 }, measurements, units: 'metric' }).draft()
@@ -94,6 +96,7 @@ describe('Snapped options', () => {
           },
         },
       },
+      draft: ({ part }) => part,
     }
     const design = new Design({ parts: [part] })
     const patternA = new design({

--- a/yarn.lock
+++ b/yarn.lock
@@ -12966,7 +12966,7 @@ lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.13.1.tgz#267a81fbd0881327c46a81c5922606a2cfe336c4"
   integrity sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==
 
-luxon@3.2.1:
+luxon@latest:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.2.1.tgz#14f1af209188ad61212578ea7e3d518d18cee45f"
   integrity sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4750,6 +4750,34 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
+"@sinonjs/commons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
+  integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@10.0.2", "@sinonjs/fake-timers@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz#d10549ed1f423d80639c528b6c7f5a1017747d0c"
+  integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+
+"@sinonjs/samsam@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-7.0.1.tgz#5b5fa31c554636f78308439d220986b9523fc51f"
+  integrity sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
+  integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
+
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
@@ -12259,6 +12287,11 @@ just-diff@^5.0.1:
   resolved "https://registry.yarnpkg.com/just-diff/-/just-diff-5.0.3.tgz#4c9c514dec5526b25ab977590e3c39a0cf271554"
   integrity sha512-a8p80xcpJ6sdurk5PxDKb4mav9MeKjA3zFKZpCWBIfvg8mznfnmb13MKZvlrwJ+Lhis0wM3uGAzE0ArhFHvIcg==
 
+just-extend@^4.0.2:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
 jwa@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
@@ -14337,6 +14370,17 @@ next@13.1.6:
     "@next/swc-win32-ia32-msvc" "13.1.6"
     "@next/swc-win32-x64-msvc" "13.1.6"
 
+nise@^5.1.2:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.4.tgz#491ce7e7307d4ec546f5a659b2efe94a18b4bbc0"
+  integrity sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    "@sinonjs/fake-timers" "^10.0.2"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 nlcst-to-string@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/nlcst-to-string/-/nlcst-to-string-2.0.4.tgz#9315dfab80882bbfd86ddf1b706f53622dc400cc"
@@ -15534,6 +15578,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -18346,6 +18397,18 @@ simple-wcswidth@^1.0.1:
   resolved "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz#8ab18ac0ae342f9d9b629604e54d2aa1ecb018b2"
   integrity sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==
 
+sinon@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-15.0.1.tgz#ce062611a0b131892e2c18f03055b8eb6e8dc234"
+  integrity sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    "@sinonjs/fake-timers" "10.0.2"
+    "@sinonjs/samsam" "^7.0.1"
+    diff "^5.0.0"
+    nise "^5.1.2"
+    supports-color "^7.2.0"
+
 sirv@^1.0.7:
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
@@ -19131,7 +19194,7 @@ supports-color@^5.3.0, supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -19650,7 +19713,7 @@ type-component@0.0.1:
   resolved "https://registry.yarnpkg.com/type-component/-/type-component-0.0.1.tgz#952a6c81c21efd24d13d811d0c8498cb860e1956"
   integrity sha512-mDZRBQS2yZkwRQKfjJvQ8UIYJeBNNWCq+HBNstl9N5s9jZ4dkVYXEGkVPsSCEh5Ld4JM1kmrZTzjnrqSAIQ7dw==
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6254,10 +6254,10 @@ bin-links@^3.0.0:
     rimraf "^3.0.0"
     write-file-atomic "^4.0.0"
 
-bin-pack@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bin-pack/-/bin-pack-1.0.2.tgz#c2a014edbf0bed70a3292062ed46577b96120679"
-  integrity sha512-aOk0SxEon5LF9cMxQFViSKb4qccG6rs7XKyMXIb1J8f8LA2acTIWnHdT0IOTe4gYBbqgjdbuTZ5f+UP+vlh4Mw==
+bin-pack-with-constraints@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bin-pack-with-constraints/-/bin-pack-with-constraints-1.0.1.tgz#47e67b481724a8a5a3644ec9c9ccf881c2725096"
+  integrity sha512-fiPxvZAWuIqLpK79Ov58PztT/ZiGbpDB7usifleilJ/4aqhSx0ivY5kRifESJnR2rq51pScbUJ0LgCebufGJnA==
 
 binary-extensions@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
In preparation for the cutting layout, I've begun refactoring the way we resolve part configurations because right now we resolve all parts at once and trigger a complete re-initialization if any changes are made. We have adding at *runtime* but not really at *draft time* and for all the parts duplication that will be needed in cutting layout I liked the idea of being able to add a part, have it resolve in-cycle, and put itself onto the end of the draft order.

I ended up separating all config resolution into a separate class while I was at it because `Pattern` is doing too many things and the file is getting unmanageably large

The goals of this pull request:

- [x] adding a part with dependencies still 'just works'
- [x] adding a part at runtime also 'just works' without needing intimate knowledge of the `Pattern` class to or having to reinitialize
- [x] to this end, all steps of part resolution happen on a per-part basis rather than in bulk
- [x] fewer recursion cycles to resolve dependencies and draft order (i.e. doing it per-part shouldn't make things less efficient)
- [x] deduplicate internal tracking of part resolution
- [x] minimal changes to expected behavior in public methods and properties of the `Pattern` class (as evidenced by all existing tests passing. Only changing tests that refer to private methods and properties, or are brittle)
- [x] draft order acts as a queue that can be manipulated at draft time without concurrency issues

Current state of the branch should be that all tests pass, so let me know how you feel about the implementation