### PR TITLE
Add functionality for yarn new plugin

### DIFF
--- a/config/templates/plugin/package.json.mustache
+++ b/config/templates/plugin/package.json.mustache
@@ -1,0 +1,12 @@
+{
+  "name": "{{pluginName}}",
+  "version": "0.0.1",
+  "description": "{{description}}",
+  "author": "Joost De Cock <joost@joost.at> (https://github.com/joostdecock)",
+  "homepage": "https://freesewing.org/",
+  "repository": "github:freesewing/freesewing",
+  "license": "MIT",
+  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
+  "scripts": {}
+}

--- a/config/templates/plugin/src/index.mjs.mustache
+++ b/config/templates/plugin/src/index.mjs.mustache
@@ -5,15 +5,13 @@ export const plugin = {
   version,
   macros: {
     {{name}}: function (so, {points, paths, Path}) { //Example shorthand, you may wish to add other elements like utils
-
-const defaults = {
-//note these are common examples and can be removed
-    scale: 1,
-    rotation: 0,
-  }
-  so = { ...defaults, ...so }
-
-
+      const defaults = {
+        //note these are common examples and can be removed
+        scale: 1,
+        rotation: 0,
+      }
+      so = { ...defaults, ...so }
+      //write plugin here
     },
   },
 }

--- a/config/templates/plugin/src/index.mjs.mustache
+++ b/config/templates/plugin/src/index.mjs.mustache
@@ -1,0 +1,23 @@
+import { name, version } from '../data.mjs'
+
+export const plugin = {
+  name,
+  version,
+  macros: {
+    {{name}}: function (so, {points, paths, Path}) { //Example shorthand, you may wish to add other elements like utils
+
+const defaults = {
+//note these are common examples and can be removed
+    scale: 1,
+    rotation: 0,
+  }
+  so = { ...defaults, ...so }
+
+
+    },
+  },
+}
+
+// More specifically named exports
+export const {{name}}Plugin = plugin
+export const plugin{{capitalized_name}} = plugin

