### PR TITLE
chore (workflows) enforce consistent caching across workflows

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@
 *.md
 *.prisma
 *.css
+*.mustache
 Dockerfile
 .git
 .env

--- a/.github/workflows/lint.all.yml
+++ b/.github/workflows/lint.all.yml
@@ -29,7 +29,7 @@ jobs:
         id: cache_node_modules
         with:
           # caching node_modules
-          path: node_modules
+          path: '**/node_modules'
           key: node_modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         if: steps.cache_node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/lint.diff.yml
+++ b/.github/workflows/lint.diff.yml
@@ -35,7 +35,7 @@ jobs:
         id: cache_node_modules
         with:
           # caching node_modules
-          path: node_modules
+          path: '**/node_modules'
           key: node_modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         if: steps.cache_node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ jobs:
       id: cache_node_modules
       with:
         # caching node_modules
-        path: node_modules
+        path: '**/node_modules'
         key: node_modules-${{ hashFiles('yarn.lock') }}
     - name: Install dependencies
       if: steps.cache_node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.all.yml
+++ b/.github/workflows/tests.all.yml
@@ -37,7 +37,7 @@ jobs:
         id: cache_node_modules
         with:
           # caching node_modules
-          path: node_modules
+          path: '**/node_modules'
           key: node_modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         if: steps.cache_node_modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
While working on the workflow for testing new-design I learned that simply caching the root `node_modules` means that some dependencies might get missed if they are not hoisted because they are not shared. So this PR now brings all workflows that use caching in line with the strategy of caching all `node_modules` folders

it also adds mustache files to the lint ignore in hopes of streamlining linting, but I'm not sure that'll help with lint.diff