### PR TITLE
Add cutlists to blocks/slopers

### DIFF
--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -253,6 +253,11 @@ export const back = {
       .close()
       .hide()
 
+    macro('grainline', {
+      from: new Point(points.hps.x / 2, points.shoulder.y),
+      to: new Point(points.hps.x / 2, points.waistSide.y),
+    })
+
     store.cutlist.addCut()
 
     if (complete) {
@@ -261,10 +266,6 @@ export const back = {
         nr: 2,
         title: 'back',
         at: points.titleAnchor,
-      })
-      macro('grainline', {
-        from: new Point(points.hps.x / 2, points.shoulder.y),
-        to: new Point(points.hps.x / 2, points.waistSide.y),
       })
       macro('sprinkle', {
         snippet: 'bnotch',

--- a/designs/bella/src/front-side-dart.mjs
+++ b/designs/bella/src/front-side-dart.mjs
@@ -204,7 +204,7 @@ export const frontSideDart = {
       .curve(points.hpsCp2, points.cfNeckCp1, points.cfNeck)
       .hide()
 
-    store.cutlist.addCut()
+    store.cutlist.addCut({ cut: 1 })
 
     if (complete) {
       points.titleAnchor = new Point(points.armholePitch.x / 2, points.armholePitchCp2.y)

--- a/designs/bella/src/front-side-dart.mjs
+++ b/designs/bella/src/front-side-dart.mjs
@@ -204,6 +204,12 @@ export const frontSideDart = {
       .curve(points.hpsCp2, points.cfNeckCp1, points.cfNeck)
       .hide()
 
+    macro('cutonfold', {
+      from: points.cfNeck,
+      to: points.cfHem,
+      grainline: true,
+    })
+
     store.cutlist.addCut({ cut: 1 })
 
     if (complete) {
@@ -220,11 +226,6 @@ export const frontSideDart = {
         .line(points.bustDartEdge)
         .line(points.bustDartBottom)
         .attr('class', 'help')
-      macro('cutonfold', {
-        from: points.cfNeck,
-        to: points.cfHem,
-        grainline: true,
-      })
       macro('sprinkle', {
         snippet: 'notch',
         on: ['bust', 'armholePitch', 'cfBust'],

--- a/designs/bent/src/topsleeve.mjs
+++ b/designs/bent/src/topsleeve.mjs
@@ -11,12 +11,15 @@ function draftBentTopSleeve({
   snippets,
   Snippet,
   sa,
+  store,
   part,
 }) {
   // Extract seamline from sleeve
   delete paths.us
   paths.seam = paths.ts.clone().attr('class', 'fabric', true)
   delete paths.ts
+
+  store.cutlist.addCut()
 
   // Complete?
   if (complete) {

--- a/designs/bent/src/undersleeve.mjs
+++ b/designs/bent/src/undersleeve.mjs
@@ -11,6 +11,7 @@ function draftBentUnderSleeve({
   snippets,
   Snippet,
   sa,
+  store,
   part,
 }) {
   // Extract seamline from sleeve
@@ -19,6 +20,8 @@ function draftBentUnderSleeve({
   delete paths.us
 
   points.anchor = points.usTip.clone()
+
+  store.cutlist.addCut()
 
   // Complete?
   if (complete) {

--- a/designs/breanna/src/back.mjs
+++ b/designs/breanna/src/back.mjs
@@ -170,6 +170,8 @@ function draftBreannaBack({
   // Anchor point
   points.gridAnchor = points.cbNeck.clone()
 
+  store.cutlist.addCut()
+
   // Complete pattern?
   if (complete) {
     // Title
@@ -182,6 +184,13 @@ function draftBreannaBack({
 
     // Notch
     snippets.armholePitch = new Snippet('bnotch', points.armholePitch)
+
+    // Grainline
+    const grainlineDistance = (points.armhole.x - points.cbNeck.x) * 0.1
+    macro('grainline', {
+      from: points.cbNeck.shift(0, grainlineDistance),
+      to: points.cbWaist.shift(0, grainlineDistance),
+    })
 
     if (sa) paths.sa = paths.saBase.offset(sa).attr('class', 'sa')
   }

--- a/designs/breanna/src/back.mjs
+++ b/designs/breanna/src/back.mjs
@@ -170,6 +170,13 @@ function draftBreannaBack({
   // Anchor point
   points.gridAnchor = points.cbNeck.clone()
 
+  // Grainline
+  const grainlineDistance = (points.armhole.x - points.cbNeck.x) * 0.1
+  macro('grainline', {
+    from: points.cbNeck.shift(0, grainlineDistance),
+    to: points.cbWaist.shift(0, grainlineDistance),
+  })
+
   store.cutlist.addCut()
 
   // Complete pattern?
@@ -184,13 +191,6 @@ function draftBreannaBack({
 
     // Notch
     snippets.armholePitch = new Snippet('bnotch', points.armholePitch)
-
-    // Grainline
-    const grainlineDistance = (points.armhole.x - points.cbNeck.x) * 0.1
-    macro('grainline', {
-      from: points.cbNeck.shift(0, grainlineDistance),
-      to: points.cbWaist.shift(0, grainlineDistance),
-    })
 
     if (sa) paths.sa = paths.saBase.offset(sa).attr('class', 'sa')
   }

--- a/designs/breanna/src/front.mjs
+++ b/designs/breanna/src/front.mjs
@@ -145,6 +145,8 @@ function draftBreannaFront({
   // Anchor point
   points.gridAnchor = points.cfNeck.clone()
 
+  store.cutlist.addCut({ cut: 1 })
+
   // Complete pattern?
   if (complete) {
     // Logo
@@ -159,6 +161,12 @@ function draftBreannaFront({
     snippets.bustNotch = new Snippet('notch', points.bustPoint)
     snippets.armholePitch = new Snippet('notch', points.armholePitch)
 
+    // CutonfoldAndGrainline
+    macro('cutonfold', {
+      from: points.cfNeck,
+      to: points.cfWaist,
+      grainline: true,
+    })
     if (sa) paths.sa = paths.saBase.offset(sa).attr('class', 'sa')
   }
 

--- a/designs/breanna/src/front.mjs
+++ b/designs/breanna/src/front.mjs
@@ -145,6 +145,13 @@ function draftBreannaFront({
   // Anchor point
   points.gridAnchor = points.cfNeck.clone()
 
+  // CutonfoldAndGrainline
+  macro('cutonfold', {
+    from: points.cfNeck,
+    to: points.cfWaist,
+    grainline: true,
+  })
+
   store.cutlist.addCut({ cut: 1 })
 
   // Complete pattern?
@@ -161,12 +168,6 @@ function draftBreannaFront({
     snippets.bustNotch = new Snippet('notch', points.bustPoint)
     snippets.armholePitch = new Snippet('notch', points.armholePitch)
 
-    // CutonfoldAndGrainline
-    macro('cutonfold', {
-      from: points.cfNeck,
-      to: points.cfWaist,
-      grainline: true,
-    })
     if (sa) paths.sa = paths.saBase.offset(sa).attr('class', 'sa')
   }
 

--- a/designs/breanna/src/sleeve.mjs
+++ b/designs/breanna/src/sleeve.mjs
@@ -52,6 +52,11 @@ function draftBreannaSleeve(params) {
   // Anchor point for sampling
   points.gridAnchor = new Point(0, 0)
 
+  macro('grainline', {
+    from: points.centerWrist,
+    to: points.centerBiceps,
+  })
+
   store.cutlist.addCut()
 
   // Complete pattern?
@@ -59,7 +64,6 @@ function draftBreannaSleeve(params) {
     points.logo = points.centerBiceps.shiftFractionTowards(points.centerWrist, 0.3)
     snippets.logo = new Snippet('logo', points.logo)
     macro('title', { at: points.centerBiceps, nr: 3, title: 'sleeve' })
-    macro('grainline', { from: points.centerWrist, to: points.centerBiceps })
     points.scaleboxAnchor = points.scalebox = points.centerBiceps.shiftFractionTowards(
       points.centerWrist,
       0.5

--- a/designs/breanna/src/sleeve.mjs
+++ b/designs/breanna/src/sleeve.mjs
@@ -52,6 +52,8 @@ function draftBreannaSleeve(params) {
   // Anchor point for sampling
   points.gridAnchor = new Point(0, 0)
 
+  store.cutlist.addCut()
+
   // Complete pattern?
   if (complete) {
     points.logo = points.centerBiceps.shiftFractionTowards(points.centerWrist, 0.3)

--- a/designs/brian/src/back.mjs
+++ b/designs/brian/src/back.mjs
@@ -126,14 +126,14 @@ export const back = {
     store.set('backArmholeLength', shared.armholeLength(points, Path))
     store.set('backArmholeToArmholePitch', shared.armholeToArmholePitch(points, Path))
 
+    macro('cutonfold', {
+      from: points.cbNeck,
+      to: points.cbHips,
+      grainline: true,
+    })
+
     // Complete pattern?
     if (complete) {
-      macro('cutonfold', {
-        from: points.cbNeck,
-        to: points.cbHips,
-        grainline: true,
-      })
-
       macro('title', { at: points.title, nr: 2, title: 'back' })
       snippets.armholePitchNotch = new Snippet('bnotch', points.armholePitch)
       paths.waist = new Path().move(points.cbWaist).line(points.waist).attr('class', 'help')

--- a/designs/brian/src/front.mjs
+++ b/designs/brian/src/front.mjs
@@ -141,13 +141,14 @@ export const front = {
     store.set('frontArmholeLength', shared.armholeLength(points, Path))
     store.set('frontArmholeToArmholePitch', shared.armholeToArmholePitch(points, Path))
 
+    macro('cutonfold', {
+      from: points.cfNeck,
+      to: points.cfHips,
+      grainline: true,
+    })
+
     // Complete pattern?
     if (complete) {
-      macro('cutonfold', {
-        from: points.cfNeck,
-        to: points.cfHips,
-        grainline: true,
-      })
       macro('title', { at: points.title, nr: 1, title: 'front' })
       snippets.armholePitchNotch = new Snippet('notch', points.armholePitch)
       paths.waist = new Path().move(points.cfWaist).line(points.waist).attr('class', 'help')

--- a/designs/brian/src/sleeve.mjs
+++ b/designs/brian/src/sleeve.mjs
@@ -56,6 +56,9 @@ export const sleeve = {
     // Anchor point for sampling
     points.gridAnchor = new Point(0, 0)
 
+    store.cutlist.removeCut()
+    store.cutlist.addCut()
+
     // Complete pattern?
     if (complete) {
       points.logo = points.centerBiceps.shiftFractionTowards(points.centerWrist, 0.3)

--- a/designs/brian/src/sleeve.mjs
+++ b/designs/brian/src/sleeve.mjs
@@ -56,6 +56,11 @@ export const sleeve = {
     // Anchor point for sampling
     points.gridAnchor = new Point(0, 0)
 
+    macro('grainline', {
+      from: points.centerWrist,
+      to: points.centerBiceps,
+    })
+
     store.cutlist.removeCut()
     store.cutlist.addCut()
 
@@ -64,7 +69,6 @@ export const sleeve = {
       points.logo = points.centerBiceps.shiftFractionTowards(points.centerWrist, 0.3)
       snippets.logo = new Snippet('logo', points.logo)
       macro('title', { at: points.centerBiceps, nr: 3, title: 'sleeve' })
-      macro('grainline', { from: points.centerWrist, to: points.centerBiceps })
       points.scaleboxAnchor = points.scalebox = points.centerBiceps.shiftFractionTowards(
         points.centerWrist,
         0.5

--- a/designs/noble/src/backinside.mjs
+++ b/designs/noble/src/backinside.mjs
@@ -2,6 +2,7 @@ import { backPoints } from './backpoints.mjs'
 
 function nobleBackInside({
   sa,
+  Point,
   points,
   Path,
   paths,
@@ -32,6 +33,13 @@ function nobleBackInside({
       .attr('class', 'fabric')
   }
 
+  ;(points.grainlineFrom = new Point(points.hps.x / 2, points.shoulder.y)),
+    (points.grainlineTo = new Point(points.hps.x / 2, points.waistSide.y)),
+    macro('grainline', {
+      from: points.grainlineFrom,
+      to: points.grainlineTo,
+    })
+
   if (complete) {
     snippets.dartTip = new Snippet('notch', points.dartTip)
 
@@ -39,10 +47,6 @@ function nobleBackInside({
       at: points.titleAnchor,
       nr: 3,
       title: options.dartPosition != 'shoulder' ? 'Back' : 'Inside Back',
-    })
-    macro('grainline', {
-      from: points.grainlineFrom,
-      to: points.grainlineTo,
     })
 
     if (sa) paths.sa = paths.insideSeam.offset(sa).attr('class', 'fabric sa')

--- a/designs/noble/src/backinside.mjs
+++ b/designs/noble/src/backinside.mjs
@@ -33,12 +33,12 @@ function nobleBackInside({
       .attr('class', 'fabric')
   }
 
-  ;(points.grainlineFrom = new Point(points.hps.x / 2, points.shoulder.y)),
-    (points.grainlineTo = new Point(points.hps.x / 2, points.waistSide.y)),
-    macro('grainline', {
-      from: points.grainlineFrom,
-      to: points.grainlineTo,
-    })
+  points.grainlineFrom = new Point(points.hps.x / 2, points.shoulder.y)
+  points.grainlineTo = new Point(points.hps.x / 2, points.waistSide.y)
+  macro('grainline', {
+    from: points.grainlineFrom,
+    to: points.grainlineTo,
+  })
 
   if (complete) {
     snippets.dartTip = new Snippet('notch', points.dartTip)

--- a/designs/noble/src/backoutside.mjs
+++ b/designs/noble/src/backoutside.mjs
@@ -2,6 +2,7 @@ import { backPoints } from './backpoints.mjs'
 
 function nobleBackOutside({
   sa,
+  Point,
   points,
   Path,
   paths,
@@ -34,6 +35,20 @@ function nobleBackOutside({
     .close()
     .attr('class', 'fabric')
 
+  points.grainlineFrom = new Point(
+    Math.max(points.shoulderDart.x, points.dartBottomRight.x),
+    points.shoulder.y
+  )
+  points.grainlineTo = new Point(
+    points.grainlineFrom.x,
+    points.waistSide.y - (points.waistSide.y - points.shoulder.y) * 0.4
+  )
+
+  macro('grainline', {
+    from: points.grainlineFrom,
+    to: points.grainlineTo,
+  })
+
   if (complete) {
     snippets.dartTip = new Snippet('notch', points.dartTip)
 
@@ -44,13 +59,6 @@ function nobleBackOutside({
       at: points.titleAnchor,
       nr: 4,
       title: 'Outside Back',
-    })
-    points.grainlineFrom.x = points.shoulderDart.x
-    points.grainlineTo.x = points.shoulderDart.x
-
-    macro('grainline', {
-      from: points.grainlineFrom,
-      to: points.grainlineTo,
     })
 
     if (sa) paths.sa = paths.outsideSeam.offset(sa).attr('class', 'fabric sa')

--- a/designs/noble/src/frontinside.mjs
+++ b/designs/noble/src/frontinside.mjs
@@ -90,6 +90,12 @@ function nobleFrontInside({
     )
   }
 
+  macro('cutonfold', {
+    from: points.cfNeck,
+    to: points.cfHem,
+    grainline: true,
+  })
+
   if (complete) {
     if (options.dartPosition == 'shoulder') {
       snippets.shoulderDartTip = new Snippet('notch', points.shoulderDartTip)
@@ -104,12 +110,6 @@ function nobleFrontInside({
     })
     points.scaleboxAnchor = points.titleAnchor.shift(-90, 90).shift(0, 10)
     macro('scalebox', { at: points.scaleboxAnchor, rotate: 270 })
-
-    macro('cutonfold', {
-      from: points.cfNeck,
-      to: points.cfHem,
-      grainline: true,
-    })
 
     if (sa) {
       paths.sa = paths.insideSeam.offset(sa).line(points.cfNeck).attr('class', 'fabric sa')

--- a/designs/noble/src/frontoutside.mjs
+++ b/designs/noble/src/frontoutside.mjs
@@ -22,6 +22,7 @@ function nobleFrontOutside({
   delete points.bustDartCpBottom
   delete points.bustB
   delete points.bustDartEdge
+  macro('cutonfold', false)
 
   if (options.dartPosition == 'shoulder') {
     paths.princessSeam = new Path()
@@ -64,6 +65,9 @@ function nobleFrontOutside({
       .close()
       .attr('class', 'fabric')
   }
+
+  store.cutlist.removeCut()
+  store.cutlist.addCut()
 
   if (complete) {
     points.snippet = paths.princessSeam.shiftAlong(

--- a/designs/noble/src/frontoutside.mjs
+++ b/designs/noble/src/frontoutside.mjs
@@ -66,15 +66,15 @@ function nobleFrontOutside({
       .attr('class', 'fabric')
   }
 
-  store.cutlist.removeCut()
-  store.cutlist.addCut()
-
   points.grainTop = points.armhole.shift(225, 20)
   points.grainBottom = points.sideHemInitial.shift(135, 20)
   macro('grainline', {
     from: points.grainBottom,
     to: points.grainTop,
   })
+
+  store.cutlist.removeCut()
+  store.cutlist.addCut()
 
   if (complete) {
     points.snippet = paths.princessSeam.shiftAlong(

--- a/designs/noble/src/frontoutside.mjs
+++ b/designs/noble/src/frontoutside.mjs
@@ -69,6 +69,13 @@ function nobleFrontOutside({
   store.cutlist.removeCut()
   store.cutlist.addCut()
 
+  points.grainTop = points.armhole.shift(225, 20)
+  points.grainBottom = points.sideHemInitial.shift(135, 20)
+  macro('grainline', {
+    from: points.grainBottom,
+    to: points.grainTop,
+  })
+
   if (complete) {
     points.snippet = paths.princessSeam.shiftAlong(
       paths.princessSeam.length() - store.get('shoulderDartTipNotch')
@@ -82,13 +89,6 @@ function nobleFrontOutside({
       at: points.titleAnchor,
       nr: 2,
       title: 'Outside Front',
-    })
-    points.grainTop = points.armhole.shift(225, 20)
-    points.grainBottom = points.sideHemInitial.shift(135, 20)
-
-    macro('grainline', {
-      from: points.grainBottom,
-      to: points.grainTop,
     })
 
     if (sa) paths.sa = paths.seam.offset(sa).attr('class', 'fabric sa')

--- a/designs/titan/src/back.mjs
+++ b/designs/titan/src/back.mjs
@@ -240,14 +240,15 @@ function titanBack({
   // Paths
   paths.seam = drawPath().attr('class', 'fabric')
 
+  points.grainlineTop.y = points.styleWaistOut.y
+  macro('grainline', {
+    from: points.grainlineTop,
+    to: points.grainlineBottom,
+  })
+
   store.cutlist.addCut()
 
   if (complete) {
-    points.grainlineTop.y = points.styleWaistOut.y
-    macro('grainline', {
-      from: points.grainlineTop,
-      to: points.grainlineBottom,
-    })
     macro('scalebox', { at: points.knee })
     points.logoAnchor = new Point(points.crossSeamCurveStart.x / 2, points.fork.y)
     snippets.logo = new Snippet('logo', points.logoAnchor)

--- a/designs/titan/src/back.mjs
+++ b/designs/titan/src/back.mjs
@@ -240,6 +240,8 @@ function titanBack({
   // Paths
   paths.seam = drawPath().attr('class', 'fabric')
 
+  store.cutlist.addCut()
+
   if (complete) {
     points.grainlineTop.y = points.styleWaistOut.y
     macro('grainline', {

--- a/designs/titan/src/front.mjs
+++ b/designs/titan/src/front.mjs
@@ -315,14 +315,15 @@ function titanFront({
   // Seamline
   paths.seam = drawPath().attr('class', 'fabric')
 
+  points.grainlineTop.y = points.styleWaistIn.y
+  macro('grainline', {
+    from: points.grainlineTop,
+    to: points.grainlineBottom,
+  })
+
   store.cutlist.addCut()
 
   if (complete) {
-    points.grainlineTop.y = points.styleWaistIn.y
-    macro('grainline', {
-      from: points.grainlineTop,
-      to: points.grainlineBottom,
-    })
     points.logoAnchor = new Point(points.crotchSeamCurveStart.x / 2, points.fork.y)
     snippets.logo = new Snippet('logo', points.logoAnchor)
     points.titleAnchor = points.logoAnchor.shift(-90, 60)

--- a/designs/titan/src/front.mjs
+++ b/designs/titan/src/front.mjs
@@ -315,6 +315,8 @@ function titanFront({
   // Seamline
   paths.seam = drawPath().attr('class', 'fabric')
 
+  store.cutlist.addCut()
+
   if (complete) {
     points.grainlineTop.y = points.styleWaistIn.y
     macro('grainline', {


### PR DESCRIPTION
PR to add cutlist info to the block/sloper designs. It is important to do this first, before adding cutlists to other designs that inherit from them.

- I chose to add a minimal amount of `addCut()`s, only adding code where needed to produce the correct cutting layout. (The alternative I considered was adding explicit cutlist code to every part, even when not required, in the name of potential clarity.)
- Some parts have a `removeCut()` that was needed to clear an inherited cutlist. I elected to not add a comment explaining these situations.
- I also considered adding an explicit `removeCut()` to every inheriting part regardless of whether it was needed, but I chose not to do so.
- I added a missing `cutonfoldAndGrainline` to Breanna's front. The foldline and grainline are mentioned in the instructions and code, so it appears that the omission was accidental. 
- I added a matching `grainline` to Breanna's back, assuming that it was also intended (given that the front is aligned on grainline) but accidentally omitted.

![Screenshot 2023-04-26 at 7 08 35 PM](https://user-images.githubusercontent.com/109869956/234743035-2fdd6607-3cd9-462f-95b7-9a17b74a4cf4.png)
![Screenshot 2023-04-26 at 7 09 09 PM](https://user-images.githubusercontent.com/109869956/234743045-b0e3b1a1-7b0d-417f-a93f-5aef4d9dae90.png)
![Screenshot 2023-04-26 at 7 08 15 PM](https://user-images.githubusercontent.com/109869956/234743078-526bf98e-eef5-4120-8c8c-5824fc74be3b.png)
![Screenshot 2023-04-26 at 7 09 26 PM](https://user-images.githubusercontent.com/109869956/234743098-e83d0025-ecd7-4083-b55a-432ac55310b1.png)
![Screenshot 2023-04-26 at 7 10 07 PM](https://user-images.githubusercontent.com/109869956/234743109-e1b72bf4-a501-468b-994b-47a78d0792c2.png)
![Screenshot 2023-04-26 at 7 17 31 PM](https://user-images.githubusercontent.com/109869956/234743121-1edf5b6e-1497-4c54-a81a-b13b3c885eee.png)