--- a/scripts/add-software.mjs
+++ b/scripts/add-software.mjs
@@ -240,7 +240,7 @@ function validatePluginName(name) {
 function createDesign(name, type) {
   const template = ['config', 'templates', 'design']
   const design = ['designs', name]
-  const description = 'A pattern that needs a description'
+  const description = 'A FreeSewing pattern that needs a description'
   const capitalized_name = name.charAt(0).toUpperCase() + name.slice(1)
 
   // Add to designs config file
@@ -280,7 +280,7 @@ function createDesign(name, type) {
 function createPlugin(name) {
   const pluginName = 'plugin-' + name
   const template = ['config', 'templates', 'plugin']
-  const description = 'A plugin that needs a description'
+  const description = 'A FreeSewing plugin that needs a description'
   const plugin = ['plugins', pluginName]
   const capitalized_name = name.charAt(0).toUpperCase() + name.slice(1)
 

--- a/scripts/add-software.mjs
+++ b/scripts/add-software.mjs
@@ -120,7 +120,7 @@ async function addDesign() {
   👉 ${chalk.yellow(
     'Dependencies'
   )}: If you need additional plugins or patterns to extend, update ${chalk.green(
-        'config/dependecies.yaml'
+        'config/dependencies.yaml'
       )}
 
   If you change any of these, run ${chalk.blue('yarn reconfigure')} to update the package(s).
@@ -176,7 +176,7 @@ async function addPlugin() {
 
   👉  We've created your plugin skeleton at ${chalk.green('plugins/plugin-' + name)}
   👉  We've configured the packages via the ${chalk.green('pacakge.json')} file
-  👉  We've added ${chalk.green('plugins/plugin-/' + name)} to the lab
+  👉  We've added ${chalk.green('plugins/plugin-' + name)} to the lab
 
 
   ${chalk.bold.yellow('✏️  Make it your own')}
@@ -193,7 +193,7 @@ async function addPlugin() {
   👉 ${chalk.yellow(
     'Dependencies'
   )}: If you need additional plugins or patterns to extend, update ${chalk.green(
-        'config/dependecies.yaml'
+        'config/dependencies.yaml'
       )}
 
   If you change any of these, run ${chalk.blue('yarn reconfigure')} to update the package(s).

--- a/scripts/add-software.mjs
+++ b/scripts/add-software.mjs
@@ -102,7 +102,7 @@ async function addDesign() {
   ${chalk.gray('≡≡≡≡≡≡≡≡≡≡')}
 
   👉  We've created your design skeleton at ${chalk.green('designs/' + name)}
-  👉  We've configured the packages via the ${chalk.green('pacakge.json')} file
+  👉  We've configured the packages via the ${chalk.green('package.json')} file
   👉  We've added ${chalk.green('designs/' + name)} to the lab
 
 
@@ -175,8 +175,7 @@ async function addPlugin() {
   ${chalk.gray('≡≡≡≡≡≡≡≡≡≡')}
 
   👉  We've created your plugin skeleton at ${chalk.green('plugins/plugin-' + name)}
-  👉  We've configured the packages via the ${chalk.green('pacakge.json')} file
-  👉  We've added ${chalk.green('plugins/plugin-' + name)} to the lab
+  👉  We've configured the packages via the ${chalk.green('package.json')} file
 
 
   ${chalk.bold.yellow('✏️  Make it your own')}

--- a/scripts/add-software.mjs
+++ b/scripts/add-software.mjs
@@ -86,7 +86,7 @@ async function addDesign() {
     type: 'text',
     name: 'name',
     message: 'What name would you like the design to have? ([a-z] only)',
-    validate: validateNameDesign,
+    validate: validateDesignName,
   })
 
   if (name && type) {
@@ -159,7 +159,7 @@ async function addPlugin() {
     type: 'text',
     name: 'name',
     message: 'What name would you like the plugin to have? ([a-z] only)',
-    validate: validateNamePlugin,
+    validate: validatePluginName,
   })
 
   if (name) {
@@ -213,7 +213,7 @@ async function addPlugin() {
   }
 }
 
-function validateNameDesign(name) {
+function validateDesignName(name) {
   if (
     [
       ...Object.keys(designs.accessories),
@@ -228,7 +228,7 @@ function validateNameDesign(name) {
   else return ' 🙈 Please use only [a-z], no spaces, no capitals, no nothing 🤷'
 }
 
-function validateNamePlugin(name) {
+function validatePluginName(name) {
   const pluginName = 'plugin-' + name
   if ([...Object.keys(plugins)].indexOf(pluginName) !== -1)
     return `Sorry but ${pluginName} is already taken so you'll need to pick something else`

--- a/scripts/add-software.mjs
+++ b/scripts/add-software.mjs
@@ -7,6 +7,7 @@ import mustache from 'mustache'
 import { execSync } from 'child_process'
 // Software
 import designs from '../config/software/designs.json' assert { type: 'json' }
+import plugins from '../config/software/plugins.json' assert { type: 'json' }
 
 const type = process.argv[2]
 
@@ -85,7 +86,7 @@ async function addDesign() {
     type: 'text',
     name: 'name',
     message: 'What name would you like the design to have? ([a-z] only)',
-    validate: validateName,
+    validate: validateNameDesign,
   })
 
   if (name && type) {
@@ -142,17 +143,77 @@ async function addDesign() {
 async function addPlugin() {
   console.log(`
 
-  ${chalk.bold.yellow('🙈 Oh no; You called our bluf!')}
-  ${chalk.gray('≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡')}
+  ${chalk.bold.yellow('👕 Add a new plugin')}
+  ${chalk.gray('≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡')}
 
-  Adding plugins is not (yet) implemented 😬
-
-  Sorry 🤥
+  We're going to add a new plugin to this repository. That's awesome 🎉
+  Let's start by picking the name for this plugin 🏷️
+  Try to keep it to one word that explains what the plugin does e.g. ${chalk.green(
+    'flip'
+  )}, ${chalk.green('mirror')},
+   ${chalk.green('round')}.
 
 `)
+
+  const { name } = await prompts({
+    type: 'text',
+    name: 'name',
+    message: 'What name would you like the plugin to have? ([a-z] only)',
+    validate: validateNamePlugin,
+  })
+
+  if (name) {
+    console.log('\n' + `  Alright, let's add ${chalk.green(name)} to plugins 🪄`)
+    createPlugin(name)
+    execSync('npm run reconfigure')
+    console.log(`  All done 🎉`)
+
+    try {
+      console.log(`
+
+  ${chalk.bold.yellow('✨ Summary')}
+  ${chalk.gray('≡≡≡≡≡≡≡≡≡≡')}
+
+  👉  We've created your plugin skeleton at ${chalk.green('plugins/plugin-' + name)}
+  👉  We've configured the packages via the ${chalk.green('pacakge.json')} file
+  👉  We've added ${chalk.green('plugins/plugin-/' + name)} to the lab
+
+
+  ${chalk.bold.yellow('✏️  Make it your own')}
+  ${chalk.gray('≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡')}
+
+  Hhere's a few other things you can configure:
+
+  👉 ${chalk.yellow('Author')}: Credit where credit is due; Add yourself as author in ${chalk.green(
+        'config/exceptions.yaml'
+      )}
+  👉 ${chalk.yellow('Description')}: We used a placeholder description; Update it in ${chalk.green(
+        'config/software/plugins.json'
+      )}
+  👉 ${chalk.yellow(
+    'Dependencies'
+  )}: If you need additional plugins or patterns to extend, update ${chalk.green(
+        'config/dependecies.yaml'
+      )}
+
+  If you change any of these, run ${chalk.blue('yarn reconfigure')} to update the package(s).
+
+
+  ${chalk.bold.yellow('👷 Get to work')}
+  ${chalk.gray('≡≡≡≡≡≡≡≡≡≡≡≡≡≡')}
+
+  🛠️   You can now start the development environment with ${chalk.blue('yarn lab')}
+  📖  Documentation is available at ${chalk.green('https://freesewing.dev/')}
+  🤓  Happy hacking
+
+    `)
+    } catch (err) {
+      console.log(err)
+    }
+  }
 }
 
-function validateName(name) {
+function validateNameDesign(name) {
   if (
     [
       ...Object.keys(designs.accessories),
@@ -167,10 +228,19 @@ function validateName(name) {
   else return ' 🙈 Please use only [a-z], no spaces, no capitals, no nothing 🤷'
 }
 
+function validateNamePlugin(name) {
+  const pluginName = 'plugin-' + name
+  if ([...Object.keys(plugins)].indexOf(pluginName) !== -1)
+    return `Sorry but ${pluginName} is already taken so you'll need to pick something else`
+
+  if (/^([a-z]+)$/.test(name)) return true
+  else return ' 🙈 Please use only [a-z], no spaces, no capitals, no nothing 🤷'
+}
+
 function createDesign(name, type) {
   const template = ['config', 'templates', 'design']
   const design = ['designs', name]
-  const description = 'A FreeSewing pattern that needs a description'
+  const description = 'A pattern that needs a description'
   const capitalized_name = name.charAt(0).toUpperCase() + name.slice(1)
 
   // Add to designs config file
@@ -205,6 +275,33 @@ function createDesign(name, type) {
   for (const file of ['box.mjs']) {
     cp([...template, 'src', file], [...design, 'src', file])
   }
+}
+
+function createPlugin(name) {
+  const pluginName = 'plugin-' + name
+  const template = ['config', 'templates', 'plugin']
+  const description = 'A plugin that needs a description'
+  const plugin = ['plugins', pluginName]
+  const capitalized_name = name.charAt(0).toUpperCase() + name.slice(1)
+
+  // Create folders
+  mkdir([...plugin, 'src'])
+  mkdir([...plugin, 'tests'])
+
+  // Create package.json
+  templateOut([...template, 'package.json.mustache'], [...plugin, 'package.json'], {
+    pluginName,
+    description,
+  })
+
+  plugins[pluginName] = description
+  write(['config', 'software', 'plugins.json'], JSON.stringify(orderPlugins(plugins), null, 2))
+
+  // Create index.mjs
+  templateOut([...template, 'src', 'index.mjs.mustache'], [...plugin, 'src', 'index.mjs'], {
+    name,
+    capitalized_name,
+  })
 }
 
 function templateOut(from, to, data) {
@@ -261,4 +358,13 @@ function orderDesigns(designs) {
   }
 
   return newDesigns
+}
+function orderPlugins(plugins) {
+  // Ensure plugins are listed alphabetically
+  const newPlugins = {}
+  for (const plugin of Object.keys(plugins).sort()) {
+    newPlugins[plugin] = plugins[plugin]
+  }
+
+  return newPlugins
 }


### PR DESCRIPTION
Initially `yarn new plugin` would not create a new plugin.

This pull request adds the functionaly for creating a new plugin

Example of prompt:
![image](https://user-images.githubusercontent.com/16866285/232789337-fce2d05a-e97c-4b25-b6d6-788c7c870053.png)

Examples of validatePluginName:
![image](https://user-images.githubusercontent.com/16866285/232790600-51d4b4d7-7788-46b1-9766-6eaea2c0bd5d.png)
![image](https://user-images.githubusercontent.com/16866285/232790658-f251de3b-459e-4793-b39c-892eb3c1fcc8.png)

Example of createPlugin:
![image](https://user-images.githubusercontent.com/16866285/232790750-fa834457-1438-4e4e-a8d2-7f35131fbfb7.png)

Example of generated `index.mjs` file:
![image](https://user-images.githubusercontent.com/16866285/232795494-d17ba73f-b0ca-4727-9a4c-ff2c52eab2af.png)

Example of generated `package.mjs` file:
![image](https://user-images.githubusercontent.com/16866285/232795986-4082f0b8-24ef-4740-8558-f792a6906f6e.png)


Additions:
- added prompt to yarn new design in `add-software.mjs`
- added validatePluginName() in `add-software.mjs`
- added createPlugin() in `add-software.mjs`
- added orderPlugin() in `add-software.mjs`
- create `config/templates/plugin` folder
- create `index.mjs.mustache` to `templates/plugin/src`
- create `packages.json.mustache` to `templates/plugin`

Changes:
- validateName has been changed to validateDesignName in `add-software.mjs`

Please don't hesitate to suggest changes on the prompt message or the example comments in the `index.mjs.mustache` file, I was more focused on the functionality so they may need changes. I did my best to 