### PR TITLE
Enchancement (workflows) cache node_modules in github workflows

### DIFF
--- a/.github/workflows/lint.all.yml
+++ b/.github/workflows/lint.all.yml
@@ -24,7 +24,15 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache node modules
+        uses: actions/cache@v3
+        id: cache_node_modules
+        with:
+          # caching node_modules
+          path: node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
+        if: steps.cache_node_modules.outputs.cache-hit != 'true'
         run: npx lerna bootstrap
         env:
           CI: true

--- a/.github/workflows/lint.all.yml
+++ b/.github/workflows/lint.all.yml
@@ -36,7 +36,5 @@ jobs:
         run: npx lerna bootstrap
         env:
           CI: true
-      - name: Prebuild Packages
-        run: npx lerna run prebuild
       - name: Run eslint
         run: npm run lint

--- a/.github/workflows/lint.diff.yml
+++ b/.github/workflows/lint.diff.yml
@@ -42,6 +42,8 @@ jobs:
         run: npx lerna bootstrap
         env:
           CI: true
+      - name: Prebuild Packages
+        run: npx lerna run prebuild
       - name: Run eslint
         run: |
           changed_files="$(git diff --name-only origin/${{ github.base_ref }})"

--- a/.github/workflows/lint.diff.yml
+++ b/.github/workflows/lint.diff.yml
@@ -42,8 +42,6 @@ jobs:
         run: npx lerna bootstrap
         env:
           CI: true
-      - name: Prebuild Packages
-        run: npx lerna run prebuild
       - name: Run eslint
         run: |
           changed_files="$(git diff --name-only origin/${{ github.base_ref }})"

--- a/.github/workflows/lint.diff.yml
+++ b/.github/workflows/lint.diff.yml
@@ -30,7 +30,15 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache node modules
+        uses: actions/cache@v3
+        id: cache_node_modules
+        with:
+          # caching node_modules
+          path: node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
+        if: steps.cache_node_modules.outputs.cache-hit != 'true'
         run: npx lerna bootstrap
         env:
           CI: true

--- a/.github/workflows/tests.all.yml
+++ b/.github/workflows/tests.all.yml
@@ -33,7 +33,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
+      - name: Cache node modules
+        uses: actions/cache@v3
+        id: cache_node_modules
+        with:
+          # caching node_modules
+          path: node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
+        if: steps.cache_node_modules.outputs.cache-hit != 'true'
         run: npx lerna bootstrap
         env:
           CI: true

--- a/.github/workflows/tests.all.yml
+++ b/.github/workflows/tests.all.yml
@@ -32,7 +32,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
       - name: Cache node modules
         uses: actions/cache@v3
         id: cache_node_modules

--- a/.github/workflows/tests.all.yml
+++ b/.github/workflows/tests.all.yml
@@ -44,8 +44,6 @@ jobs:
         run: npx lerna bootstrap
         env:
           CI: true
-      - name: Build all
-        run: npm run buildall
       - name: Run all tests
         run: npm run testall
       - name: Upload to codecov.io

--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -6,6 +6,8 @@ _types:
     dev:
       'mocha': &mocha '10.2.0'
       'chai': &chai '4.3.7'
+      '@freesewing/models': *freesewing
+      '@freesewing/plugin-timing': *freesewing
   plugin:
     peer:
       '@freesewing/core': *freesewing

--- a/designs/aaron/package.json
+++ b/designs/aaron/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/albert/package.json
+++ b/designs/albert/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/bee/package.json
+++ b/designs/bee/package.json
@@ -53,7 +53,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/bella/package.json
+++ b/designs/bella/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/benjamin/package.json
+++ b/designs/benjamin/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/bent/package.json
+++ b/designs/bent/package.json
@@ -55,7 +55,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/bob/package.json
+++ b/designs/bob/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/breanna/package.json
+++ b/designs/breanna/package.json
@@ -53,7 +53,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/brian/package.json
+++ b/designs/brian/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/bruce/package.json
+++ b/designs/bruce/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/carlita/package.json
+++ b/designs/carlita/package.json
@@ -57,7 +57,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/carlton/package.json
+++ b/designs/carlton/package.json
@@ -56,7 +56,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/carlton/src/back.mjs
+++ b/designs/carlton/src/back.mjs
@@ -1,7 +1,6 @@
 import { back as bentBack } from '@freesewing/bent'
 import { calculateRatios } from './shared.mjs'
 import { hidePresets } from '@freesewing/core'
