### PR TITLE
fix(workbench): Change forPrinting background fill to "none". Fixes #2649

### DIFF
--- a/sites/shared/components/workbench/layout/print/index.mjs
+++ b/sites/shared/components/workbench/layout/print/index.mjs
@@ -35,7 +35,7 @@ export const PrintLayout = (props) => {
   } catch (err) {
     console.log(err, props.gist)
   }
-  const bgProps = { fill: 'url(#page)' }
+  const bgProps = { fill: 'none' }
 
   const exportIt = () => {
     setError(false)


### PR DESCRIPTION
I believe that the intention was to have the fill set to `none` and that the previous `url(#page)` was simply left over from some previous implementation. It just happened that the failover behavior for the non-existent `#page` URL was setting fill to `none`, and because of this the issue was not noticeable (except on Safari which handles the failover incorrectly).

I'll request reviews from @joostdecock and @eriese who might have knowledge about why we are currently using the `#page` URL. Perhaps its use is intentional. Or, perhaps it actually is a valid, existent URL that I failed to locate.