### PR TITLE
fix(workbench): renderProps in xray caused error as 'draft' was not part of props

### DIFF
--- a/sites/shared/components/wrappers/workbench.mjs
+++ b/sites/shared/components/wrappers/workbench.mjs
@@ -157,6 +157,7 @@ export const WorkbenchWrapper = ({
     gistReady,
     showInfo: setPopup,
     hasRequiredMeasurements,
+    draft,
   }
   // Required props for layout
   const layoutProps = {


### PR DESCRIPTION
Before:
![Screenshot from 2023-04-08 11-35-26](https://user-images.githubusercontent.com/6039675/230730332-c1d455cb-c456-40eb-9c02-bdba35fc50a7.png)

After:
![Screenshot from 2023-04-08 11-38-00](https://user-images.githubusercontent.com/6039675/230730352-c197f99c-4992-4044-a650-ace3e5256446.png)
