### PR TITLE
fix(docs): Add warning to curve intersection methods and functions

### DIFF
--- a/markdown/dev/reference/api/path/intersects/en.md
+++ b/markdown/dev/reference/api/path/intersects/en.md
@@ -5,6 +5,13 @@ title: Path.intersects()
 The `Path.intersects()` method returns the Point object(s) where the path
 intersects with a path you pass it.
 
+<Warning>
+This method can sometimes fail to find intersections in some curves
+due to a limitation in an underlying Bézier library.
+Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
+for more information.
+</Warning>
+
 ## Signature
 
 ```

--- a/markdown/dev/reference/api/path/intersects/en.md
+++ b/markdown/dev/reference/api/path/intersects/en.md
@@ -6,10 +6,12 @@ The `Path.intersects()` method returns the Point object(s) where the path
 intersects with a path you pass it.
 
 <Warning>
+
 This method can sometimes fail to find intersections in some curves
 due to a limitation in an underlying Bézier library.
 Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
 for more information.
+
 </Warning>
 
 ## Signature

--- a/markdown/dev/reference/api/path/intersectsx/en.md
+++ b/markdown/dev/reference/api/path/intersectsx/en.md
@@ -5,6 +5,13 @@ title: Path.intersectsX()
 The `Path.intersectsX()` method returns the Point object(s) where the path
 intersects with a given X-value.
 
+<Warning>
+This method can sometimes fail to find intersections in some curves
+due to a limitation in an underlying Bézier library.
+Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
+for more information.
+</Warning>
+
 ## Signature
 
 ```js

--- a/markdown/dev/reference/api/path/intersectsx/en.md
+++ b/markdown/dev/reference/api/path/intersectsx/en.md
@@ -6,10 +6,12 @@ The `Path.intersectsX()` method returns the Point object(s) where the path
 intersects with a given X-value.
 
 <Warning>
+
 This method can sometimes fail to find intersections in some curves
 due to a limitation in an underlying Bézier library.
 Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
 for more information.
+
 </Warning>
 
 ## Signature

--- a/markdown/dev/reference/api/path/intersectsy/en.md
+++ b/markdown/dev/reference/api/path/intersectsy/en.md
@@ -5,6 +5,13 @@ title: Path.intersectsY()
 The `Path.intersectsY()` method returns the Point object(s) where the path
 intersects with a given Y-value.
 
