### PR TITLE
chore (store plugin methods) Change method access to via store only

### DIFF
--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -65,7 +65,6 @@ export const back = {
     measurements,
     log,
     part,
-    addCut,
   }) => {
     // Get to work
     points.cbNeck = new Point(0, measurements.neck * options.backNeckCutout)
@@ -270,7 +269,7 @@ export const back = {
         on: ['armholePitch', 'bustCenter'],
       })
 
-      addCut()
+      if (typeof store.addCut === 'function') store.addCut()
 
       if (sa) paths.sa = paths.saBase.offset(sa).attr('class', 'fabric sa')
 

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -253,6 +253,8 @@ export const back = {
       .close()
       .hide()
 
+    store.cutlist.addCut()
+
     if (complete) {
       points.titleAnchor = new Point(points.hps.x, points.armholePitchCp2.y)
       macro('title', {
@@ -268,8 +270,6 @@ export const back = {
         snippet: 'bnotch',
         on: ['armholePitch', 'bustCenter'],
       })
-
-      if (typeof store.addCut === 'function') store.addCut()
 
       if (sa) paths.sa = paths.saBase.offset(sa).attr('class', 'fabric sa')
 

--- a/designs/carlita/src/front.mjs
+++ b/designs/carlita/src/front.mjs
@@ -18,7 +18,6 @@ function draftCarlitaFront({
   paths,
   Path,
   part,
-  addCut,
 }) {
   /**
    * we're adding half of the proportionate amount of chest east for the bust span
@@ -349,9 +348,9 @@ function draftCarlitaFront({
     .attr('class', 'fabric help')
 
   if (complete) {
-    if (typeof addCut === 'function') {
-      addCut()
-      addCut({ material: 'lining' })
+    if (typeof store.addCut === 'function') {
+      store.addCut()
+      store.addCut({ material: 'lining' })
     }
     snippets.button1Left = new Snippet('button', points.button1Left).attr('data-scale', 2)
     snippets.button1Right = new Snippet('button', points.button1Right).attr('data-scale', 2)

--- a/designs/carlita/src/front.mjs
+++ b/designs/carlita/src/front.mjs
@@ -347,11 +347,10 @@ function draftCarlitaFront({
     .close()
     .attr('class', 'fabric help')
 
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lining' })
+
   if (complete) {
-    if (typeof store.addCut === 'function') {
-      store.addCut()
-      store.addCut({ material: 'lining' })
-    }
     snippets.button1Left = new Snippet('button', points.button1Left).attr('data-scale', 2)
     snippets.button1Right = new Snippet('button', points.button1Right).attr('data-scale', 2)
     snippets.button2Left = new Snippet('button', points.button2Left).attr('data-scale', 2)

--- a/designs/carlita/src/side.mjs
+++ b/designs/carlita/src/side.mjs
@@ -37,11 +37,10 @@ function draftCarlitaSide({
     .line(points.psHem)
   paths.seam = paths.saBase.clone().line(points.hem).close().attr('class', 'fabric')
 
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lining' })
+
   if (complete) {
-    if (typeof store.addCut === 'function') {
-      store.addCut()
-      store.addCut({ material: 'lining' })
-    }
     points.title = points.bustPoint.shiftFractionTowards(points.waist, 0.5)
     macro('title', {
       at: points.title,

--- a/designs/carlita/src/side.mjs
+++ b/designs/carlita/src/side.mjs
@@ -13,7 +13,6 @@ function draftCarlitaSide({
   paths,
   Path,
   part,
-  addCut,
 }) {
   // Give points their original names
   for (let i of store.get('side')) points[i] = points[i + 'Rot2'].clone()
@@ -39,9 +38,9 @@ function draftCarlitaSide({
   paths.seam = paths.saBase.clone().line(points.hem).close().attr('class', 'fabric')
 
   if (complete) {
-    if (typeof addCut === 'function') {
-      addCut()
-      addCut({ material: 'lining' })
+    if (typeof store.addCut === 'function') {
+      store.addCut()
+      store.addCut({ material: 'lining' })
     }
     points.title = points.bustPoint.shiftFractionTowards(points.waist, 0.5)
     macro('title', {

--- a/designs/carlton/src/back.mjs
+++ b/designs/carlton/src/back.mjs
@@ -18,7 +18,6 @@ function draftCarltonBack({
   paths,
   Path,
   part,
-  addCut,
 }) {
   calculateRatios(part)
   // Belt width
@@ -98,10 +97,18 @@ function draftCarltonBack({
     .line(points.bpStart)
     .attr('class', 'dashed')
 
-  addCut()
-  addCut({ cut: 2, material: 'lining' })
+  if (typeof store.addCut === 'function') {
+    store.addCut()
+    store.addCut({ cut: 2, material: 'lining' })
+  }
 
   if (complete) {
+    macro('title', {
+      at: points.title,
+      nr: '2',
+      title: 'back',
+    })
+
     macro('sprinkle', {
       snippet: 'bnotch',
       on: ['shoulder', 'bpTriangleTip'],

--- a/designs/carlton/src/back.mjs
+++ b/designs/carlton/src/back.mjs
@@ -97,10 +97,8 @@ function draftCarltonBack({
     .line(points.bpStart)
     .attr('class', 'dashed')
 
-  if (typeof store.addCut === 'function') {
-    store.addCut()
-    store.addCut({ cut: 2, material: 'lining' })
-  }
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lining' })
 
   if (complete) {
     macro('title', {

--- a/designs/carlton/src/belt.mjs
+++ b/designs/carlton/src/belt.mjs
@@ -49,7 +49,8 @@ function draftCarltonBelt({
     .close()
     .attr('class', 'fabric')
 
-  if (typeof store.addCut === 'function') store.addCut({ cut: 4 })
+  store.cutlist.addCut({ cut: 4 })
+
   if (complete) {
     snippets.button = new Snippet('button', points.button).attr('data-scale', 2)
     points.title = new Point(points.bottomRight.x / 2, points.bottomRight.y / 2)

--- a/designs/carlton/src/belt.mjs
+++ b/designs/carlton/src/belt.mjs
@@ -13,7 +13,6 @@ function draftCarltonBelt({
   paths,
   Path,
   part,
-  addCut,
 }) {
   let length = 1.6 * (store.get('cbToDart') + store.get('dartToSide'))
   let width = store.get('beltWidth')
@@ -50,7 +49,7 @@ function draftCarltonBelt({
     .close()
     .attr('class', 'fabric')
 
-  addCut({ cut: 4 })
+  if (typeof store.addCut === 'function') store.addCut({ cut: 4 })
   if (complete) {
     snippets.button = new Snippet('button', points.button).attr('data-scale', 2)
     points.title = new Point(points.bottomRight.x / 2, points.bottomRight.y / 2)

--- a/designs/carlton/src/chestpocketbag.mjs
+++ b/designs/carlton/src/chestpocketbag.mjs
@@ -12,7 +12,6 @@ function draftCarltonChestPocketBag({
   paths,
   Path,
   part,
-  addCut,
 }) {
   points.topLeft = new Point(0, 0)
   points.bottomRight = new Point(
@@ -44,7 +43,7 @@ function draftCarltonChestPocketBag({
     .line(points.startRight)
     .attr('class', 'lining dashed')
 
-  addCut({ material: 'lining' })
+  if (typeof store.addCut === 'function') store.addCut({ material: 'lining' })
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/chestpocketbag.mjs
+++ b/designs/carlton/src/chestpocketbag.mjs
@@ -43,7 +43,7 @@ function draftCarltonChestPocketBag({
     .line(points.startRight)
     .attr('class', 'lining dashed')
 
-  if (typeof store.addCut === 'function') store.addCut({ material: 'lining' })
+  store.cutlist.addCut({ material: 'lining' })
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/chestpocketwelt.mjs
+++ b/designs/carlton/src/chestpocketwelt.mjs
@@ -30,10 +30,8 @@ function draftCarltonChestPocketWelt({
 
   paths.fold = new Path().move(points.topMid).line(points.bottomMid).attr('class', 'dashed')
 
-  if (typeof store.addCut === 'function') {
-    store.addCut()
-    store.addCut({ material: 'lmhCanvas' })
-  }
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lmhCanvas' })
 
   if (complete) {
     points.title = new Point(points.bottomRight.x / 4, points.bottomRight.y / 2)

--- a/designs/carlton/src/chestpocketwelt.mjs
+++ b/designs/carlton/src/chestpocketwelt.mjs
@@ -11,7 +11,6 @@ function draftCarltonChestPocketWelt({
   paths,
   Path,
   part,
-  addCut,
 }) {
   points.topLeft = new Point(0, 0)
   points.bottomRight = new Point(store.get('chestPocketWidth') * 2, store.get('chestPocketHeight'))
@@ -31,8 +30,10 @@ function draftCarltonChestPocketWelt({
 
   paths.fold = new Path().move(points.topMid).line(points.bottomMid).attr('class', 'dashed')
 
-  addCut()
-  addCut({ material: 'lmhCanvas' })
+  if (typeof store.addCut === 'function') {
+    store.addCut()
+    store.addCut({ material: 'lmhCanvas' })
+  }
 
   if (complete) {
     points.title = new Point(points.bottomRight.x / 4, points.bottomRight.y / 2)

--- a/designs/carlton/src/collar.mjs
+++ b/designs/carlton/src/collar.mjs
@@ -178,6 +178,10 @@ function draftCarltonCollar({
     ._curve(points.topLeftCp, points.topLeft)
   paths.seam = paths.saBase.clone().line(points.standTop).close().attr('class', 'fabric')
 
+  store.cutlist.addCut({ cut: 1 })
+  store.cutlist.addCut({ cut: 1, bias: true })
+  store.cutlist.addCut({ cut: 2, material: 'lining', bias: true, ignoreOnFold: true })
+
   if (complete) {
     // Remove grainline from collarstand part
     delete paths.grainline
@@ -186,12 +190,6 @@ function draftCarltonCollar({
       to: points.standTop,
       grainline: true,
     })
-
-    if (typeof store.addCut === 'function') {
-      store.addCut({ cut: 1 })
-      store.addCut({ cut: 1, bias: true })
-      store.addCut({ cut: 2, material: 'lining', bias: true, ignoreOnFold: true })
-    }
 
     points.title = points.standTopCp.clone()
     macro('title', {

--- a/designs/carlton/src/collar.mjs
+++ b/designs/carlton/src/collar.mjs
@@ -16,7 +16,7 @@ function draftCarltonCollar({
   paths,
   Path,
   part,
-  addCut,
+  store,
 }) {
   // We're going to slash and spread this collar. Slashing first:
   // Divide top in 5 parts
@@ -187,9 +187,11 @@ function draftCarltonCollar({
       grainline: true,
     })
 
-    addCut({ cut: 1 })
-    addCut({ cut: 1, bias: true })
-    addCut({ cut: 2, material: 'lining', bias: true, ignoreOnFold: true })
+    if (typeof store.addCut === 'function') {
+      store.addCut({ cut: 1 })
+      store.addCut({ cut: 1, bias: true })
+      store.addCut({ cut: 2, material: 'lining', bias: true, ignoreOnFold: true })
+    }
 
     points.title = points.standTopCp.clone()
     macro('title', {

--- a/designs/carlton/src/collarstand.mjs
+++ b/designs/carlton/src/collarstand.mjs
@@ -14,7 +14,6 @@ function draftCarltonCollarStand({
   paths,
   Path,
   part,
-  addCut,
 }) {
   let height = measurements.chest * options.collarHeight
   let length = store.get('frontCollarLength') + store.get('backCollarLength')
@@ -46,8 +45,10 @@ function draftCarltonCollarStand({
     .close()
     .attr('class', 'fabric')
 
-  addCut()
-  addCut({ cut: 1, material: 'lmhCanvas' })
+  if (typeof store.addCut === 'function') {
+    store.addCut()
+    store.addCut({ cut: 1, material: 'lmhCanvas' })
+  }
 
   if (complete) {
     points.title = points.bottomLeftCp.clone()

--- a/designs/carlton/src/collarstand.mjs
+++ b/designs/carlton/src/collarstand.mjs
@@ -45,10 +45,8 @@ function draftCarltonCollarStand({
     .close()
     .attr('class', 'fabric')
 
-  if (typeof store.addCut === 'function') {
-    store.addCut()
-    store.addCut({ cut: 1, material: 'lmhCanvas' })
-  }
+  store.cutlist.addCut()
+  store.cutlist.addCut({ cut: 1, material: 'lmhCanvas' })
 
   if (complete) {
     points.title = points.bottomLeftCp.clone()

--- a/designs/carlton/src/cufffacing.mjs
+++ b/designs/carlton/src/cufffacing.mjs
@@ -46,10 +46,8 @@ function draftCarltonCuffFacing({
     .close()
     .attr('class', 'fabric')
 
-  if (typeof store.addCut === 'function') {
-    store.addCut()
-    store.addCut({ cut: 2, material: 'lmhCanvas' })
-  }
+  store.cutlist.addCut()
+  store.cutlist.addCut({ cut: 2, material: 'lmhCanvas' })
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/cufffacing.mjs
+++ b/designs/carlton/src/cufffacing.mjs
@@ -12,7 +12,6 @@ function draftCarltonCuffFacing({
   paths,
   Path,
   part,
-  addCut,
 }) {
   points.topLeft = new Point(0, 0)
   points.bottomRight = new Point(
@@ -47,8 +46,10 @@ function draftCarltonCuffFacing({
     .close()
     .attr('class', 'fabric')
 
-  addCut()
-  addCut({ cut: 2, material: 'lmhCanvas' })
+  if (typeof store.addCut === 'function') {
+    store.addCut()
+    store.addCut({ cut: 2, material: 'lmhCanvas' })
+  }
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/front.mjs
+++ b/designs/carlton/src/front.mjs
@@ -300,7 +300,7 @@ function draftCarltonFront({
     .close()
     .attr('class', 'fabric help')
 
-  if (typeof store.addCut === 'function') store.addCut()
+  store.cutlist.addCut()
 
   if (complete) {
     snippets.button1Left = new Snippet('button', points.button1Left).attr('data-scale', 2)

--- a/designs/carlton/src/front.mjs
+++ b/designs/carlton/src/front.mjs
@@ -19,7 +19,6 @@ function draftCarltonFront({
   paths,
   Path,
   part,
-  addCut,
 }) {
   calculateRatios(part)
 
@@ -301,7 +300,7 @@ function draftCarltonFront({
     .close()
     .attr('class', 'fabric help')
 
-  addCut()
+  if (typeof store.addCut === 'function') store.addCut()
 
   if (complete) {
     snippets.button1Left = new Snippet('button', points.button1Left).attr('data-scale', 2)

--- a/designs/carlton/src/innerpocketbag.mjs
+++ b/designs/carlton/src/innerpocketbag.mjs
@@ -13,7 +13,6 @@ function draftCarltonInnerPocketBag({
   paths,
   Path,
   part,
-  addCut,
 }) {
   points.topLeft = new Point(0, 0)
   points.bottomRight = new Point(
@@ -45,7 +44,7 @@ function draftCarltonInnerPocketBag({
     .line(points.startRight)
     .attr('class', 'lining dashed')
 
-  addCut({ material: 'lining' })
+  if (typeof store.addCut === 'function') store.addCut({ material: 'lining' })
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/innerpocketbag.mjs
+++ b/designs/carlton/src/innerpocketbag.mjs
@@ -44,7 +44,7 @@ function draftCarltonInnerPocketBag({
     .line(points.startRight)
     .attr('class', 'lining dashed')
 
-  if (typeof store.addCut === 'function') store.addCut({ material: 'lining' })
+  store.cutlist.addCut({ material: 'lining' })
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/innerpockettab.mjs
+++ b/designs/carlton/src/innerpockettab.mjs
@@ -11,7 +11,6 @@ function draftCarltonInnerPocketTab({
   paths,
   Path,
   part,
-  addCut,
 }) {
   points.topLeft = new Point(0, 0)
   points.topRight = new Point(store.get('innerPocketWidth') * 1.2, 0)
@@ -31,7 +30,7 @@ function draftCarltonInnerPocketTab({
 
   paths.hint = new Path().move(points.top).line(points.bottom).attr('class', 'lining dashed')
 
-  addCut({ cut: 1, material: 'lining' })
+  if (typeof store.addCut === 'function') store.addCut({ cut: 1, material: 'lining' })
 
   if (complete) {
     points.title = points.top.shiftFractionTowards(points.bottom, 0.5)

--- a/designs/carlton/src/innerpockettab.mjs
+++ b/designs/carlton/src/innerpockettab.mjs
@@ -30,7 +30,7 @@ function draftCarltonInnerPocketTab({
 
   paths.hint = new Path().move(points.top).line(points.bottom).attr('class', 'lining dashed')
 
-  if (typeof store.addCut === 'function') store.addCut({ cut: 1, material: 'lining' })
+  store.cutlist.addCut({ cut: 1, material: 'lining' })
 
   if (complete) {
     points.title = points.top.shiftFractionTowards(points.bottom, 0.5)

--- a/designs/carlton/src/innerpocketwelt.mjs
+++ b/designs/carlton/src/innerpocketwelt.mjs
@@ -49,10 +49,8 @@ function draftCarltonInnerPocketWelt({
     .close()
     .attr('class', 'lashed')
 
-  if (typeof store.addCut === 'function') {
-    store.addCut()
-    store.addCut({ material: 'lmhCanvas' })
-  }
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lmhCanvas' })
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/innerpocketwelt.mjs
+++ b/designs/carlton/src/innerpocketwelt.mjs
@@ -11,7 +11,6 @@ function draftCarltonInnerPocketWelt({
   paths,
   Path,
   part,
-  addCut,
 }) {
   points.topLeft = new Point(0, 0)
   points.bottomRight = new Point(
@@ -50,8 +49,10 @@ function draftCarltonInnerPocketWelt({
     .close()
     .attr('class', 'lashed')
 
-  addCut()
-  addCut({ material: 'lmhCanvas' })
+  if (typeof store.addCut === 'function') {
+    store.addCut()
+    store.addCut({ material: 'lmhCanvas' })
+  }
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/pocket.mjs
+++ b/designs/carlton/src/pocket.mjs
@@ -53,7 +53,7 @@ function draftCarltonPocket({
 
   paths.fold = new Path().move(points.topLeft).line(points.topRight).attr('class', 'fabric dashed')
 
-  if (typeof store.addCut === 'function') store.addCut()
+  store.cutlist.addCut()
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/pocket.mjs
+++ b/designs/carlton/src/pocket.mjs
@@ -12,7 +12,6 @@ function draftCarltonPocket({
   paths,
   Path,
   part,
-  addCut,
 }) {
   points.topLeft = new Point(0, 0)
   points.bottomRight = new Point(store.get('pocketWidth'), store.get('pocketHeight'))
@@ -54,7 +53,7 @@ function draftCarltonPocket({
 
   paths.fold = new Path().move(points.topLeft).line(points.topRight).attr('class', 'fabric dashed')
 
-  addCut()
+  if (typeof store.addCut === 'function') store.addCut()
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/pocketflap.mjs
+++ b/designs/carlton/src/pocketflap.mjs
@@ -45,10 +45,8 @@ function draftCarltonPocketFlap({
 
   paths.seam = paths.seam.line(points.topRight).line(points.topLeft).close().attr('class', 'fabric')
 
-  if (typeof store.addCut === 'function') {
-    store.addCut({ cut: 4 })
-    store.addCut({ material: 'lmhCanvas' })
-  }
+  store.cutlist.addCut({ cut: 4 })
+  store.cutlist.addCut({ material: 'lmhCanvas' })
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/pocketflap.mjs
+++ b/designs/carlton/src/pocketflap.mjs
@@ -12,7 +12,6 @@ function draftCarltonPocketFlap({
   paths,
   Path,
   part,
-  addCut,
 }) {
   points.topLeft = new Point(0, 0)
   points.bottomRight = new Point(store.get('pocketWidth'), store.get('pocketFlapHeight'))
@@ -46,8 +45,10 @@ function draftCarltonPocketFlap({
 
   paths.seam = paths.seam.line(points.topRight).line(points.topLeft).close().attr('class', 'fabric')
 
-  addCut({ cut: 4 })
-  addCut({ material: 'lmhCanvas' })
+  if (typeof store.addCut === 'function') {
+    store.addCut({ cut: 4 })
+    store.addCut({ material: 'lmhCanvas' })
+  }
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/pocketlining.mjs
+++ b/designs/carlton/src/pocketlining.mjs
@@ -12,7 +12,6 @@ function draftCarltonPocketLining({
   paths,
   Path,
   part,
-  addCut,
 }) {
   points.topLeft = points.bottomLeft.shiftFractionTowards(points.topLeft, 0.75)
   points.topRight = new Point(points.bottomRight.x, points.topLeft.y)
@@ -46,7 +45,7 @@ function draftCarltonPocketLining({
 
   delete paths.fold
 
-  addCut({ material: 'lining' })
+  if (typeof store.addCut === 'function') store.addCut({ material: 'lining' })
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/pocketlining.mjs
+++ b/designs/carlton/src/pocketlining.mjs
@@ -45,7 +45,7 @@ function draftCarltonPocketLining({
 
   delete paths.fold
 
-  if (typeof store.addCut === 'function') store.addCut({ material: 'lining' })
+  store.cutlist.addCut({ material: 'lining' })
 
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/carlton/src/tail.mjs
+++ b/designs/carlton/src/tail.mjs
@@ -13,7 +13,6 @@ function draftCarltonTail({
   paths,
   Path,
   part,
-  addCut,
 }) {
   let length = store.get('waistToHem') - store.get('beltWidth') / 2
 
@@ -69,8 +68,10 @@ function draftCarltonTail({
     .line(points.fold5Bottom)
     .attr('class', 'fabric dashed')
 
-  addCut()
-  addCut({ material: 'lining' })
+  if (typeof store.addCut === 'function') {
+    store.addCut()
+    store.addCut({ material: 'lining' })
+  }
 
   if (complete) {
     points.title = points.fold4Top.shiftFractionTowards(points.waistBottom, 0.5)

--- a/designs/carlton/src/tail.mjs
+++ b/designs/carlton/src/tail.mjs
@@ -68,10 +68,8 @@ function draftCarltonTail({
     .line(points.fold5Bottom)
     .attr('class', 'fabric dashed')
 
-  if (typeof store.addCut === 'function') {
-    store.addCut()
-    store.addCut({ material: 'lining' })
-  }
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lining' })
 
   if (complete) {
     points.title = points.fold4Top.shiftFractionTowards(points.waistBottom, 0.5)

--- a/designs/carlton/src/topsleeve.mjs
+++ b/designs/carlton/src/topsleeve.mjs
@@ -54,10 +54,8 @@ function draftCarltonTopSleeve({
     .close()
     .attr('class', 'fabric')
 
-  if (typeof store.addCut === 'function') {
-    store.addCut()
-    store.addCut({ material: 'lining' })
-  }
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lining' })
 
   if (complete) {
     macro('title', {

--- a/designs/carlton/src/topsleeve.mjs
+++ b/designs/carlton/src/topsleeve.mjs
@@ -16,7 +16,6 @@ function draftCarltonTopSleeve({
   Snippet,
   snippets,
   part,
-  addCut,
 }) {
   // Add cuff
   let length = measurements.shoulderToWrist * options.cuffLength
@@ -55,10 +54,17 @@ function draftCarltonTopSleeve({
     .close()
     .attr('class', 'fabric')
 
-  addCut()
-  addCut({ material: 'lining' })
+  if (typeof store.addCut === 'function') {
+    store.addCut()
+    store.addCut({ material: 'lining' })
+  }
 
   if (complete) {
+    macro('title', {
+      at: points.armCenter,
+      nr: 3,
+      title: 'topsleeve',
+    })
     macro('grainline', {
       from: points.boxBottom,
       to: points.top,

--- a/designs/carlton/src/undersleeve.mjs
+++ b/designs/carlton/src/undersleeve.mjs
@@ -50,10 +50,8 @@ function draftCarltonUnderSleeve({
     .close()
     .attr('class', 'fabric')
 
-  if (typeof store.addCut === 'function') {
-    store.addCut()
-    store.addCut({ material: 'lining' })
-  }
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lining' })
 
   if (complete) {
     macro('title', {

--- a/designs/carlton/src/undersleeve.mjs
+++ b/designs/carlton/src/undersleeve.mjs
@@ -15,7 +15,6 @@ function draftCarltonUnderSleeve({
   paths,
   Path,
   part,
-  addCut,
 }) {
   // Add cuff
   let length = measurements.shoulderToWrist * options.cuffLength
@@ -51,9 +50,18 @@ function draftCarltonUnderSleeve({
     .close()
     .attr('class', 'fabric')
 
-  addCut()
-  addCut({ material: 'lining' })
+  if (typeof store.addCut === 'function') {
+    store.addCut()
+    store.addCut({ material: 'lining' })
+  }
+
   if (complete) {
+    macro('title', {
+      at: points.armCenter,
+      nr: 4,
+      title: 'undersleeve',
+    })
+
     macro('grainline', {
       from: points.boxBottom,
       to: new Point(points.top.x, points.usLeftEdge.y),

--- a/markdown/dev/howtos/design/cutlist/en.md
+++ b/markdown/dev/howtos/design/cutlist/en.md
@@ -2,7 +2,7 @@
 title: "Include Cutting Instructions"
 ---
 
-To include cutting instructions with your part, use the [cutlist plugin](/reference/plugins/cutlist) to add the [`addCut` method](/reference/plugins/cutlist#addcut) to your part's [`draft` method](/reference/api/part/draft)
+To include cutting instructions with your part, use the [cutlist plugin](/reference/plugins/cutlist) to add the [`cutlist.addCut` method](/reference/plugins/cutlist#addcut) to your part's [`store`](/reference/api/store/extend)
 
 <Tip>When you use the cutlist plugin, the [grainline plugin](/reference/plugins/grainline) and the [cut on fold plugin](/reference/plugins/cutonfold) will automatically add grain and fold information to the cutting instructions </Tip>
 
@@ -12,7 +12,7 @@ To include cutting instructions with your part, use the [cutlist plugin](/refere
 	<details>
 	<summary>addCut() Parameters</summary>
 
-Pass an object to the `addCut` method with any of the following keys; any you don't provide will be filled with the defaults:
+Pass an object to the `store.cutlist.addCut` method with any of the following keys; any you don't provide will be filled with the defaults:
 
 | Key | Type | Default | Description |
 | :-- | :--- | :------ | :---------- |
@@ -49,9 +49,9 @@ import {pluginCutlist} from '@freesewing/plugin-cutlist'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist],
-	draft: ({part, addCut}) => {
+	draft: ({part, store}) => {
 		// add instructions to cut two mirrored from main fabric
-		addCut()
+		store.cutlist.addCut()
 	}
 }
 ```
@@ -69,9 +69,9 @@ import {pluginCutlist} from '@freesewing/plugin-cutlist'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist],
-	draft: ({part, addCut}) => {
+	draft: ({part, store}) => {
 		// add instructions to cut three identical from lining
-		addCut({cut: 3, material: 'lining', identical: true})
+		store.cutlist.addCut({cut: 3, material: 'lining', identical: true})
 	}
 }
 ```
@@ -85,11 +85,11 @@ import {pluginCutlist} from '@freesewing/plugin-cutlist'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist],
-	draft: ({part, addCut}) => {
+	draft: ({part, store}) => {
 		// add instructions to cut four mirrored from main fabric
-		addCut({cut: 4})
+		store.cutlist.addCut({cut: 4})
 		// add instructions to cut three identical from lining
-		addCut({cut: 3, material: 'lining', identical: true})
+		store.cutlist.addCut({cut: 3, material: 'lining', identical: true})
 	}
 }
 ```
@@ -106,7 +106,7 @@ import {pluginCutonfold} from '@freesewing/plugin-cutonfold'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist, pluginCutonfold],
-	draft: ({part, points, Point, macro, addCut}) => {
+	draft: ({part, points, Point, macro, store}) => {
 		// set the cut on fold line
 		points.p1 = new Point(0, 0)
 		points.p2 = new Point(0, 10)
@@ -115,9 +115,9 @@ const part = {
 		macro('cutonfold', {from: points.p1, to: points.p2})
 
 		// cut two on the fold
-		addCut()
+		store.cutlist.addCut()
 		// cut two, not on the fold
-		addCut({cut: 2, ignoreOnFold: true})
+		store.cutlist.addCut({cut: 2, ignoreOnFold: true})
 	}
 }
 ```
@@ -133,7 +133,7 @@ import {pluginGrainline} from '@freesewing/plugin-grainline'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist, pluginGrainline],
-	draft: ({part, points, Point, macro, addCut}) => {
+	draft: ({part, points, Point, macro, store}) => {
 		// set the cut on fold line
 		points.p1 = new Point(0, 0)
 		points.p2 = new Point(0, 10)
@@ -142,9 +142,9 @@ const part = {
 		macro('grainline', {from: points.p1, to: points.p2})
 
 		// cut two mirrored on the grain
-		addCut()
+		store.cutlist.addCut()
 		// cut two mirrored on the bias
-		addCut({cut: 2, bias: true})
+		store.cutlist.addCut({cut: 2, bias: true})
 	}
 }
 ```

--- a/markdown/dev/reference/api/part/draft/en.md
+++ b/markdown/dev/reference/api/part/draft/en.md
@@ -45,5 +45,3 @@ access the following properties:
 | `Bezier`          | The [bezier-js](https://pomax.github.io/bezierjs/) library's `Bezier` named export |
 || **_Return value_**   |
 | `part`            | Your draft method **must** return this |
-
-<Note> Some plugins, such as the [cutlist plugin](/reference/plugins/cutlist) add additional methods to this object that can be accessed through the same destructuring </Note>

--- a/markdown/dev/reference/api/store/extend/en.md
+++ b/markdown/dev/reference/api/store/extend/en.md
@@ -19,8 +19,10 @@ The single argument should be an Array of methods to add to the
 store. Each entry in the array should be an array itself holding a path in
 dot notation and a method, as such:
 
+The expected first parameter for the method is the `Store` instance.
+
 ```js
-function myCustomMethod() {
+function myCustomMethod(store, ...otherArguments) {
  // Do something clever
 }
 

--- a/markdown/dev/reference/plugins/cutlist/en.md
+++ b/markdown/dev/reference/plugins/cutlist/en.md
@@ -2,7 +2,7 @@
 title: plugin-cutlist
 ---
 
-Published as [@freesewing/plugin-cutlist][1], this plugin provides additional methods to the [part draft function](/reference/api/part/draft) which allow you to configure cutting instructions for your parts.
+Published as [@freesewing/plugin-cutlist][1], this plugin adds additional methods to the [store](/reference/api/store/extend) which allow you to configure cutting instructions for your parts.
 
 <Tip> For an in-depth look at how to add cutting instructions to your part, see our [cutlist how-to](/howtos/design/cutlist) </Tip>
 
@@ -29,16 +29,16 @@ import { pluginCutlist } from '@freesewing/plugin-cutlist'
 
 The cutlist plugin adds the following methods to the part draft method parameter
 
-### addCut
+### store.cutlist.addCut
 
-The `addCut()` method will add a set of cutting instructions for the part
+The `store.cutlist.addCut()` method will add a set of cutting instructions for the part
 
 #### Signature
 ```js
-addCut(Object so)
+store.cutlist.addCut(Object so)
 ````
 
-Pass an object to the `addCut` method with any of the following keys; any you don't provide will be filled with the defaults:
+Pass an object to the `store.cutlist.addCut` method with any of the following keys; any you don't provide will be filled with the defaults:
 
 | Key | Type | Default | Description |
 | :-- | :--- | :------ | :---------- |
@@ -76,11 +76,11 @@ import {pluginCutlist} from '@freesewing/plugin-cutlist'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist],
-	draft: ({part, addCut}) => {
+	draft: ({part, store}) => {
 		// add instructions to cut two from main fabric
-		addCut()
+		store.cutlist.addCut()
 		// add instructions to cut four on the biad from lining
-		addCut({cut: 4, material: 'lining', bias: true, })
+		store.cutlist.addCut({cut: 4, material: 'lining', bias: true, })
 		return part
 	}
 }
@@ -93,24 +93,24 @@ import {pluginCutlist} from '@freesewing/plugin-cutlist'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist],
-	draft: ({part, addCut}) => {
+	draft: ({part, store}) => {
 		// add instructions to 1 from lining
-		addCut({cut: 1, material: 'lining'})
+		store.cutlist.addCut({cut: 1, material: 'lining'})
 		// add instructions to cut 1 on the bias from lining
-		addCut({cut: 1, material: 'lining', bias: true, })
+		store.cutlist.addCut({cut: 1, material: 'lining', bias: true, })
 		return part
 	}
 }
 ```
 
-### removeCut
+### store.cutlist.removeCut
 
-The `removeCut()` method will remove cutting instructions from the part
+The `store.cutlist.removeCut()` method will remove cutting instructions from the part
 
 #### Signature
 
 ```js
-removeCut(String material)
+store.cutlist.removeCut(String material)
 ```
 
 #### Example
@@ -120,24 +120,24 @@ import {pluginCutlist} from '@freesewing/plugin-cutlist'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist],
-	draft: ({part, removeCut}) => {
+	draft: ({part, store}) => {
 		// remove all cutting instructions for all materials
-		removeCut()
+		store.cutlist.removeCut()
 
 		// remove cutting instructions for just one material
-		removeCut('fabric')
+		store.cutlist.removeCut('fabric')
 		return part
 	}
 }
 ```
-### setGrain
+### store.cutlist.setGrain
 
-The `setGrain()` method will record the angle of the grainline annotation. This method is called internally by [`plugin-grainline`](/reference/plugins/grainline) to store information for cutting layout tools. You shouldn't have to call it, but it's there if you need it.
+The `store.cutlist.setGrain()` method will record the angle of the grainline annotation. This method is called internally by [`plugin-grainline`](/reference/plugins/grainline) to store information for cutting layout tools. You shouldn't have to call it, but it's there if you need it.
 
 #### Signature
 
 ```js
-setGrain(Number grainAngle)
+store.cutlist.setGrain(Number grainAngle)
 ```
 
 #### Example
@@ -147,21 +147,21 @@ import {pluginCutlist} from '@freesewing/plugin-cutlist'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist],
-	draft: ({part, setGrain}) => {
+	draft: ({part, store}) => {
 		// set the grainline angle
-		setGrain(0)
+		store.cutlist.setGrain(0)
 		return part
 	}
 }
 ```
 
-### setCutOnFold
-The `setCutOnFold()` method will record the points that make up the cut on fold line. This method is called internally by [`plugin-cutonfold`](/reference/plugins/cutonfold) to store information for cutting layout tools. You shouldn't have to call it, but it's there if you need it.
+### store.cutlist.setCutOnFold
+The `store.cutlist.setCutOnFold()` method will record the points that make up the cut on fold line. This method is called internally by [`plugin-cutonfold`](/reference/plugins/cutonfold) to store information for cutting layout tools. You shouldn't have to call it, but it's there if you need it.
 
 #### Signature
 
 ```js
-setCutOnFold(Point p1, Point p2)
+store.cutlist.setCutOnFold(Point p1, Point p2)
 ```
 
 #### Example
@@ -171,11 +171,11 @@ import {pluginCutlist} from '@freesewing/plugin-cutlist'
 const part = {
 	name: 'example.front',
 	plugins: [pluginCutlist],
-	draft: ({part, points, Point, setCutOnFold}) => {
+	draft: ({part, points, Point, store}) => {
 		// set the cut on fold line
 		points.p1 = new Point(0, 0)
 		points.p2 = new Point(0, 10)
-		setCutOnFold(points.p1, points.p2)
+		store.cutlist.setCutOnFold(points.p1, points.p2)
 		return part
 	}
 }

--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -135,15 +135,6 @@ Part.prototype.shorthand = function () {
     utils: utils,
     Bezier: Bezier,
   }
-  // Add top-level store methods and add a part name parameter
-  const partName = this.name
-  for (const [key, method] of Object.entries(this.context.store)) {
-    if (typeof method === 'function')
-      shorthand[key] = function (...args) {
-        return method(partName, ...args)
-      }
-  }
-
   // We'll need this
   let self = this
 

--- a/packages/core/src/pattern.mjs
+++ b/packages/core/src/pattern.mjs
@@ -160,6 +160,7 @@ Pattern.prototype.createPartForSet = function (partName, set = 0) {
 Pattern.prototype.draftPartForSet = function (partName, set) {
   if (typeof this.config.parts?.[partName]?.draft === 'function') {
     this.activePart = partName
+    this.setStores[set].set('activePart', partName)
     try {
       this.__runHooks('prePartDraft')
       const result = this.config.parts[partName].draft(this.parts[set][partName].shorthand())

--- a/packages/core/tests/store.test.mjs
+++ b/packages/core/tests/store.test.mjs
@@ -74,41 +74,6 @@ describe('Store', () => {
     expect(pattern.setStores[0].get('test.message.info')).to.equal('hello info')
   })
 
-  it('Should make top-level plugin methods available via shorthand', () => {
-    const plugin = {
-      name: 'test',
-      version: 1,
-      store: [
-        [
-          'methodA',
-          function (store, name, msg) {
-            store.set(['test', name, 'a'], msg)
-          },
-        ],
-        [
-          'methodB',
-          function (store, name, msg) {
-            store.set(['test', name, 'b'], msg)
-          },
-        ],
-      ],
-    }
-    const part = {
-      name: 'example_part',
-      plugins: [plugin],
-      draft: ({ methodA, methodB, part }) => {
-        methodA('hello A')
-        methodB('hello B')
-        return part
-      },
-    }
-    const Test = new Design({ parts: [part] })
-    const pattern = new Test()
-    pattern.draft()
-    expect(pattern.setStores[0].get('test.example_part.a')).to.equal('hello A')
-    expect(pattern.setStores[0].get('test.example_part.b')).to.equal('hello B')
-  })
-
   it('Should log a warning when trying to extend a protected method via the constructor', () => {
     const store = new Store([['get', () => false]])
     expect(store.logs.warning.length).to.equal(1)

--- a/plugins/plugin-cutlist/src/index.mjs
+++ b/plugins/plugin-cutlist/src/index.mjs
@@ -5,10 +5,10 @@ export const plugin = {
   name,
   version,
   store: [
-    [['cutlist', 'addCut'], addCut],
-    [['cutlist', 'removeCut'], removeCut],
-    [['cutlist', 'setGrain'], setGrain],
-    [['cutlist', 'setCutOnFold'], setCutOnFold],
+    [['cutlist.addCut'], addCut],
+    [['cutlist.removeCut'], removeCut],
+    [['cutlist.setGrain'], setGrain],
+    [['cutlist.setCutOnFold'], setCutOnFold],
   ],
 }
 

--- a/plugins/plugin-cutlist/src/index.mjs
+++ b/plugins/plugin-cutlist/src/index.mjs
@@ -19,7 +19,6 @@ export const pluginCutlist = plugin
 /**
  * Add a set of cutting instructions for the part
  * @param {Store} store                   the Store
- * @param {string} partName               the name of the part
  * @param {Object} so                     a set of cutting instructions for a material
  * @param {number} so.cut = 2             the number of pieces to cut from the specified fabric
  * @param {string} so.material = fabric   the name of the material to cut from
@@ -27,8 +26,9 @@ export const pluginCutlist = plugin
  * @param {boolean} so.bias = false       should the pieces in these cutting instructions be cut on the bias
  * @param {boolean} so.ignoreOnFold       should these cutting instructions ignore any cutOnFold information set by the part
  */
-function addCut(store, partName, so = {}) {
+function addCut(store, so = {}) {
   const { cut = 2, material = 'fabric', identical = false, bias = false, ignoreOnFold = false } = so
+  const partName = store.get('activePart')
   if (cut === false) {
     if (material === false) store.unset(['cutlist', partName, 'materials'])
     else store.unset(['cutlist', partName, 'materials', material])
@@ -50,12 +50,13 @@ function addCut(store, partName, so = {}) {
 }
 
 /** Method to remove the cut info */
-function removeCut(store, partName, material = false) {
-  return addCut(store, partName, { cut: false, material })
+function removeCut(store, material = false) {
+  return addCut(store, { cut: false, material })
 }
 
 /** Method to add the grain info */
-function setGrain(store, partName, grain = false) {
+function setGrain(store, grain = false) {
+  const partName = store.get('activePart')
   const path = ['cutlist', partName, 'grain']
   if (grain === false) return store.unset(path)
   if (typeof grain !== 'number') {
@@ -66,7 +67,8 @@ function setGrain(store, partName, grain = false) {
 }
 
 /** Method to add the cutOnFold info */
-function setCutOnFold(store, partName, p1, p2) {
+function setCutOnFold(store, p1, p2) {
+  const partName = store.get('activePart')
   const path = ['cutlist', partName, 'cutOnFold']
   if (p1 === false && typeof p2 === 'undefined') {
     return store.unset(path)

--- a/plugins/plugin-cutlist/src/index.mjs
+++ b/plugins/plugin-cutlist/src/index.mjs
@@ -5,10 +5,10 @@ export const plugin = {
   name,
   version,
   store: [
-    ['addCut', addCut],
-    ['removeCut', removeCut],
-    ['setGrain', setGrain],
-    ['setCutOnFold', setCutOnFold],
+    [['cutlist', 'addCut'], addCut],
+    [['cutlist', 'removeCut'], removeCut],
+    [['cutlist', 'setGrain'], setGrain],
+    [['cutlist', 'setCutOnFold'], setCutOnFold],
   ],
 }
 

--- a/plugins/plugin-cutonfold/src/index.mjs
+++ b/plugins/plugin-cutonfold/src/index.mjs
@@ -37,7 +37,7 @@ export const plugin = {
         prefix: 'cutonfold',
         ...so,
       }
-      if (typeof store.cutlist !== undefined) {
+      if (typeof store.cutlist !== 'undefined') {
         store.cutlist.setCutOnFold(so.from, so.to)
         if (so.grainline) store.cutlist.setGrain(so.from.angle(so.to))
       }

--- a/plugins/plugin-cutonfold/src/index.mjs
+++ b/plugins/plugin-cutonfold/src/index.mjs
@@ -18,7 +18,7 @@ export const plugin = {
     },
   },
   macros: {
-    cutonfold: function (so, { points, paths, Path, complete, setCutOnFold, setGrain, scale }) {
+    cutonfold: function (so, { points, paths, Path, complete, store, scale }) {
       if (so === false) {
         delete points.cutonfoldFrom
         delete points.cutonfoldTo
@@ -26,8 +26,8 @@ export const plugin = {
         delete points.cutonfoldVia2
         delete paths.cutonfoldCutonfold
         // setCutOnFold relies on plugin-cutlist
-        if (typeof setCutOnFold === 'function') {
-          setCutOnFold(false) // Restore default
+        if (typeof store.setCutOnFold === 'function') {
+          store.setCutOnFold(false) // Restore default
         }
         return true
       }
@@ -37,9 +37,9 @@ export const plugin = {
         prefix: 'cutonfold',
         ...so,
       }
-      if (typeof setCutOnFold === 'function') {
-        setCutOnFold(so.from, so.to)
-        if (so.grainline) setGrain(so.from.angle(so.to))
+      if (typeof store.setCutOnFold === 'function') {
+        store.setCutOnFold(so.from, so.to)
+        if (so.grainline) store.setGrain(so.from.angle(so.to))
       }
       if (complete) {
         points[so.prefix + 'From'] = so.from.shiftFractionTowards(so.to, so.margin / 100)

--- a/plugins/plugin-cutonfold/src/index.mjs
+++ b/plugins/plugin-cutonfold/src/index.mjs
@@ -37,9 +37,9 @@ export const plugin = {
         prefix: 'cutonfold',
         ...so,
       }
-      if (typeof store.setCutOnFold === 'function') {
-        store.setCutOnFold(so.from, so.to)
-        if (so.grainline) store.setGrain(so.from.angle(so.to))
+      if (typeof store.cutlist !== undefined) {
+        store.cutlist.setCutOnFold(so.from, so.to)
+        if (so.grainline) store.cutlist.setGrain(so.from.angle(so.to))
       }
       if (complete) {
         points[so.prefix + 'From'] = so.from.shiftFractionTowards(so.to, so.margin / 100)

--- a/plugins/plugin-grainline/src/index.mjs
+++ b/plugins/plugin-grainline/src/index.mjs
@@ -24,8 +24,8 @@ export const plugin = {
         delete points.grainlineFrom
         delete points.grainlineTo
         delete paths.grainline
-        if (typeof store.setGrain === 'function') {
-          setGrain(false) // Restoring default
+        if (typeof store.cutlist.setGrain === 'function') {
+          store.cutlist.setGrain(false) // Restoring default
         }
         return true
       }
@@ -34,8 +34,8 @@ export const plugin = {
         ...so,
       }
       // setGrain relies on plugin-cutlist
-      if (typeof store.setGrain === 'function') {
-        store.setGrain(so.from.angle(so.to))
+      if (typeof store.cutlist.setGrain === 'function') {
+        store.cutlist.setGrain(so.from.angle(so.to))
       }
       if (complete) {
         points.grainlineFrom = so.from.shiftFractionTowards(so.to, 0.05)

--- a/plugins/plugin-grainline/src/index.mjs
+++ b/plugins/plugin-grainline/src/index.mjs
@@ -19,12 +19,14 @@ export const plugin = {
     },
   },
   macros: {
-    grainline: function (so = {}, { points, paths, Path, complete, setGrain }) {
+    grainline: function (so = {}, { points, paths, Path, complete, store }) {
       if (so === false) {
         delete points.grainlineFrom
         delete points.grainlineTo
         delete paths.grainline
-        setGrain(90) // Restoring default
+        if (typeof store.setGrain === 'function') {
+          setGrain(false) // Restoring default
+        }
         return true
       }
       so = {
@@ -32,8 +34,8 @@ export const plugin = {
         ...so,
       }
       // setGrain relies on plugin-cutlist
-      if (typeof setGrain === 'function') {
-        setGrain(so.from.angle(so.to))
+      if (typeof store.setGrain === 'function') {
+        store.setGrain(so.from.angle(so.to))
       }
       if (complete) {
         points.grainlineFrom = so.from.shiftFractionTowards(so.to, 0.05)


### PR DESCRIPTION
Destructuring methods added by plugins into the draft method was seeming a little magical. Accessing those methods via the store, and namespacing those methods by the plugin that brought them will hopefully help demystify where those methods came from