### PR TITLE
Update Yuri's option config

### DIFF
--- a/designs/yuri/src/back.mjs
+++ b/designs/yuri/src/back.mjs
@@ -99,21 +99,17 @@ function yuriBack({
 
 export const back = {
   name: 'yuri.back',
-  from: {
-    ...brianBack,
-    options: {
-      ...brianBack.options,
-      // Overrides
-      collarEase: { pct: 20, min: 10, max: 30 },
-      cuffEase: { pct: 30, min: 20, max: 60 },
-      lengthBonus: { pct: 10, min: 5, max: 15 },
-      sleeveLengthBonus: { pct: 1, min: 0, max: 10 },
-    },
+  from: brianBack,
+  options: {
+    ...brianBack.options,
+    // Overrides
+    hipsEase: { pct: 0, min: 0, max: 10, menu: 'fit' },
+    collarEase: { pct: 20, min: 10, max: 30, menu: 'fit' },
+    cuffEase: { pct: 30, min: 20, max: 60, menu: 'fit' },
+    lengthBonus: { pct: 10, min: 5, max: 15, menu: 'fit' },
+    sleeveLengthBonus: { pct: 1, min: 0, max: 10, menu: 'fit' },
   },
   hide: hidePresets.HIDE_TREE,
-  options: {
-    hipsEase: { pct: 0, min: 0, max: 10 },
-  },
   measurements: ['hips'],
   draft: yuriBack,
 }

--- a/designs/yuri/src/front.mjs
+++ b/designs/yuri/src/front.mjs
@@ -108,21 +108,11 @@ function yuriFront({
 
 export const front = {
   name: 'yuri.front',
-  from: {
-    ...brianFront,
-    options: {
-      ...brianFront.options,
-      // Overrides
-      collarEase: { pct: 20, min: 10, max: 30 },
-      cuffEase: { pct: 30, min: 20, max: 60 },
-      lengthBonus: { pct: 10, min: 5, max: 15 },
-      sleeveLengthBonus: { pct: 1, min: 0, max: 10 },
-    },
+  from: brianFront,
+  options: {
+    ...brianFront.options,
   },
   hide: hidePresets.HIDE_TREE,
-  options: {
-    hipsEase: { pct: 0, min: 0, max: 10 },
-  },
   measurements: ['hips', 'hpsToBust'],
   draft: yuriFront,
 }


### PR DESCRIPTION
This should solve #3004 

Some of Yuri's options were lost from v2 to v3. This PR should restore them.
I placed the options on the back as brianBack will draft before brianFront so it makes logical sense to put it on the yuri.back

Changes
- Separated from and options in `back.mjs`
- Separated from and options in `front.mjs`
- Added menus to override options in `back,mjs`

Deletions
- Removed duplicated override options from `front.mjs`