### PR TITLE
fix(docs): (bruce) Correct description of side piece from symmetric to  not symmetric

### DIFF
--- a/markdown/org/docs/patterns/bruce/instructions/en.md
+++ b/markdown/org/docs/patterns/bruce/instructions/en.md
@@ -27,7 +27,9 @@ Serge them together, taking into account that the seam allowance is 1cm. So aim 
 
 ![Join back to second side](step02.png)
 
-Align the other side of the back (piece 1) with the second side (piece 3) making sure to put the good sides together. Since the side (piece 3) is symmetric, you can't go wrong.
+Align the other side of the back (piece 1) with the second side (piece 3)
+making sure to put the good sides together. Again, because the side (piece 3)
+is asymmetric, be careful to correctly match them.
 
 Serge them together, as you did on the other side.
 

--- a/markdown/org/docs/patterns/bruce/instructions/en.md
+++ b/markdown/org/docs/patterns/bruce/instructions/en.md
@@ -29,7 +29,7 @@ Serge them together, taking into account that the seam allowance is 1cm. So aim 
 
 Align the other side of the back (piece 1) with the second side (piece 3)
 making sure to put the good sides together. Again, because the side (piece 3)
-is asymmetric, be careful to correctly match them.
+is not symmetric, be careful to correctly match them.
 
 Serge them together, as you did on the other side.
 


### PR DESCRIPTION
Discussion:
https://discord.com/channels/698854858052075530/757632953097388043/1099674823162081280
discord://discord.com/channels/698854858052075530/757632953097388043/1099674823162081280

I elected to repeat the warning to better match the rest of the instruction wording, rather than simply say "repeat step 1" as had been suggested.

So with the fix:
> Step 1:
> Align the side of the back (piece 1) with the side (piece 3) making sure to put the good sides together. The side (piece 3) is not symmetric, so make be careful to correctly match them.

> Step 2:
> Align the other side of the back (piece 1) with the second side (piece 3) making sure to put the good sides together. Again, because the side (piece 3) is not symmetric, be careful to correctly match them.