### PR TITLE
Update Wahid Options Config

### DIFF
--- a/designs/wahid/src/back.mjs
+++ b/designs/wahid/src/back.mjs
@@ -1,6 +1,23 @@
 import { constructMainDart, shapeSideSeam, dartPath } from './shared.mjs'
 import { back as brianBack } from '@freesewing/brian'
-import { backInset, shoulderInset, neckInset, centerBackDart, backScyeDart } from './options.mjs'
+import {
+  backInset,
+  shoulderInset,
+  neckInset,
+  centerBackDart,
+  backScyeDart,
+  brianFitSleeve,
+  brianFitCollar,
+  collarFactor,
+  backNeckCutout,
+  shoulderSlopeReduction,
+  collarEase,
+  shoulderEase,
+  bicepsEase,
+  cuffEase,
+  s3Collar,
+  s3Armhole,
+} from './options.mjs'
 import { hidePresets } from '@freesewing/core'
 
 function wahidBack({
@@ -236,6 +253,17 @@ export const back = {
     neckInset,
     centerBackDart,
     backScyeDart,
+    brianFitSleeve,
+    brianFitCollar,
+    collarFactor,
+    backNeckCutout,
+    shoulderSlopeReduction,
+    collarEase,
+    shoulderEase,
+    bicepsEase,
+    cuffEase,
+    s3Collar,
+    s3Armhole,
   },
   draft: wahidBack,
 }

--- a/designs/wahid/src/options.mjs
+++ b/designs/wahid/src/options.mjs
@@ -2,6 +2,17 @@
 export const acrossBackFactor = 0.97
 export const frontOverlap = 0.01
 export const frontArmholeDeeper = 0.005
+export const brianFitSleeve = false
+export const brianFitCollar = false
+export const collarFactor = 4.8
+export const backNeckCutout = 0.05
+export const shoulderSlopeReduction = 0
+export const collarEase = 0.035
+export const shoulderEase = 0
+export const bicepsEase = 0.15
+export const s3Collar = 0
+export const s3Armhole = 0
+export const cuffEase = 0
 // Fit
 export const armholeDepthFactor = { pct: 70, min: 60, max: 80, menu: 'fit' }
 export const backScyeDart = { deg: 2, min: 0, max: 6, menu: 'fit' }


### PR DESCRIPTION
Should be a solve for #3005 

Some of Wahid's options were lost from v2 to v3. This PR should restore them.

Additions
- Added missing constant options to `options.mjs`
- Change `cuffEase` to constant
- Imported missing constants to `back.mjs`