+<Warning>
+This method can sometimes fail to find intersections in some curves
+due to a limitation in an underlying Bézier library.
+Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
+for more information.
+</Warning>
+
 ## Signature
 
 ```js

--- a/markdown/dev/reference/api/path/intersectsy/en.md
+++ b/markdown/dev/reference/api/path/intersectsy/en.md
@@ -6,10 +6,12 @@ The `Path.intersectsY()` method returns the Point object(s) where the path
 intersects with a given Y-value.
 
 <Warning>
+
 This method can sometimes fail to find intersections in some curves
 due to a limitation in an underlying Bézier library.
 Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
 for more information.
+
 </Warning>
 
 ## Signature

--- a/markdown/dev/reference/api/utils/curveintersectsx/en.md
+++ b/markdown/dev/reference/api/utils/curveintersectsx/en.md
@@ -5,11 +5,18 @@ title: utils.curveIntersectsX()
 The `utils.curveIntersectsX()` function finds the point(s) where a curve
 intersects a given X-value.
 
+<Warning>
+This function can sometimes fail to find intersections in some curves
+due to a limitation in an underlying Bézier library.
+Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
+for more information.
+</Warning>
+
 ## Signature
 
 ```js
 array | Point | false utils.curveIntersectsX(
-  Point start, 
+  Point start,
   Point cp1,
   Point cp2,
   Point end,
@@ -32,11 +39,11 @@ multiple intersections are found.
   points.cp1 = new Point(80, 10)
   points.cp2 = new Point(-50, 80)
   points.end = new Point(110, 70)
-  
+
   paths.curve = new Path()
     .move(points.start)
     .curve(points.cp1, points.cp2, points.end)
-  
+
   for (let x of [30, 40]) {
     points["from" + x] = new Point(x, 10)
     points["to" + x] = new Point(x, 80)
@@ -45,12 +52,12 @@ multiple intersections are found.
       .line(points["to" + x])
       .addClass("lining dashed")
   }
-  
+
   snippets.i40 = new Snippet(
     "notch",
     utils.curveIntersectsX(points.start, points.cp1, points.cp2, points.end, 40)
   )
-  
+
   for (let p of utils.curveIntersectsX(
     points.start,
     points.cp1,
@@ -72,4 +79,3 @@ This is a low-level (and faster) variant
 of [`Path.intersectsX()`](/reference/api/path/intersectsx).
 Instead of a path, you describe a single curve by passing the four
 points that describes it.
-

--- a/markdown/dev/reference/api/utils/curveintersectsx/en.md
+++ b/markdown/dev/reference/api/utils/curveintersectsx/en.md
@@ -6,10 +6,12 @@ The `utils.curveIntersectsX()` function finds the point(s) where a curve
 intersects a given X-value.
 
 <Warning>
+
 This function can sometimes fail to find intersections in some curves
 due to a limitation in an underlying Bézier library.
 Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
 for more information.
+
 </Warning>
 
 ## Signature

--- a/markdown/dev/reference/api/utils/curveintersectsy/en.md
+++ b/markdown/dev/reference/api/utils/curveintersectsy/en.md
@@ -5,11 +5,18 @@ title: utils.curveIntersectsY()
 The `utils.curveIntersectsY()` function finds the point(s) where a curve
 intersects a given Y-value.
 
+<Warning>
+This function can sometimes fail to find intersections in some curves
+due to a limitation in an underlying Bézier library.
+Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
+for more information.
+</Warning>
+
 ## Signature
 
 ```js
 array | Point | false utils.curveIntersectsY(
-  Point start, 
+  Point start,
   Point cp1,
   Point cp2,
   Point end,
@@ -32,11 +39,11 @@ multiple intersections are found.
   points.cp1 = new Point(50, 10)
   points.cp2 = new Point(0, 80)
   points.end = new Point(110, 70)
-  
+
   paths.curve = new Path()
     .move(points.start)
     .curve(points.cp1, points.cp2, points.end)
-  
+
   for (let y of [40, 50]) {
     points["from" + y] = new Point(10, y)
     points["to" + y] = new Point(110, y)
@@ -45,12 +52,12 @@ multiple intersections are found.
       .line(points["to" + y])
       .addClass("lining dashed")
   }
-  
+
   snippets.i50 = new Snippet(
     "notch",
     utils.curveIntersectsY(points.start, points.cp1, points.cp2, points.end, 50)
   )
-  
+
   for (let p of utils.curveIntersectsY(
     points.start,
     points.cp1,
@@ -71,5 +78,3 @@ This is a low-level (and faster) variant
 of [`Path.intersectsY()`](/reference/api/path/intersectsy).
 Instead of a path, you describe a single curve by passing the four
 points that describes it.
-
-

--- a/markdown/dev/reference/api/utils/curveintersectsy/en.md
+++ b/markdown/dev/reference/api/utils/curveintersectsy/en.md
@@ -6,10 +6,12 @@ The `utils.curveIntersectsY()` function finds the point(s) where a curve
 intersects a given Y-value.
 
 <Warning>
+
 This function can sometimes fail to find intersections in some curves
 due to a limitation in an underlying Bézier library.
 Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
 for more information.
+
 </Warning>
 
 ## Signature

--- a/markdown/dev/reference/api/utils/curvesintersect/en.md
+++ b/markdown/dev/reference/api/utils/curvesintersect/en.md
@@ -5,6 +5,13 @@ title: utils.curvesIntersect()
 The `utils.curvesIntersect()` function finds the intersections between two curves
 described by 4 points each.
 
+<Warning>
+This function can sometimes fail to find intersections in some curves
+due to a limitation in an underlying Bézier library.
+Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
+for more information.
+</Warning>
+
 ## Signature
 
 ```js
@@ -71,4 +78,3 @@ multiple intersections are found.
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/utils/curvesintersect/en.md
+++ b/markdown/dev/reference/api/utils/curvesintersect/en.md
@@ -6,10 +6,12 @@ The `utils.curvesIntersect()` function finds the intersections between two curve
 described by 4 points each.
 
 <Warning>
+
 This function can sometimes fail to find intersections in some curves
 due to a limitation in an underlying Bézier library.
 Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
 for more information.
+
 </Warning>
 
 ## Signature

--- a/markdown/dev/reference/api/utils/lineintersectscurve/en.md
+++ b/markdown/dev/reference/api/utils/lineintersectscurve/en.md
@@ -6,15 +6,22 @@ The `utils.lineIntersectsCurve()` function finds the intersection between a line
 segment from point `from` to point `to` and a curve described by points
 `start`, `cp1`, `cp2, and `end\`.
 
+<Warning>
+This function can sometimes fail to find intersections in some curves
+due to a limitation in an underlying Bézier library.
+Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
+for more information.
+</Warning>
+
 ## Signature
 
 ```js
 array | false utils.lineIntersectsCurve(
-  Point from, 
-  Point to, 
-  Point start, 
-  Point cp1, 
-  Point cp2, 
+  Point from,
+  Point to,
+  Point start,
+  Point cp1,
+  Point cp2,
   Point end
 )
 ```
@@ -35,7 +42,7 @@ array | false utils.lineIntersectsCurve(
     .move(points.A)
     .curve(points.Acp, points.Bcp, points.B)
   paths.line = new Path().move(points.E).line(points.D)
-  
+
   for (let p of utils.lineIntersectsCurve(
     points.D,
     points.E,
@@ -51,4 +58,3 @@ array | false utils.lineIntersectsCurve(
 }
 ```
 </Example>
-

--- a/markdown/dev/reference/api/utils/lineintersectscurve/en.md
+++ b/markdown/dev/reference/api/utils/lineintersectscurve/en.md
@@ -7,10 +7,12 @@ segment from point `from` to point `to` and a curve described by points
 `start`, `cp1`, `cp2, and `end\`.
 
 <Warning>
+
 This function can sometimes fail to find intersections in some curves
 due to a limitation in an underlying Bézier library.
 Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
 for more information.
+
 </Warning>
 
 ## Signature


### PR DESCRIPTION
To address the situation that Bug #3367 will not be fixed, this PR adds warnings to the documentation for the problem methods/functions.
