### PR TITLE
fix(sites) Fix Menu Settings sliders and Seam Allowance Default

### DIFF
--- a/sites/shared/components/workbench/menu/core-settings/core-setting-mm.mjs
+++ b/sites/shared/components/workbench/menu/core-settings/core-setting-mm.mjs
@@ -5,7 +5,7 @@ import { ClearIcon } from 'shared/components/icons.mjs'
 
 export const CoreSettingMm = (props) => {
   const { t } = useTranslation(['app', 'settings'])
-  const { dflt, min, max } = props
+  const { dflt, min, max, step, stepIm } = props
   const val = props.gist?.[props.setting]
 
   const [value, setValue] = useState(val)
@@ -22,6 +22,13 @@ export const CoreSettingMm = (props) => {
   const reset = () => {
     setValue(props.dflt)
     props.updateGist([props.setting], props.dflt)
+  }
+
+  let stepVal
+  if (props.gist.units == 'imperial') {
+    stepVal = stepIm
+  } else {
+    stepVal = step
   }
 
   return (
@@ -47,7 +54,7 @@ export const CoreSettingMm = (props) => {
         type="range"
         max={max}
         min={min}
-        step={1}
+        step={stepVal}
         value={value}
         onChange={handleChange}
         className={`

--- a/sites/shared/components/workbench/menu/core-settings/core-setting-mm.mjs
+++ b/sites/shared/components/workbench/menu/core-settings/core-setting-mm.mjs
@@ -47,7 +47,7 @@ export const CoreSettingMm = (props) => {
         type="range"
         max={max}
         min={min}
-        step={0.1}
+        step={1}
         value={value}
         onChange={handleChange}
         className={`

--- a/sites/shared/components/workbench/menu/core-settings/core-setting-sa-mm.mjs
+++ b/sites/shared/components/workbench/menu/core-settings/core-setting-sa-mm.mjs
@@ -26,8 +26,6 @@ export const CoreSettingSaMm = (props) => {
   const handleChange = (evt) => {
     const newVal = parseFloat(evt.target.value)
 
-    setValue(stepVal)
-
     setValue(newVal)
     if (props.gist.saBool)
       props.setGist({

--- a/sites/shared/components/workbench/menu/core-settings/core-setting-sa-mm.mjs
+++ b/sites/shared/components/workbench/menu/core-settings/core-setting-sa-mm.mjs
@@ -5,13 +5,28 @@ import { useTranslation } from 'next-i18next'
 
 export const CoreSettingSaMm = (props) => {
   const { t } = useTranslation(['app', 'settings'])
-  const { dflt, min, max } = props
+  const { dflt, min, max, step, dfltIm, maxIm, stepIm } = props
   const val = props.gist?.[props.setting]
+
+  let dfltVal
+  let maxVal
+  let stepVal
+  if (props.gist.units == 'imperial') {
+    dfltVal = dfltIm
+    maxVal = maxIm
+    stepVal = stepIm
+  } else {
+    dfltVal = dflt
+    maxVal = max
+    stepVal = step
+  }
 
   const [value, setValue] = useState(val)
 
   const handleChange = (evt) => {
     const newVal = parseFloat(evt.target.value)
+
+    setValue(stepVal)
 
     setValue(newVal)
     if (props.gist.saBool)
@@ -23,9 +38,9 @@ export const CoreSettingSaMm = (props) => {
     else props.updateGist(['saMm'], newVal)
   }
   const reset = () => {
-    setValue(dflt)
-    props.updateGist(['saMm'], dflt)
-    props.updateGist(['sa'], dflt)
+    setValue(dfltVal)
+    props.updateGist(['saMm'], dfltVal)
+    props.updateGist(['sa'], dfltVal)
   }
 
   return (
@@ -37,24 +52,24 @@ export const CoreSettingSaMm = (props) => {
           dangerouslySetInnerHTML={{ __html: formatMm(min, props.gist.units) }}
         />
         <span
-          className={`font-bold ${val === dflt ? 'text-secondary-focus' : 'text-accent'}`}
+          className={`font-bold ${val === dfltVal ? 'text-secondary-focus' : 'text-accent'}`}
           dangerouslySetInnerHTML={{ __html: formatMm(val, props.gist.units) }}
         />
         <span
           className="opacity-50"
-          dangerouslySetInnerHTML={{ __html: formatMm(max, props.gist.units) }}
+          dangerouslySetInnerHTML={{ __html: formatMm(maxVal, props.gist.units) }}
         />
       </div>
       <input
         type="range"
-        max={max}
+        max={maxVal}
         min={min}
-        step={1}
+        step={stepVal}
         value={value}
         onChange={handleChange}
         className={`
           range range-sm mt-1
-          ${val === dflt ? 'range-secondary' : 'range-accent'}
+          ${val === dfltVal ? 'range-secondary' : 'range-accent'}
         `}
       />
       <div className="flex flex-row justify-between">
@@ -62,7 +77,7 @@ export const CoreSettingSaMm = (props) => {
         <button
           title={t('reset')}
           className="btn btn-ghost btn-xs text-accent"
-          disabled={val === dflt}
+          disabled={val === dfltVal}
           onClick={reset}
         >
           <ClearIcon />

--- a/sites/shared/components/workbench/menu/core-settings/core-setting-sa-mm.mjs
+++ b/sites/shared/components/workbench/menu/core-settings/core-setting-sa-mm.mjs
@@ -25,6 +25,7 @@ export const CoreSettingSaMm = (props) => {
   const reset = () => {
     setValue(dflt)
     props.updateGist(['saMm'], dflt)
+    props.updateGist(['sa'], dflt)
   }
 
   return (
@@ -48,7 +49,7 @@ export const CoreSettingSaMm = (props) => {
         type="range"
         max={max}
         min={min}
-        step={0.1}
+        step={1}
         value={value}
         onChange={handleChange}
         className={`

--- a/sites/shared/components/workbench/menu/core-settings/index.mjs
+++ b/sites/shared/components/workbench/menu/core-settings/index.mjs
@@ -15,6 +15,10 @@ export const settings = {
     min: 0,
     max: 25,
     dflt: 10,
+    step: 1,
+    maxIm: 25.4,
+    dfltIm: 9.525,
+    stepIm: 1.5875,
   },
   complete: {
     dflt: false,


### PR DESCRIPTION
Problem:
- Seam Allowance and Margin sliders were stepping to intervals between values.
- Seam Allowances would not reset to default after clicking reset button.

Example:
![image](https://user-images.githubusercontent.com/16866285/229858361-26f5b37d-df79-481b-becf-9982f4238a21.png)

^ Seen above the reset button has been clicked, the slider has been updated but the seam allowances has remained as the previous value.

Solution:
- Change step values from `0.1` to `1`
- Add `props.updateGist(['sa'], dflt)` to `const reset`