### PR TITLE
Insure section directory exists for lab prebuild

### DIFF
--- a/sites/shared/prebuild/lab.mjs
+++ b/sites/shared/prebuild/lab.mjs
@@ -48,6 +48,7 @@ export const prebuildLab = async () => {
       const page = pageTemplate(design)
       const pages = ['..', 'lab', 'pages']
       await fs.mkdir(path.resolve(...pages, 'v', 'next'), { recursive: true })
+      await fs.mkdir(path.resolve(...pages, section, 'v', 'next'), { recursive: true })
       promises.push(
         fs.writeFile(path.resolve(...pages, `${design}.mjs`), page),
         fs.writeFile(path.resolve(...pages, section, `${design}.mjs`), page)


### PR DESCRIPTION
I've run into build errors with custom catergories because the folder didn't exist in `sites/lab/pages`. Upon inspection of the prebuild script I saw that it ws not creating folders for design catergories. The is pull requests insures that the folder exists so the prebuild can run without error. 

This will be helpful down line if we decide to add new catergories such as Historical.