-import { pluginCutlist } from '@freesewing/plugin-cutlist'
 
 function draftCarltonBack({
   paperless,
@@ -249,6 +248,5 @@ export const back = {
     waistEase: { pct: 14, min: 8, max: 25, menu: 'fit' },
     seatEase: { pct: 14, min: 8, max: 25, menu: 'fit' },
   },
-  plugins: [pluginCutlist],
   draft: draftCarltonBack,
 }

--- a/designs/carlton/src/front.mjs
+++ b/designs/carlton/src/front.mjs
@@ -1,7 +1,6 @@
 import { front as bentFront } from '@freesewing/bent'
 import { calculateRatios } from './shared.mjs'
 import { hidePresets } from '@freesewing/core'
-import { pluginCutlist } from '@freesewing/plugin-cutlist'
 
 function draftCarltonFront({
   paperless,
@@ -505,6 +504,5 @@ export const front = {
     seatEase: { pct: 14, min: 8, max: 25, menu: 'fit' },
     innerPocketWeltHeight: { pct: 3.5, min: 2.5, max: 5, menu: 'pockets' },
   },
-  plugins: [pluginCutlist],
   draft: draftCarltonFront,
 }

--- a/designs/carlton/src/topsleeve.mjs
+++ b/designs/carlton/src/topsleeve.mjs
@@ -1,6 +1,5 @@
 import { topSleeve as bentTopSleeve } from '@freesewing/bent'
 import { front as bentFront } from '@freesewing/bent'
-import { pluginCutlist } from '@freesewing/plugin-cutlist'
 
 function draftCarltonTopSleeve({
   paperless,
@@ -184,6 +183,5 @@ export const topSleeve = {
     sleevecapHeight: { pct: 45, min: 40, max: 60, menu: 'advanced' },
     sleevecapEase: { pct: 1, min: 0, max: 10, menu: 'advanced' },
   },
-  plugins: [pluginCutlist],
   draft: draftCarltonTopSleeve,
 }

--- a/designs/carlton/src/undersleeve.mjs
+++ b/designs/carlton/src/undersleeve.mjs
@@ -1,6 +1,5 @@
 import { underSleeve as bentUnderSleeve } from '@freesewing/bent'
 import { front as bentFront } from '@freesewing/bent'
-import { pluginCutlist } from '@freesewing/plugin-cutlist'
 
 function draftCarltonUnderSleeve({
   paperless,
@@ -163,6 +162,5 @@ export const underSleeve = {
     sleevecapHeight: { pct: 45, min: 40, max: 60, menu: 'advanced' },
     sleevecapEase: { pct: 1, min: 0, max: 10, menu: 'advanced' },
   },
-  plugins: [pluginCutlist],
   draft: draftCarltonUnderSleeve,
 }

--- a/designs/cathrin/package.json
+++ b/designs/cathrin/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/charlie/package.json
+++ b/designs/charlie/package.json
@@ -56,7 +56,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/cornelius/package.json
+++ b/designs/cornelius/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/diana/package.json
+++ b/designs/diana/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/examples/package.json
+++ b/designs/examples/package.json
@@ -49,7 +49,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/florence/package.json
+++ b/designs/florence/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/florent/package.json
+++ b/designs/florent/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/hi/package.json
+++ b/designs/hi/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/holmes/package.json
+++ b/designs/holmes/package.json
@@ -55,7 +55,9 @@
   },
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/hortensia/package.json
+++ b/designs/hortensia/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/huey/package.json
+++ b/designs/huey/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/hugo/package.json
+++ b/designs/hugo/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/jaeger/package.json
+++ b/designs/jaeger/package.json
@@ -56,7 +56,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/legend/package.json
+++ b/designs/legend/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/lucy/package.json
+++ b/designs/lucy/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/lunetius/package.json
+++ b/designs/lunetius/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/magde/package.json
+++ b/designs/magde/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/noble/package.json
+++ b/designs/noble/package.json
@@ -53,7 +53,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/octoplushy/package.json
+++ b/designs/octoplushy/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/paco/package.json
+++ b/designs/paco/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/penelope/package.json
+++ b/designs/penelope/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/plugintest/package.json
+++ b/designs/plugintest/package.json
@@ -64,7 +64,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/rendertest/package.json
+++ b/designs/rendertest/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/sandy/package.json
+++ b/designs/sandy/package.json
@@ -53,7 +53,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/shin/package.json
+++ b/designs/shin/package.json
@@ -53,7 +53,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/simon/package.json
+++ b/designs/simon/package.json
@@ -55,7 +55,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/simone/package.json
+++ b/designs/simone/package.json
@@ -56,7 +56,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/sven/package.json
+++ b/designs/sven/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/tamiko/package.json
+++ b/designs/tamiko/package.json
@@ -53,7 +53,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/teagan/package.json
+++ b/designs/teagan/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/tiberius/package.json
+++ b/designs/tiberius/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/titan/package.json
+++ b/designs/titan/package.json
@@ -53,7 +53,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/trayvon/package.json
+++ b/designs/trayvon/package.json
@@ -53,7 +53,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/tutorial/package.json
+++ b/designs/tutorial/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/unice/package.json
+++ b/designs/unice/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/ursula/package.json
+++ b/designs/ursula/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/wahid/package.json
+++ b/designs/wahid/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/walburga/package.json
+++ b/designs/walburga/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/waralee/package.json
+++ b/designs/waralee/package.json
@@ -52,7 +52,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/designs/yuri/package.json
+++ b/designs/yuri/package.json
@@ -54,7 +54,9 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "10.2.0",
-    "chai": "4.3.7"
+    "chai": "4.3.7",
+    "@freesewing/models": "3.0.0-alpha.9",
+    "@freesewing/plugin-timing": "3.0.0-alpha.9"
   },
   "files": [
     "dist/*",

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,19 @@
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": [],
+        "parallel": 5
+      }
+    }
+  },
+  "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build", "prebuild"]
+    },
+    "testci": {
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/nx.json
+++ b/nx.json
@@ -14,6 +14,9 @@
     },
     "testci": {
       "dependsOn": ["^build"]
+    },
+    "lint": {
+      "dependsOn": ["prebuild"]
     }
   }
 }


### PR DESCRIPTION
Caches are isolated by branch, BUT branches can access caches from their parent branch, so I believe this will speed up almost all workflows, and it will certainly speed up the the common use case of "I had a failed workflow and now I need to wait 4-8 minutes to see if my fix worked"

Seems like we get a 1-2 minute reduction in run time

I also leveraged Lerna's "Task Pipeline" configuration to tell it to make `build` and `test` scripts rely on running dependency `build` scripts, which eliminates the need for a separate build step in the test workflow, also shaving off about a minute. This required that I include `@freesewing/models` and `@freesewing/plugin-timing` as dev dependencies in the designs. 

I think better use of task pipelines could help us eliminate our build order management entirely, but that's another PR