### PR TITLE
fix(sites) Missing Path Name Info

### DIFF
--- a/sites/shared/components/workbench/draft/path.mjs
+++ b/sites/shared/components/workbench/draft/path.mjs
@@ -463,7 +463,7 @@ export const pathInfo = (props) => {
             <tbody>
               <Tr>
                 <KeyTd>Name</KeyTd>
-                <ValTd>{bbox.name}</ValTd>
+                <ValTd>{props.pathName}</ValTd>
               </Tr>
               <Tr>
                 <KeyTd>Length</KeyTd>


### PR DESCRIPTION
Problem:
Noticed that the Name catergory in the info box was empty for paths.

Example:
![image](https://user-images.githubusercontent.com/16866285/229846459-dfddcf93-4d3e-43ce-81c3-5c3d09b102ff.png)

Solution:
Change `bbox.name` to `props.pathName`

Fixed:

![image](https://user-images.githubusercontent.com/16866285/229851240-197218a1-dfee-48eb-b3f0-6c6f09eb6cb3.png)


This works with inherted paths as well.