### PR TITLE
fix(plugin-cutlist, plugin-test, workbench): Cutting layout-related fixes

### DIFF
--- a/plugins/plugin-cutlist/src/index.mjs
+++ b/plugins/plugin-cutlist/src/index.mjs
@@ -4,10 +4,10 @@ export const plugin = {
   name,
   version,
   store: [
-    [['cutlist.addCut'], addCut],
-    [['cutlist.removeCut'], removeCut],
-    [['cutlist.setGrain'], setGrain],
-    [['cutlist.setCutOnFold'], setCutOnFold],
+    ['cutlist.addCut', addCut],
+    ['cutlist.removeCut', removeCut],
+    ['cutlist.setGrain', setGrain],
+    ['cutlist.setCutOnFold', setCutOnFold],
   ],
 }
 

--- a/plugins/plugin-cutlist/src/index.mjs
+++ b/plugins/plugin-cutlist/src/index.mjs
@@ -42,7 +42,7 @@ function addCut(store, so = {}) {
     return store
   }
   const path = ['cutlist', partName, 'materials', material]
-  const existing = store.get(path) || []
+  const existing = store.get(path, [])
   store.set(path, existing.concat({ cut, identical, bias, ignoreOnFold }))
 
   return store

--- a/plugins/plugin-title/src/index.mjs
+++ b/plugins/plugin-title/src/index.mjs
@@ -79,7 +79,7 @@ export const plugin = {
       }
 
       // Cut List instructions
-      const partCutlist = store.get(['cutlist', part.name])
+      const partCutlist = store.get(['cutlist', part.name], [])
       // if there's a cutlist and it should be included
       if (so.cutlist && partCutlist?.materials) {
         // get the default cutonfold

--- a/sites/shared/components/workbench/layout/cut/plugin-cut-layout.mjs
+++ b/sites/shared/components/workbench/layout/cut/plugin-cut-layout.mjs
@@ -167,9 +167,10 @@ export const cutLayoutPlugin = function (material, grainAngle) {
         if (partGrain === undefined) return
 
         // the amount to rotate is the difference between this part's grain angle (as drafted) and the fabric's grain angle
-        let toRotate = Math.abs(grainAngle - partGrain)
+        let toRotate = grainAngle - partGrain
         // don't over rotate
         if (toRotate >= 180) toRotate -= 180
+        else if (toRotate <= -180) toRotate += 180
         // if there's no difference, don't rotate
         if (toRotate === 0) return
 


### PR DESCRIPTION
1. Corrects the updated cutlist method names to fix the pattern crashes.
> TypeError: Cannot read properties of undefined (reading 'addCut')

2. Prevents these warning messages:
> Store.get(key) on key cutlist,carlton.front,materials,fabric, which is undefined
> Store.get(key) on key cutlist,bent.underSleeve, which is undefined

3. Corrects grainline rotation in the cutting layout. The fix is to allow rotation in both directions, clockwise and counter-clockwise, instead of always rotating in one direction.
Before and after:
![Screenshot 2023-03-19 at 5 47 59 AM](https://user-images.githubusercontent.com/109869956/226177786-89bff7d9-2576-4fe0-8c05-8ff4f83d7d6d.png)
![Screenshot 2023-03-19 at 5 48 44 AM](https://user-images.githubusercontent.com/109869956/226177790-2e68cb44-a4a8-4f73-b1f6-1c13f8436b21.png)

