### PR TITLE
fix(sandy): Correct 100% full circle angle and seam allowance

### DIFF
--- a/designs/sandy/src/skirt.mjs
+++ b/designs/sandy/src/skirt.mjs
@@ -76,7 +76,7 @@ function sandySkirt({
      * maximum angle calculated so the seam allowance fits in the
      * fabric
      */
-    if (an > 90 && sa) {
+    if (an > 90 && an !== 180 && sa) {
       const maxAn = utils.rad2deg(Math.atan(radiusWaist / sa))
       if (an > 90 + maxAn) an = 90 + maxAn
     }
@@ -138,7 +138,8 @@ function sandySkirt({
         .move(points.in2Flipped)
         .curve(points.in2CFlipped, points.in1CFlipped, points.in2FlippedRotated)
         .curve(points.in2CFlippedRotated, points.in1CFlippedRotated, points.in1Rotated)
-      if (!options.seamlessFullCircle) paths.saBase = paths.saBase.line(points.ex1Rotated)
+      if (!options.seamlessFullCircle && an !== 180)
+        paths.saBase = paths.saBase.line(points.ex1Rotated)
       paths.saBase = paths.saBase.offset(sa * -1)
 
       paths.hemBase.hide()


### PR DESCRIPTION
There was a behavior in Sandy where if a 100% circle is used and seam allowance is enabled, the skirt pattern is not the expected half-circle. Instead, the skirt falls short of a half-circle. This PR fixes this so 100% circle skirts have an exact half-circle pattern and there is no seam allowance along that 2nd edge (because it is on the fold).

Before the fix:
![Screenshot 2023-04-26 at 2 07 58 PM](https://user-images.githubusercontent.com/109869956/234704882-90692fa8-7be7-4b7f-9d55-b0e901a3e03e.png)

After the fix:
![Screenshot 2023-04-26 at 2 05 24 PM](https://user-images.githubusercontent.com/109869956/234704735-8c36d6e0-12db-4097-bdab-7dbb74b659b7.png)

This has a side effect that the pattern jumps between 99.9% and 100.0%:

At 99.9%:
![Screenshot 2023-04-26 at 2 02 45 PM](https://user-images.githubusercontent.com/109869956/234705496-c8c961b1-39e3-4c34-b3fb-6bd8caf0cf07.png)

At 100.0%:
![Screenshot 2023-04-26 at 2 02 29 PM](https://user-images.githubusercontent.com/109869956/234705523-b4eeda43-c2fe-4362-a4b7-cfacb64b991b.png)

