### PR TITLE
fix(sites) Counter Option Bug

### DIFF
--- a/sites/shared/components/workbench/inputs/design-option-count.mjs
+++ b/sites/shared/components/workbench/inputs/design-option-count.mjs
@@ -37,7 +37,7 @@ export const DesignOptionCount = (props) => {
   const handleChange = (evt) => {
     const newVal = evt.target.value
     setValue(newVal)
-    props.updateGist(['options', props.option], newVal)
+    props.updateGist(['options', props.option], newVal * 1)
   }
   const reset = () => {
     setValue(count)

--- a/sites/shared/components/workbench/inputs/design-option-count.mjs
+++ b/sites/shared/components/workbench/inputs/design-option-count.mjs
@@ -37,7 +37,7 @@ export const DesignOptionCount = (props) => {
   const handleChange = (evt) => {
     const newVal = evt.target.value
     setValue(newVal)
-    props.updateGist(['options', props.option], newVal * 1)
+    props.updateGist(['options', props.option], parseInt(newVal))
   }
   const reset = () => {
     setValue(count)


### PR DESCRIPTION
When using the counter option I found some weird behaviour when the option is being used in the below example

Example Given:
```
options: {
pleatNumber: { count: 3, min: 1, max: 10, menu: 'style' },
}

for (let i = 0; i < options.pleatNumber + 1; i++) {
points['pleatFromTopS' + i] = paths.straightCurve.shiftAlong(
          pleatKeep + (pleatKeep + pleatLengthStraight) * i
        )
}
```

When the counter slider is updated the code breaks and options.pleatNumber is not registered. This does not occur when the options is not in a for () bracket and functions correctly when this is not the case. 


The solution is to simply times the option by 1

```
options: {
pleatNumber: { count: 3, min: 1, max: 10, menu: 'style' },
}

for (let i = 0; i < options.pleatNumber  * 1 + 1; i++) {
points['pleatFromTopS' + i] = paths.straightCurve.shiftAlong(
          pleatKeep + (pleatKeep + pleatLengthStraight) * i
        )
}
```

However this is not instinctual for the user.  So isntead the change can be made on the site level.

in `sites\shared\components\workbench\inputs\design-option-count.mjs`

Goes from:
```
const handleChange = (evt) => {
    const newVal = evt.target.value
    setValue(newVal)
    props.updateGist(['options', props.option], newVal)
  }

```

Becomes:
```
const handleChange = (evt) => {
    const newVal = evt.target.value
    setValue(newVal)
    props.updateGist(['options', props.option], newVal * 1)
  }

```

This change fixes the bug without affecting the rest of the functionality of the option. It is also important to note that when clicked to (not reset) the default does not display display correctly or update correctly when this bug occurs. I am still preplexed why this bug occurs and how it breaks in such a manner but the solution was simple and easy to add.