### PR TITLE
fix(albert): Remove unused variables to pass eslint

### DIFF
--- a/designs/albert/src/pocket.mjs
+++ b/designs/albert/src/pocket.mjs
@@ -4,8 +4,6 @@ export const pocket = {
   name: 'albert.pocket',
   after: front,
   draft: ({
-    options,
-    measurements,
     Point,
     Path,
     points,
@@ -19,7 +17,6 @@ export const pocket = {
     store,
     part,
   }) => {
-    let apronLength = store.get('apronLength')
     let pocketSize = store.get('pocketSize')
     let hemWidth = store.get('hemWidth')
 


### PR DESCRIPTION
Fixing eslint errors flagged/introduced by my PR:
```
/home/runner/work/freesewing/freesewing/designs/albert/src/pocket.mjs
   7:5  error  'options' is defined but never used               no-unused-vars
   8:5  error  'measurements' is defined but never used          no-unused-vars
  22:9  error  'apronLength' is assigned a value but never used  no-unused-vars

✖ 3 problems (3 errors, 0 warnings)

error Command failed with exit code 1.
```