### PR TITLE
Add Missing Cross/Crotch Seam Curve Angle Option Info

### DIFF
--- a/markdown/org/docs/patterns/charlie/options/crossseamcurveangle/en.md
+++ b/markdown/org/docs/patterns/charlie/options/crossseamcurveangle/en.md
@@ -2,7 +2,10 @@
 title: "Cross seam angle"
 ---
 
-Controls the angle of the cross seam curve.
+Controls the angle of cross seam curve.
+
+- 0% makes the cross seam draft parallel to the hem.
+- Increasing this option will draft the cross seam at that angle away from the hem.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/charlie/options/crotchseamcurveangle/en.md
+++ b/markdown/org/docs/patterns/charlie/options/crotchseamcurveangle/en.md
@@ -4,6 +4,9 @@ title: "Crotch seam angle"
 
 Controls the angle of the crotch seam curve.
 
+- 0% makes the crotch seam draft parallel to the hem.
+- Increasing this option will draft the crotch seam at 180 - the angle.
+
 ## Effect of this option on the pattern
 
 ![This image shows the effect of this option by superimposing several variants that have a different value for this option](charlie_crotchseamcurveangle_sample.svg "Effect of this option on the pattern")

--- a/markdown/org/docs/patterns/paco/options/crossseamcurveangle/en.md
+++ b/markdown/org/docs/patterns/paco/options/crossseamcurveangle/en.md
@@ -2,11 +2,10 @@
 title: "Cross seam angle"
 ---
 
-<Fixme>
+Controls the angle of cross seam curve.
 
-Documentation missing
-
-</Fixme>
+- 0% makes the cross seam draft parallel to the hem.
+- Increasing this option will draft the cross seam at that angle away from the hem.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/paco/options/crotchseamcurveangle/en.md
+++ b/markdown/org/docs/patterns/paco/options/crotchseamcurveangle/en.md
@@ -2,11 +2,11 @@
 title: "Crotch seam angle"
 ---
 
-<Fixme>
+Controls the angle of the crotch seam curve.
 
-Documentation missing
+- 0% makes the crotch seam draft parallel to the hem.
+- Increasing this option will draft the crotch seam at 180 - the angle.
 
-</Fixme>
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/titan/options/crossseamcurveangle/en.md
+++ b/markdown/org/docs/patterns/titan/options/crossseamcurveangle/en.md
@@ -2,11 +2,10 @@
 title: "Cross seam angle"
 ---
 
-<Fixme>
+Controls the angle of cross seam curve.
 
-Documentation missing
-
-</Fixme>
+- 0% makes the cross seam draft parallel to the hem.
+- Increasing this option will draft the cross seam at that angle away from the hem.
 
 ## Effect of this option on the pattern
 

--- a/markdown/org/docs/patterns/titan/options/crotchseamcurveangle/en.md
+++ b/markdown/org/docs/patterns/titan/options/crotchseamcurveangle/en.md
@@ -2,11 +2,10 @@
 title: "Crotch seam angle"
 ---
 
-<Fixme>
+Controls the angle of the crotch seam curve.
 
-Documentation missing
-
-</Fixme>
+- 0% makes the crotch seam draft parallel to the hem.
+- Increasing this option will draft the crotch seam at 180 - the angle.
 
 ## Effect of this option on the pattern
 


### PR DESCRIPTION
One of the outstanding on #1342

Was initially going to just do Titan's but thought best to check Paco's and Charlie's. Found some info on Charlies but decided to add a little more info

Added
- Titan options,crossSeamCurveAngle info
- Titan options,crotchSeamCurveAngle info
- Paco options,crossSeamCurveAngle info
- Paco options,crotchSeamCurveAngle info

Updates
- Charlie options,crossSeamCurveAngle info
- Charlie options,crotchSeamCurveAngle info

If the extra info is not accurate I can remove it