### PR TITLE
Pattern design tutorial proofreading

### DIFF
--- a/markdown/dev/howtos/ways-to-contribute/proofreading/en.md
+++ b/markdown/dev/howtos/ways-to-contribute/proofreading/en.md
@@ -2,5 +2,5 @@
 title: Proofreading
 ---
 
-You could check the original English text of translations for typos and/or grammar mistakes.
+You could check the original English text or translations for typos and/or grammar mistakes.
 You could propose improvements and watch over a consistent style and tone across FreeSewing’s documentation and written text.

--- a/markdown/dev/tutorials/pattern-design/completing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/completing-the-neck-opening/en.md
@@ -127,7 +127,7 @@ function draftBib({
 </Example>
 
 To add the points, we're using the `Point.flipX()` and `Point.flipY()` methods
-here.  There's a few new Path methods to, like `close()` and `addClass()`.
+here.  There's a few new Path methods too, like `close()` and `addClass()`.
 
 Perhaps you can figure out what they do? If not, both [the Point
 documentation](/reference/api/point/) and [the Path

--- a/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/constructing-the-neck-opening/en.md
@@ -23,7 +23,7 @@ function draftBib({
   points,
   // highlight-start
   measurements,
-  options
+  options,
   // highlight-end
   part,
 }) {

--- a/markdown/dev/tutorials/pattern-design/draft-method/en.md
+++ b/markdown/dev/tutorials/pattern-design/draft-method/en.md
@@ -31,18 +31,18 @@ equivalent:
 <Tabs tabs="Without destructuring, With destructuring">
 <Tab>
 ```design/src/bib.mjs
-function draftBib({ part }) {
+function draftBib(props) {
 
-  return part
+  return props.part
+
 }
 ```
 </Tab>
 <Tab>
 ```design/src/bib.mjs
-function draftBib(props) {
+function draftBib({ part }) {
 
-  return props.part
-
+  return part
 }
 ```
 </Tab>


### PR DESCRIPTION
The example for "without destructuring" was the destructured way it's done in the tutorial, the example for "with destructuring" was the old way to pass in a props object without destructuring. I switched the two so that the "without destructuring" example is of a function without destructuring and the "with destructuring" example is of the preferred destructured function.