### PR TITLE
wip(core); Idea to facilitate checking for store methods.

### DIFF
--- a/packages/core/src/store.mjs
+++ b/packages/core/src/store.mjs
@@ -44,10 +44,18 @@ export function Store(methods = []) {
   }
   this.logs = logs
 
+  // Make it easy to figure out whether store has a method available
+  this.hasMethod = {}
+  for (const level in this.log) this.hasMethod[`log.${level}`] = true
+  for (const method of avoid) this.hasMethod[method] = true
+
   for (const [path, method] of methods) {
     if (avoid.indexOf(path) !== -1) {
       this.log.warning(`You cannot overwrite store.${path}()`)
-    } else set(this, path, method)
+    } else {
+      set(this, path, method)
+      this.hasMethod[path] = true
+    }
   }
 
   return this


### PR DESCRIPTION
Calling `store.some.method()` is risky because what if the method is not available (as it's provided by a plugin).

The correct way to handle that is to check whether it's a method:

```js
if (typeof store.some.method === 'function') {
  store.some.method()
}
```

But that will get tired pretty soon.

This proposal implements the following alternative check:

```js
if (store.hasMethod('some.method')) store.some.method()
```

It's just a quick idea, this needs tests and so on.