### PR TITLE
fix(workbench): Restore missing whole and half interval ticks on ruler

### DIFF
--- a/sites/shared/components/workbench/layout/print/plugin.mjs
+++ b/sites/shared/components/workbench/layout/print/plugin.mjs
@@ -293,6 +293,10 @@ const basePlugin = ({
 
       // get the distance between the smaller ticks on the rule
       const division = (isMetric ? 0.1 : 0.125) / rulerLength
+      // Set up intervals for whole and half units.
+      const wholeInterval = isMetric ? 10 : 8
+      const halfInterval = isMetric ? 5 : 4
+      let tickCounter = 1
       // we're going to go by fraction, so we want to do this up to 1
       for (var d = division; d < 1; d += division) {
         // make a start point
@@ -304,9 +308,10 @@ const basePlugin = ({
         // base tick size on whether this is a major interval or a minor one
         let tick = 1
         // if this tick indicates a whole unit, extra long
-        if (d.toFixed(3) % (1 / rulerLength) === 0) tick = 3
+        if (tickCounter % wholeInterval === 0) tick = 3
         // if this tick indicates half a unit, long
-        else if (d.toFixed(3) % (0.5 / rulerLength) === 0) tick = 2
+        else if (tickCounter % halfInterval === 0) tick = 2
+        tickCounter++
 
         // make a point for the end of the tick
         points[`${rulerName}-ruler-${d}-tick`] = points[`${rulerName}-ruler-${d}-end`].translate(


### PR DESCRIPTION
Due to issues with floating point math imprecision, some of the longer half and whole unit interval ticks are missing on the metric ruler:
![Screenshot 2023-02-24 at 5 31 31 PM](https://user-images.githubusercontent.com/109869956/221328785-7beb5ef5-290b-4fc2-8775-8a5b2c9545d8.png)

(The bug does not appear with the 2-inch imperial ruler that we currently use. However, the bug would appear if different inch lengths were to be used.)

This fix uses whole numbers for the intervals and a counter, and the resulting integer math more reliably detects half and whole unit intervals.