### PR TITLE
fix (#3834) Use one dRaft sample for all example tabs

### DIFF
--- a/markdown/dev/guides/patterns/sets/en.md
+++ b/markdown/dev/guides/patterns/sets/en.md
@@ -18,16 +18,17 @@ _combine_ multiple drafted variants into a single pattern container.
 Here's a simple example:
 
 <Example settings="sample: { type: measurement, measurement: head }" withHead caption="A simple example of sampling the `head` measurement">
+
 ```js
-({ 
-  Point, 
-  points, 
-  Path, 
-  paths, 
-  Snippet, 
-  snippets, 
-  measurements, 
-  part 
+({
+  Point,
+  points,
+  Path,
+  paths,
+  Snippet,
+  snippets,
+  measurements,
+  part
 }) => {
 
   const size = measurements.head
@@ -44,6 +45,7 @@ Here's a simple example:
   return part
 }
 ```
+
 </Example>
 
 When drafting for multiple sets of settings, it's important to keep the different draft variants from cross-contaminating each other.
@@ -57,7 +59,8 @@ This is illustrated below:
 
 
 <Example caption="A schematic overview of what goes on inside a FreeSewing pattern">
-```mjs
+
+```js
 ({ Point, points, Path, paths, options, part }) => {
 
   // Draws a w*h box, returns a Path object
@@ -145,17 +148,17 @@ This is illustrated below:
 
   // Stacks
   drawBox('Stack 0', -30, -33, 50, 169, 'b', 'mark', 'fill-mark')
-  paths['Stack 0'].attr('fill-opacity', 0.2)
+  paths['Stack 0'].attr('fillOpacity', 0.2)
   drawBox('Stack 1', 23, -33, 50, 169, 'b', 'mark', 'fill-mark')
-  paths['Stack 1'].attr('fill-opacity', 0.2)
+  paths['Stack 1'].attr('fillOpacity', 0.2)
   drawBox('Stack 2', 76, -33, 50, 169, 'b', 'mark', 'fill-mark')
-  paths['Stack 2'].attr('fill-opacity', 0.2)
+  paths['Stack 2'].attr('fillOpacity', 0.2)
 
   // Sets
   drawBox('Set 0', -33, -30, 174, 76, 'r', 'contrast fill-contrast', 'bold text-lg fill-contrast')
-  paths['Set 0'].attr('fill-opacity', 0.2)
+  paths['Set 0'].attr('fillOpacity', 0.2)
   drawBox('Set 1', -33, 50, 174, 76, 'r', 'contrast fill-contrast', 'bold text-lg fill-contrast')
-  paths['Set 1'].attr('fill-opacity', 0.2)
+  paths['Set 1'].attr('fillOpacity', 0.2)
 
   // Parts set 0
   drawBox('Part A (set 0)', -27, -27, 44, 70, 'b', 'note')
@@ -174,7 +177,7 @@ This is illustrated below:
   drawBox('  snippets  ', 82, 6, 38, 12, true, 'note')
 
   drawBox('setStore 0', -24, 21, 144, 12, true, 'lining', 'fill-various')
-  paths['setStore 0'].attr('fill-opacity', 0.2)
+  paths['setStore 0'].attr('fillOpacity', 0.2)
 
   // Parts set 1
   drawBox('Part A (set 1)', -27, 53, 44, 70, 'b', 'note')
@@ -193,16 +196,17 @@ This is illustrated below:
   drawBox('   snippets  ', 82, 86, 38, 12, true, 'note')
 
   drawBox('setStore 1', -24, 101, 147, 12, true, 'lining', 'fill-various')
-  paths['setStore 1'].attr('fill-opacity', 0.2)
+  paths['setStore 1'].attr('fillOpacity', 0.2)
 
   // Pattern
   drawBox('Pattern Store', -30, -52, 155, 15, true, 'lining', 'fill-lining')
-  paths['Pattern Store'].attr('fill-opacity', 0.2)
+  paths['Pattern Store'].attr('fillOpacity', 0.2)
   drawBox('Pattern', -43, -59, 195, 216, 'b', 'fabric stroke-lg', 'text-lg bold')
 
   return part
 }
 ```
+
 </Example>
 
 ## One set is plenty
@@ -216,7 +220,8 @@ pattern-wide store and a different store per set, the so-called _setStore(s)_.
 Below is an illustration of a pattern with a single set of settings which, once again, is the vast majority of use cases:
 
 <Example caption="A schematic overview of what goes on inside a FreeSewing pattern in a typical use-case: a single set of settings">
-```mjs
+
+```js
 ({ Point, points, Path, paths, options, part }) => {
 
   // Draws a w*h box, returns a Path object
@@ -309,7 +314,7 @@ Below is an illustration of a pattern with a single set of settings which, once 
 
   // Sets
   drawBox('Set 0', -33, -30, 174, 76, 'r', 'contrast fill-contrast', 'bold text-lg fill-contrast')
-  paths['Set 0'].attr('fill-opacity', 0.2)
+  paths['Set 0'].attr('fillOpacity', 0.2)
 
   // Parts set 0
   drawBox('Part A (set 0)', -27, -27, 44, 70, 'b', 'note')
@@ -328,16 +333,17 @@ Below is an illustration of a pattern with a single set of settings which, once 
   drawBox('  snippets  ', 82, 6, 38, 12, true, 'note')
 
   drawBox('setStore 0', -24, 21, 144, 12, true, 'lining', 'fill-various')
-  paths['setStore 0'].attr('fill-opacity', 0.2)
+  paths['setStore 0'].attr('fillOpacity', 0.2)
 
   // Pattern
   drawBox('Pattern Store', -30, -52, 155, 15, true, 'lining', 'fill-lining')
-  paths['Pattern Store'].attr('fill-opacity', 0.2)
+  paths['Pattern Store'].attr('fillOpacity', 0.2)
   drawBox(' Pattern', -43, -59, 195, 128, 'b', 'fabric stroke-lg', 'text-lg bold')
 
   return part
 }
 ```
+
 </Example>
 
 


### PR DESCRIPTION
The bug was happening because that particular example was sampling a measurement. 

`Pattern.__measurementSets()`, called during measurement sampling, creates a new array of settings sets starting at `this.settings[0].measurements[measurementName] * 0.9`. Because the `Example` component was being passed an existing `Pattern` instance and then sampling it on render, every time the tabs were switched a new `Example` component was being mounted, causing the instance to be re-sampled and measurement being sampled to be reduced by 10%. The logo appeared to be getting bigger because it was staying the same size and the box was getting smaller.

This PR fixes the issue by drafting or sampling the pattern at the `TabbedExample` level, and passing the returned renderProps to the `Example` components instead.

It also fixes a compiler complaint about `fillOpacity` that came up while I was investigating the pattern sets documentation