### PR TITLE
fix(simon): Improve positioning for snippets and macros using relative points

### DIFF
--- a/designs/simon/src/back.mjs
+++ b/designs/simon/src/back.mjs
@@ -250,7 +250,7 @@ function simonBack({
     })
     points.title = new Point(points.armhole.x / 4, points.armhole.y)
     macro('title', { at: points.title, nr: 3, title: 'back' })
-    points.logo = points.title.shift(-90, 70)
+    points.logo = new Point(points.armhole.x / 4, points.waistCp2.y)
     snippets.logo = new Snippet('logo', points.logo)
     if (options.boxPleat) {
       paths.boxPleat = new Path()

--- a/designs/simon/src/collar.mjs
+++ b/designs/simon/src/collar.mjs
@@ -102,9 +102,10 @@ function simonCollar({
     paths.help = new Path().move(points.topMid).line(points.bottomMid).attr('class', 'dotted')
 
     // Grainline
+    const grainlineY = (points.bottomMid.y - points.ucTopMid.y) / 2
     macro('grainline', {
-      from: points.bottomMidCp2.shift(90, 10),
-      to: points.bottomMidCp1.shift(90, 10),
+      from: new Point(points.bottomMidCp2.x, grainlineY),
+      to: new Point(points.bottomMidCp1.x, grainlineY),
     })
 
     // Title

--- a/designs/simon/src/front.mjs
+++ b/designs/simon/src/front.mjs
@@ -122,9 +122,10 @@ function simonFront({
   // Complete pattern?
   if (complete) {
     delete paths.cutonfold
+    const grainlineDistance = (points.hem.x - points.cfHem.x) * 0.2
     macro('grainline', {
-      from: points.cfHem.shift(0, 45),
-      to: points.cfNeck.shift(0, 45),
+      from: points.cfHem.shift(0, grainlineDistance),
+      to: points.cfNeck.shift(0, grainlineDistance),
     })
     macro('title', { at: points.title, nr: 'X', title: 'front' })
     macro('sprinkle', {

--- a/designs/simon/src/yoke.mjs
+++ b/designs/simon/src/yoke.mjs
@@ -43,14 +43,14 @@ function simonYoke({
     delete snippets.collarNotch
     delete snippets.shoulderNotch
     snippets.sleevecapNotch = new Snippet('notch', points.armholeYokeSplitPreBoxpleat)
-    points.title = new Point(points.neck.x, points.cbYoke.y / 3)
+    points.title = new Point(points.neck.x, points.cbYoke.y / 2)
     macro('title', { at: points.title, nr: 4, title: 'yoke', scale: 0.8 })
-    points.logo = points.title.shift(-90, 50)
+    points.logo = new Point(-points.neck.x, points.cbYoke.y * 0.6)
     snippets.logo = new Snippet('logo', points.logo)
     snippets.logo.attr('data-scale', 0.8)
 
-    points.grainlineFrom = points.cbYoke.shift(0, 20)
-    points.grainlineTo = points.cbNeck.shift(0, 20)
+    points.grainlineFrom = points.cbYoke.shiftFractionTowards(points.cbNeck, 0.2)
+    points.grainlineTo = points.cbNeck.shiftFractionTowards(points.cbYoke, 0.2)
     macro('grainline', {
       from: points.grainlineFrom,
       to: points.grainlineTo,


### PR DESCRIPTION
Used relative positioning to avoid snippets and macros positioned outside parts when scaled to doll sizes. (Also adjusted the positioning of some elements which were okay but could be improved.)

Before and after screenshots of the SVGs:
![Screenshot 2023-02-27 at 4 22 51 PM](https://user-images.githubusercontent.com/109869956/221721152-d357236c-5a32-4361-9e0c-c0166a391aef.png)
![Screenshot 2023-02-27 at 4 25 39 PM](https://user-images.githubusercontent.com/109869956/221721159-3c398d06-5296-42af-8ac6-82f462cf9606.png)
