### PR TITLE
fix(core): Proposal to fix #3781

### DIFF
--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -295,6 +295,7 @@ Part.prototype.__getIdClosure = function () {
 
 /**
  * Copies point/path/snippet data from part orig into this
+ * Also sets the freeId
  *
  * @private
  * @param {object} orig - The original part to inject into this
@@ -307,6 +308,7 @@ Part.prototype.__inject = function (orig) {
     }
   }
 
+  this.freeId = orig.freeId
   for (let i in orig.points) this.points[i] = orig.points[i].clone()
   for (let i in orig.paths) {
     this.paths[i] = orig.paths[i].clone()


### PR DESCRIPTION
This is an (untested) fix for #3781
It ensures a part's freeId is inherited when the part is injected.