### PR TITLE
fix(charlie): Remove duplicated code from two merged PRs

### DIFF
--- a/designs/charlie/src/back.mjs
+++ b/designs/charlie/src/back.mjs
@@ -96,11 +96,6 @@ function draftCharlieBack({
     .curve(points.forkCp2, points.kneeInCp1, points.kneeIn)
     .line(points.floorIn)
 
-  // Helper object holding the inseam path
-  const backInseamPath = new Path()
-    .move(points.fork)
-    .curve(points.forkCp2, points.kneeInCp1, points.floorIn)
-
   // Keep the seat control point vertically between the (lowered) waist and seat line
   points.seatOutCp2.y = points.styleWaistOut.y + points.styleWaistOut.dy(points.seatOut) / 2
 

--- a/designs/charlie/src/front.mjs
+++ b/designs/charlie/src/front.mjs
@@ -58,11 +58,6 @@ function draftCharlieFront({
     .line(points.kneeIn)
     .curve(points.kneeInCp2, points.forkCp1, points.fork)
 
-  // Helper object holding the inseam path
-  const frontInseamPath = new Path()
-    .move(points.floorIn)
-    .curve(points.kneeInCp2, points.forkCp1, points.fork)
-
   // Draw fly J-seam
   const flyBottom = utils.curveIntersectsY(
     points.crotchSeamCurveStart,


### PR DESCRIPTION
Two of my PRs added the same code to Charlie (because each PR was written to be independent, unsure of whether the other PR would be merged). The result was duplicate code. 

This PR removes the duplicate code (the old version that calculated the inseam without `fitKnee=true`).
