### PR TITLE
DRAFT: fix(workbench): Improve paperless imperial grid appearance

### DIFF
--- a/sites/shared/components/workbench/draft/defs.mjs
+++ b/sites/shared/components/workbench/draft/defs.mjs
@@ -2,28 +2,47 @@ const style = ` style="fill: none; stroke: currentColor;" `
 const grids = {
   imperial: `
       <pattern id="grid" height="25.4" width="25.4" patternUnits="userSpaceOnUse" key="grid">
-        <path class="gridline lg imperial" d="M 0 0 L 0 25.4 L 25.4 25.4" ${style} />
+        <!-- lg: solid lines every 1 inch -->
+        <path class="gridline lg imperial"
+          d="M 0 0 L 0 25.4 L 25.4 25.4"
+          ${style}
+        />
+        <!-- md: dashed lines every 1/2 inch -->
         <path
-          class="gridline lg imperial"
+          class="gridline md imperial"
           d="M 12.7 0 L 12.7 25.4 M 0 12.7 L 25.4 12.7"
           ${style}
         />
+        <!-- sm: small dashed lines every 1/4 inch -->
         <path
           class="gridline sm imperial"
-          d="M 3.175 0 L 3.175 25.4 M 6.32 0 L 6.35 25.4 M 9.525 0 L 9.525 25.4 M 15.875 0 L 15.875 25.4 M 19.05 0 L 19.05 25.4 M 22.225 0 L 22.225 25.4"
+          d="M 6.35 0 L 6.35 25.4 M 19.05 0 L 19.05 25.4"
           ${style}
         />
         <path
           class="gridline sm imperial"
-          d="M 0 3.175 L 25.4 3.175 M 0 6.32 L 25.4 6.35 M 0 9.525 L 25.4 9.525 M 0 15.875 L 25.4 15.875 M 0 19.05 L 25.4 19.05 M 0 22.225 L 25.4 22.225"
+          d="M 0 6.35 L 25.4 6.35 M 0 19.05 L 25.4 19.05"
           ${style}
+        />
+        <!-- xs: dotted lines every 1/8 inch -->
+        <path
+          class="gridline xs imperial"
+          d="M 3.175 0 L 3.175 25.4 M 9.525 0 L 9.525 25.4 M 15.875 0 L 15.875 25.4 M 22.225 0 L 22.225 25.4"
+          class="gridline xs imperial"
+           ${style}
+         />
+        <path
+          class="gridline xs imperial"
+          d="M 0 3.175 L 25.4 3.175 M 0 9.525 L 25.4 9.525 M 0 15.875 L 25.4 15.875 M 0 22.225 L 25.4 22.225"
         />
       </pattern>
       `,
   metric: `
       <pattern id="grid" height="100" width="100" patternUnits="userSpaceOnUse" key="grid">
+        <!-- lg: solid lines every 5 cm -->
         <path class="gridline lg metric" d="M 0 0 L 0 100 L 100 100" ${style} />
-        <path class="gridline metric" d="M 50 0 L 50 100 M 0 50 L 100 50" ${style} />
+        <path class="gridline lg metric" d="M 50 0 L 50 100 M 0 50 L 100 50" ${style} />
+        <!-- sm: dashed lines every 1 cm -->
         <path
           class="gridline sm metric"
           d="M 10 0 L 10 100 M 20 0 L 20 100 M 30 0 L 30 100 M 40 0 L 40 100 M 60 0 L 60 100 M 70 0 L 70 100 M 80 0 L 80 100 M 90 0 L 90 100"
@@ -34,6 +53,7 @@ const grids = {
           d="M 0 10 L 100 10 M 0 20 L 100 20 M 0 30 L 100 30 M 0 40 L 100 40 M 0 60 L 100 60 M 0 70 L 100 70 M 0 80 L 100 80 M 0 90 L 100 90"
           ${style}
         />
+        <!-- xs: small dashed lines every 0.5 cm -->
         <path
           class="gridline xs metric"
           d="M 5 0 L 5 100 M 15 0 L 15 100 M 25 0 L 25 100 M 35 0 L 35 100 M 45 0 L 45 100 M 55 0 L 55 100 M 65 0 L 65 100 M 75 0 L 75 100 M 85 0 L 85 100 M 95 0 L 95 100"

--- a/sites/shared/styles/svg-freesewing-draft.css
+++ b/sites/shared/styles/svg-freesewing-draft.css
@@ -297,11 +297,16 @@ path.gridline.metric.sm {
 path.gridline.metric.xs {
   stroke-dasharray: 1 1;
 }
-path.gridline.imperial {
-  stroke-dasharray: 5 5;
+path.gridline.imperial.md {
+  stroke-width: 0.15 !important;
+  stroke-dasharray: 3 1;
 }
 path.gridline.imperial.sm {
-  stroke-dasharray: 2 2;
+  stroke-width: 0.1 !important;
+  stroke-dasharray: 1 1;
+}
+path.gridline.imperial.xs {
+  stroke-dasharray: 0.1 0.5;
 }
 
 figure.develop.example div.develop {


### PR DESCRIPTION
Currently the imperial grid has large dashed lines at every 1 inch and 1/2 inch and smaller dashed lines at every 1/4 and 1/8 inch. I find it a bit busy and difficult to view. 

For the same 1 inch or 2.5 cm length, the imperial grid has 9 lines while the metric grid has only 6 lines. So, the imperial grid can tends to be more visually dense unless it is lightened.

To try to improve the imperial grid's appearance, this PR:
- Changes the 1 inch lines in the "lg" class to be solid.
- Moves the 1/2 inch lines to a new "md" class, with large dashes.
- Keeps the 1/4 inch lines in the "sm" class, with small dashes.
- Moved the 1/8th inch lines to a new "xs" class, with light dots.
- Added comments to make the code easier to read. 

![Screenshot 2023-04-09 at 7 04 24 AM](https://user-images.githubusercontent.com/109869956/230778811-91d59cf5-8e8e-4db7-bddf-1e702d8eb5ef.png)
![Screenshot 2023-04-09 at 6 57 23 AM](https://user-images.githubusercontent.com/109869956/230778833-5d5c0e3a-60a4-4f96-b569-1b55a0daf483.png)
![Screenshot 2023-04-09 at 7 04 59 AM](https://user-images.githubusercontent.com/109869956/230778819-355be8bb-bab0-477e-b196-ea2c77744571.png)
![Screenshot 2023-04-09 at 6 58 12 AM](https://user-images.githubusercontent.com/109869956/230778840-b6dca4b8-91e6-4d1b-8711-a71c8f4b216d.png)

There was also a small change to metric to add a missing "lg" class to one of the lines, but it did not cause any actual visual changes. This PR does not change the metric grid.

![Screenshot 2023-04-09 at 7 04 34 AM](https://user-images.githubusercontent.com/109869956/230778864-6f656e1f-3ce3-44a6-8d83-4898dd0a6669.png)
![Screenshot 2023-04-09 at 6 57 40 AM](https://user-images.githubusercontent.com/109869956/230778882-4819a363-0d84-457c-a549-96aa7f5b7cd7.png)
![Screenshot 2023-04-09 at 7 04 49 AM](https://user-images.githubusercontent.com/109869956/230778887-5ffec794-67be-47ef-8cc4-75f0b97a7de5.png)
![Screenshot 2023-04-09 at 6 58 00 AM](https://user-images.githubusercontent.com/109869956/230778890-084fff49-0799-418c-bf8d-9ca934118571.png)

