### PR TITLE
Sandy Documentation Overhaul

### DIFF
--- a/markdown/org/docs/patterns/sandy/cutting/en.md
+++ b/markdown/org/docs/patterns/sandy/cutting/en.md
@@ -12,8 +12,8 @@ If not using seamless follow the default list, If using seamless follow the seam
 
 - (If default) Cut **1 skirt** part on the fold.
 - (If seamless) Cut **1 skirt** part on double fold.
-- (If default) Cut **2 waistband** parts.
-- (If seamless) Cut **1 waistband** part.
+- (If straight) Cut **1 waistband** part.
+- (If curved) Cut **2 waistband** parts.
 
 **Lining Fabric (Optional)**
 
@@ -22,5 +22,4 @@ If not using seamless follow the default list, If using seamless follow the seam
 
 **Interfacing**
 
-- (If default) Cut **2 waistband** parts.
-- (If seamless) Cut **1 waistband** part.
+- Cut **1 waistband** part.

--- a/markdown/org/docs/patterns/sandy/fabric/en.md
+++ b/markdown/org/docs/patterns/sandy/fabric/en.md
@@ -30,7 +30,7 @@ Need some inspo? check out [Sandy's showcase](/showcase/designs/sandy/) page and
 
 ### Lining Fabric
 
-Linings are optional for Sandy but you made need one if your main fabric is scratchy, sheds, hard to wash or is not nice to wear against skin.
+Linings are optional for Sandy but you may need one if your main fabric is scratchy, sheds, hard to wash or is not nice to wear against skin.
 You will want to use lighter fabrics to reduce bulk such as lightweight **Cottons** and **Silks**.
 
 <Note>

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -41,7 +41,7 @@ If you do not wish to create additional seams but still wish to have pockets, yo
 
 Skip this step if:
 - You are including the zipper in the waistband.
-- You are making a seamless version
+- You are making a seamless version.
 
 </Note>
 

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -71,7 +71,7 @@ There will be some overhangs:
 - If using a zipper in the waistband the greater overhang will need to be trimmed to the seam allowance.
 
 __Inserting Zipper in Waistband__
-- If inserting a zipper into the waistband now is the time to do so, attach the zipper from the waistband fold line down. Or for from seam-line down for curved waistband.
+- If inserting a zipper into the waistband now is the time to do so, attach the zipper from the waistband fold line down. Or from seam-line down for curved waistband.
 - _Slipstich_ or _Whipstitch_ the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
 - Press under overhangs.  
 - Press the waistband _wrong sides together_ along fold-line. Or along seam-line for curved waistband.

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -35,7 +35,7 @@ If you do not wish to create additional seams but still wish to have pockets, yo
 ## Step 2: Prep the opening
 
 - Insert zipper or placket into opening if using.
-- If not using, press the openings seam allowance to the inside and _Edgestitch_/_Topstitch_ in place. You may also wish to continue the topstiching down the seam.
+- If not using, press the openings seam allowance to the inside and _Edgestitch_/_Topstitch_ in place. You may also wish to continue the topstitching down the seam.
 
 <Note>
 

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -26,7 +26,7 @@ Due to seamless and closure Sandy's needing different constructions we have sepa
 
 <Note>
 
-Pockets are not included in Sandy as it has one seam by default, if you cut multiple skirt pieces instead of a single one you and easily add pockets.
+Pockets are not included in Sandy as it has one seam by default, if you cut the skirt pattern piece into multiple pieces rather than a single one you can easily add pockets. Cutting it into thirds will give you two sideseams for two pockets, just don't forget to add seam allowance to the slashed seams.
 
 </Note>
 

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -58,9 +58,10 @@ Skip this step if:
 
 ### Closures
 
-- Interface/stiffen half the waistband part lengthwise.
+- Interface/stiffen half the waistband part lengthwise. Or interface/stiffen one of the curved waistband parts.
 - Press under the seam allowance on the long edge of the waistband that is not interfaced. Trim. _Baste_ the fold in place if needed.
-- With _good sides together_ sew the interfaced side of the waistband to the skirt. Gather the skrit down to the waistband if needed.
+- With _good sides together_ sew the interfaced waistband/side of the waistband to the skirt. Gather the skrit down to the waistband if needed.
+- If curved waistband sew the non-interfaced part to the interfaced part. Trim and clip seam and press the non-interfaced part up and away from the skirt.
 
 There will be some overhangs:
 
@@ -70,16 +71,16 @@ There will be some overhangs:
 - If using a zipper in the waistband the greater overhang will need to be trimmed to the seam allowance.
 
 __Zipper in Waistband__
-- If inserting a zipper into the waistband now is the time to do so, attach the zipper from the waistband fold line down.
+- If inserting a zipper into the waistband now is the time to do so, attach the zipper from the waistband fold line down. Or for from seam-line down for curved waistband.
 - _Slipstich_ or _Whipstitch_ the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
-- Press under overhangs.
-- Press the waistband _wrong sides together_ along fold-line.
+- Press under overhangs.  
+- Press the waistband _wrong sides together_ along fold-line. Or along seam-line for curved waistband.
 - Slipstich_ or _Whipstitch_ the overhang edges to the zipper.
 - _Egdestitch_ the waistband in place.
 - Alternatively, _Slipstich_ or _Whipstitch_ the waistband in place on the inside.
 
-__Other closures__
-- Press the waistband _good sides together_ along fold-line.
+__Other closures__ 
+- Press the waistband _good sides together_ along fold-line. Or along seam-line for curved waistband.
 - Sew the overhangs with your seam allowance.
 - Turn the waistband out and to the inside, Press.
 - _Egdestitch_ the waistband in place, this should also close the gap of the over-lap.

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -15,7 +15,7 @@ Due to seamless and closure Sandy's needing different constructions we have sepa
 
 </Note>
 
-### Step 1: Prepping the Skirt
+## Step 1: Prepping the Skirt
 
 - If including a closure, sew the skirt seam  _good sides together_ up to where you intend the opening to start.
 - Add Pockets if using.
@@ -32,7 +32,7 @@ If you do not wish to create additional seams but still wish to have pockets, yo
 
 </Note>
 
-### Step 2: Prep the opening
+## Step 2: Prep the opening
 
 - Insert zipper or placket into opening if using.
 - If not using, press the openings seam allowance to the inside and _Edgestitch_/_Topstitch_ in place. You may also wish to continue the topstiching down the seam.
@@ -45,7 +45,7 @@ Skip this step if:
 
 </Note>
 
-### Step 3: Lining
+## Step 3: Lining
 
 - (Optional) Interline the skirt with a stiffener.
 - Attach Lining to skirt at hem and opening by your preferred method.
@@ -54,9 +54,9 @@ Skip this step if:
 
 <Note>
 
-### Step 4: The waistband
+## Step 4: The waistband
 
-#### Closure
+### Closures
 
 - Interface/stiffen half the waistband part lengthwise.
 - Press under the seam allowance on the long edge of the waistband that is not interfaced. Trim. _Baste_ the fold in place if needed.
@@ -64,10 +64,10 @@ Skip this step if:
 
 There will be some overhangs:
 
-	- The side you wish not to overlap should be overhang by your seam allowance.
-	- The side intended to overlap will have a greater overhang.
-	- If using a placket, both sides will overhang by your seam allowance.
-	- If using a zipper in the waistband the greater overhang will need to be trimmed to the seam allowance.
+- The side you wish not to overlap should be overhang by your seam allowance.
+- The side intended to overlap will have a greater overhang.
+- If using a placket, both sides will overhang by your seam allowance.
+- If using a zipper in the waistband the greater overhang will need to be trimmed to the seam allowance.
 
 __Zipper in Waistband__
 - If inserting a zipper into the waistband now is the time to do so, attach the zipper from the waistband fold line down.
@@ -86,7 +86,7 @@ __Other closures__
 - Alternatively, _Slipstich_ or _Whipstitch_ the waistband in place on the inside and close the gap of the over-lap with _Slipstiching_.
 - Add snaps, dress hooks or button and buttonhole, whatever is your preferred closure to the waistband overhang.
 
-#### Seamless
+### Seamless
 
 - With _good sides together_ sew the waistband in half along the short seams, leaving a gap for the elastic that will be on the inside.
 - Press under the seam allowance on the long edge of the waistband that is intended to be on the inside.
@@ -100,7 +100,7 @@ __Other closures__
 - Overlap the ends of the elastic by 1cm (3/8 inch) and zig-zag stitch in place.
 - Tuck elastic into waistband and close the opening with hand-sewing.
 
-### Step 5: Hemming
+## Step 5: Hemming
 
 If you have hemmed the skirt with the lining you can skip this step.
 
@@ -115,7 +115,7 @@ There are many ways to hem/face the bottom of a skirt, If you have a prefered me
 
 </Note>
 
-### Step 6: Enjoy!
+## Step 6: Enjoy!
 
 You are all done! Now go enjoy your wonderful new skirt and try not to get too dizzy showing off it's fullness!
 

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -47,7 +47,7 @@ Skip this step if:
 
 ## Step 3: Lining
 
-- (Optional) Interline the skirt with a stiffener.
+- (Optional) Interline the skirt with a stiffer or stronger fabric.
 - Attach Lining to skirt at hem and opening by your preferred method.
 - _Baste_ Lining to skirt at waist.
 - Gather the waist if needed.

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -61,7 +61,7 @@ Skip this step if:
 - Interface/stiffen half the waistband part lengthwise. Or interface/stiffen one of the curved waistband parts.
 - Press under the seam allowance on the long edge of the waistband that is not interfaced. Trim. _Baste_ the fold in place if needed.
 - With _good sides together_ sew the interfaced waistband/side of the waistband to the skirt. Gather the skirt down to the waistband if needed.
-- If curved waistband sew the non-interfaced part to the interfaced part. Trim and clip seam and press the non-interfaced part up and away from the skirt.
+- If using the curved waistband sew the non-interfaced part to the interfaced part. Trim and clip seam and press the non-interfaced part up and away from the skirt.
 
 There will be some overhangs:
 

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -26,9 +26,11 @@ Due to seamless and closure Sandy's needing different constructions we have sepa
 
 <Note>
 
-Pockets are not included in Sandy as it has one seam by default, if you cut the skirt pattern piece into multiple pieces rather than a single one you can easily add pockets. Cutting it into thirds will give you two sideseams for two pockets, just don't forget to add seam allowance to the slashed seams.
+Pockets are not included in Sandy as it has one seam by default or no seams at all.
 
-If you can't be bothered with creating seams to add inseam pockets but still wish to have some you can always use Patch Pockets or if you are feeling brave Welt Pockets.
+If you would like inseam pockets you can cut the skirt pattern piece into multiple pieces rather than a single one to create seams to insert them into. Cutting it into thirds (for default) or two (for seamless) will give you two sideseams for two inseam pockets, just don't forget to add seam allowance to the slashed seams.
+
+If you do not wish to create additional seams but still wish to have pockets, you can use Patch Pockets or if you are feeling adventurous, you can use Welt Pockets.
 
 </Note>
 

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -89,11 +89,12 @@ __Other closures__
 
 ### Seamless
 
-- With _good sides together_ sew the waistband in half along the short seams, leaving a gap for the elastic that will be on the inside.
+- If curved waistband with _good sides together_ sew the two waistbands together along the shortest curved edge. Press away from one another, Trim and clip the seam.
+- With _good sides together_ sew the waistband together along the short seams, leaving a gap for the elastic that will be on the inside.
 - Press under the seam allowance on the long edge of the waistband that is intended to be on the inside.
 - With _good sides together_ attach the waistband to the skirt along the unpressed seam. Trim seam.
 - Press waistband and seam allowance up away from skirt.
-- Press the waistband to the inside along the fold-line.
+- Press the waistband to the inside along the fold-line/seam-line.
 - _Edgestitch_ the waistband in place.
 - Alternatively you can _Slipstitch_ or _Whipstitch_ the waistband in place on the inside.
 - Cut the elastic to your waist.

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -15,20 +15,18 @@ Due to seamless and closure Sandy's needing different constructions we have sepa
 
 </Note>
 
-## Sandy with Closure (default)
-
 ### Step 1: Prepping the Skirt
 
-- With _good sides together_ sew the skirt seam up to where you intend the opening to start.
+- If including a closure, sew the skirt seam  _good sides together_ up to where you intend the opening to start.
 - Add Pockets if using.
 - If using lining, prep the same as the skirt.
-- _Finish_ if not lining.
+- _Finish_ seams if not lining.
 
 <Note>
 
 Pockets are not included in Sandy as it has one seam by default or no seams at all.
 
-If you would like inseam pockets you can cut the skirt pattern piece into multiple pieces rather than a single one to create seams to insert them into. Cutting it into thirds (for default) or two (for seamless) will give you two sideseams for two inseam pockets, just don't forget to add seam allowance to the slashed seams.
+If you would like inseam pockets you can cut the skirt pattern piece into multiple pieces rather than a single one to create seams to insert them into. Cutting it into thirds (for default) or two (for seamless) will give you two sideseams for two inseam pockets, just don't forget to add back seam allowance to the cut lines if including.
 
 If you do not wish to create additional seams but still wish to have pockets, you can use Patch Pockets or if you are feeling adventurous, you can use Welt Pockets.
 
@@ -41,80 +39,54 @@ If you do not wish to create additional seams but still wish to have pockets, yo
 
 <Note>
 
-Skip this step if you are including the zipper in the waistband.
+Skip this step if:
+- You are including the zipper in the waistband.
+- You are making a seamless version
 
 </Note>
 
 ### Step 3: Lining
 
-- Face the skirt if desired.
+- (Optional) Interline the skirt with a stiffener.
 - Attach Lining to skirt at hem and opening by your preferred method.
 - _Baste_ Lining to skirt at waist.
-- Gather skirt and lining skit if needed.
+- Gather the waist if needed.
 
 <Note>
 
-These instructions will treat the lining and skirt the same at the waist.  
-If not lining you should face the skirt when hemming later.
-
-</Note>
-
 ### Step 4: The waistband
 
-- Face half the waistband part lengthwise.
-- Press under the seam allowance on the long edge of the waistband that is not faced.
-- Attach the faced side of the waistband, _good sides together_ to the skirt. There will be some overhang, the side you wish not to overlap should be overhang by your seam allowance. The side intended to overlap will have a greater overhang. Trim seam.
-- Press the waistband and seam allowance up and away from the skirt.
-- If inserting a zipper now is the time to do so, attach the zipper from the fold line down. Then follow the rest of the instructions ommiting overhangs and other closures. You will need to attach the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
+#### Closure
+
+- Interface/stiffen half the waistband part lengthwise.
+- Press under the seam allowance on the long edge of the waistband that is not interfaced. Trim. _Baste_ the fold in place if needed.
+- With _good sides together_ sew the interfaced side of the waistband to the skirt. Gather the skrit down to the waistband if needed.
+
+There will be some overhangs:
+
+	- The side you wish not to overlap should be overhang by your seam allowance.
+	- The side intended to overlap will have a greater overhang.
+	- If using a placket, both sides will overhang by your seam allowance.
+	- If using a zipper in the waistband the greater overhang will need to be trimmed to the seam allowance.
+
+__Zipper in Waistband__
+- If inserting a zipper into the waistband now is the time to do so, attach the zipper from the waistband fold line down.
+- _Slipstich_ or _Whipstitch_ the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
+- Press under overhangs.
+- Press the waistband _wrong sides together_ along fold-line.
+- Slipstich_ or _Whipstitch_ the overhang edges to the zipper.
+- _Egdestitch_ the waistband in place.
+- Alternatively, _Slipstich_ or _Whipstitch_ the waistband in place on the inside.
+
+__Other closures__
 - Press the waistband _good sides together_ along fold-line.
 - Sew the overhangs with your seam allowance.
 - Turn the waistband out and to the inside, Press.
 - _Egdestitch_ the waistband in place, this should also close the gap of the over-lap.
 - Alternatively, _Slipstich_ or _Whipstitch_ the waistband in place on the inside and close the gap of the over-lap with _Slipstiching_.
-- Add button and buttonhole, snaps or dress hooks, whatever is your preferred closure to the waistband overhang.
+- Add snaps, dress hooks or button and buttonhole, whatever is your preferred closure to the waistband overhang.
 
-<Tip>
-
-If you are having trouble keeping the pressed under seam allowance of the waistband folded/not staying pressed you may find it helpful to _Baste_ the fold in place.
-
-</Tip>
-
-### Step 5: Hemming/Facing
-
-If you have hemmed the skirt with the lining you can skip this step.
-
-- Faced the skirt if desired.
-- Line the facing if desired.
-- Hem the skirt if you have not already done so with the lining.
-
-<Note>  
-
-There are many ways to hem/face the bottom of a skirt, If you have a prefered method use it here.
-
-</Note>
-
-### Step 6: Enjoy!
-
-You are all done! Now go enjoy your wonderful new skirt!
-
-## Sandy with no closure (seamless/elasticated waistband)
-
-### Step 1: Lining and Skirt
-
-- Face skirt if desired.
-- Attach Lining to skirt at hem by your preferred method if using.
-- _Baste_ Lining to skirt at waist.
-- _Finish_ seams if not lining.
-- Gather skirt and lining skit if needed.
-
-<Note>
-
-These instructions will treat the lining and skirt the same at the waist.  
-If not lining you should face the skirt when hemming later.
-
-</Note>
-
-### Step 2: The waistband
+#### Seamless
 
 - With _good sides together_ sew the waistband in half along the short seams, leaving a gap for the elastic that will be on the inside.
 - Press under the seam allowance on the long edge of the waistband that is intended to be on the inside.
@@ -125,22 +97,17 @@ If not lining you should face the skirt when hemming later.
 - Alternatively you can _Slipstitch_ or _Whipstitch_ the waistband in place on the inside.
 - Cut the elastic to your waist.
 - Thread the elastic through the opening of the waistband making sure not to lose the end.
-- Overlap the ends by 1cm (3/8 inch) and zig-zag stitch in place.
+- Overlap the ends of the elastic by 1cm (3/8 inch) and zig-zag stitch in place.
 - Tuck elastic into waistband and close the opening with hand-sewing.
 
-<Tip>
-
-If you are having trouble keeping the pressed under seam allowance of the waistband folded/not staying pressed you may find it helpful to _Baste_ the fold in place.
-
-</Tip>
-
-### Step 3: Hemming/Facing
+### Step 5: Hemming
 
 If you have hemmed the skirt with the lining you can skip this step.
 
-- Faced the skirt if desired.
-- Line the facing if desired.
-- Hem the skirt if you have not already done so with the lining.
+Hem the skirt in one of the following ways:
+- Omit the hem allowance and bind the raw edge.
+- Bind the raw edge of the hem allowance, single fold the hem under and either _Topstitch_ or hand sew the hem in place.
+- Double fold the hem under and either _Topstitch_ or hand sew the hem in place. You may have heard this be called a Rolled hem.
 
 <Note>  
 
@@ -148,9 +115,9 @@ There are many ways to hem/face the bottom of a skirt, If you have a prefered me
 
 </Note>
 
-### Step 4: Enjoy!
+### Step 6: Enjoy!
 
-You all done! Now go enjoy your wonderfully seamless skirt!
+You are all done! Now go enjoy your wonderful new skirt and try not to get too dizzy showing off it's fullness!
 
 <Note>
 

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -60,7 +60,7 @@ Skip this step if:
 
 - Interface/stiffen half the waistband part lengthwise. Or interface/stiffen one of the curved waistband parts.
 - Press under the seam allowance on the long edge of the waistband that is not interfaced. Trim. _Baste_ the fold in place if needed.
-- With _good sides together_ sew the interfaced waistband/side of the waistband to the skirt. Gather the skrit down to the waistband if needed.
+- With _good sides together_ sew the interfaced waistband/side of the waistband to the skirt. Gather the skirt down to the waistband if needed.
 - If curved waistband sew the non-interfaced part to the interfaced part. Trim and clip seam and press the non-interfaced part up and away from the skirt.
 
 There will be some overhangs:

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -28,6 +28,8 @@ Due to seamless and closure Sandy's needing different constructions we have sepa
 
 Pockets are not included in Sandy as it has one seam by default, if you cut the skirt pattern piece into multiple pieces rather than a single one you can easily add pockets. Cutting it into thirds will give you two sideseams for two pockets, just don't forget to add seam allowance to the slashed seams.
 
+If you can't be bothered with creating seams to add inseam pockets but still wish to have some you can always use Patch Pockets or if you are feeling brave Welt Pockets.
+
 </Note>
 
 ### Step 2: Prep the opening

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -72,12 +72,12 @@ There will be some overhangs:
 
 __Inserting Zipper in Waistband__
 - If inserting a zipper into the waistband now is the time to do so, attach the zipper from the waistband fold line down. Or from seam-line down for curved waistband.
-- _Slipstich_ or _Whipstitch_ the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
+- _Slipstitch_ or _Whipstitch_ the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
 - Press under overhangs.  
 - Press the waistband _wrong sides together_ along fold-line. Or along seam-line for curved waistband.
-- Slipstich_ or _Whipstitch_ the overhang edges to the zipper.
-- _Egdestitch_ the waistband in place.
-- Alternatively, _Slipstich_ or _Whipstitch_ the waistband in place on the inside.
+- Slipstitch_ or _Whipstitch_ the overhang edges to the zipper.
+- _Edgestitch_ the waistband in place.
+- Alternatively, _Slipstitch_ or _Whipstitch_ the waistband in place on the inside.
 
 __Other closures__ 
 - Press the waistband _good sides together_ along fold-line. Or along seam-line for curved waistband.

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -70,7 +70,7 @@ There will be some overhangs:
 - If using a placket, both sides will overhang by your seam allowance.
 - If using a zipper in the waistband the greater overhang will need to be trimmed to the seam allowance.
 
-__Zipper in Waistband__
+__Inserting Zipper in Waistband__
 - If inserting a zipper into the waistband now is the time to do so, attach the zipper from the waistband fold line down. Or for from seam-line down for curved waistband.
 - _Slipstich_ or _Whipstitch_ the lining to the zipper at this point if you have not treated the lining and skirt as one at the opening.
 - Press under overhangs.  

--- a/markdown/org/docs/patterns/sandy/instructions/en.md
+++ b/markdown/org/docs/patterns/sandy/instructions/en.md
@@ -61,8 +61,7 @@ If not lining you should face the skirt when hemming later.
 
 ### Step 4: The waistband
 
-- Face half the waistbands parts lengthwise.
-- With _good sides together_ sew the waistbands together along one of the short edges.
+- Face half the waistband part lengthwise.
 - Press under the seam allowance on the long edge of the waistband that is not faced.
 - Attach the faced side of the waistband, _good sides together_ to the skirt. There will be some overhang, the side you wish not to overlap should be overhang by your seam allowance. The side intended to overlap will have a greater overhang. Trim seam.
 - Press the waistband and seam allowance up and away from the skirt.

--- a/markdown/org/docs/patterns/sandy/options/seamlessfullcircle/en.md
+++ b/markdown/org/docs/patterns/sandy/options/seamlessfullcircle/en.md
@@ -10,7 +10,7 @@ Since it has no openings, you'll need an elastic waistband.
 <Note>
 
 - This produces a full circle ignoring the _Circle percent_ option.
-- You will need to use the [gathering option](sandy/options/gathering) to increase the waist circumference to fit over seat.
+- You may need to use the [gathering option](sandy/options/gathering) to increase the waist circumference to fit over your seat/hips.
 - You will need to set the [waistband overlap](sandy/options/waistbandoverlap) to 0%.
 
 </Note>

--- a/markdown/org/docs/patterns/sandy/options/seamlessfullcircle/en.md
+++ b/markdown/org/docs/patterns/sandy/options/seamlessfullcircle/en.md
@@ -11,7 +11,7 @@ Since it has no openings, you'll need an elastic waistband.
 
 - This produces a full circle ignoring the _Circle percent_ option.
 - You will need to use the [gathering option](sandy/options/gathering) to increase the waist circumference to fit over seat.
-- You will need to set the [waistband overlap](sandy/options/waistbandoverlap) to 0
+- You will need to set the [waistband overlap](sandy/options/waistbandoverlap) to 0%.
 
 </Note>
 

--- a/markdown/org/docs/patterns/sandy/options/seamlessfullcircle/en.md
+++ b/markdown/org/docs/patterns/sandy/options/seamlessfullcircle/en.md
@@ -9,7 +9,9 @@ Since it has no openings, you'll need an elastic waistband.
 
 <Note>
 
-This produces a full circle ignoring the _Circle percent_ option.
+- This produces a full circle ignoring the _Circle percent_ option.
+- You will need to use the [gathering option](sandy/options/gathering) to increase the waist circumference to fit over seat.
+- You will need to set the [waistband overlap](sandy/options/waistbandoverlap) to 0
 
 </Note>
 


### PR DESCRIPTION
For #2615

I had a noticed a while back that my initial Doc work on Sandy needed some more refinement. It was a bit confusing and the waistband cutting info was incorrect.

Upon further inspection I decided it was best to completely overhaul the instructions to streamline them as having two separate instructions were confusing and could be merged together. 