### PR TITLE
DRAFT: chore(hi): Add cutlist

### DIFF
--- a/designs/hi/src/aboveMouth.mjs
+++ b/designs/hi/src/aboveMouth.mjs
@@ -85,6 +85,8 @@ function draftHiAboveMouth({
   store.set('aboveMouthBottomLength', paths.bellyAndMouthAttachment.length())
   store.set('aboveMouthFinLength', points.aboveMouth02.dist(points.aboveMouth03))
 
+  store.cutlist.addCut({ material: 'color2Belly' })
+
   // Complete?
   if (complete) {
     points.aboveMouthSnippet = new Path()

--- a/designs/hi/src/belly.mjs
+++ b/designs/hi/src/belly.mjs
@@ -186,6 +186,15 @@ function draftHiBelly({
       .length()
   )
 
+  points.grainlineFrom = new Point(points.belly10.x, points.belly02.y * 0.7)
+  points.grainlineTo = new Point(points.belly05.x, points.belly02.y * 0.7)
+  macro('grainline', {
+    from: points.grainlineFrom,
+    to: points.grainlineTo,
+  })
+
+  store.cutlist.addCut({ cut: 1, material: 'color2Belly' })
+
   // Complete?
   if (complete) {
     points.bellyMouthSnippet1 = paths.mouthAttachment1
@@ -261,14 +270,6 @@ function draftHiBelly({
       dy: 0,
       spaces: 3,
       repeat: 3,
-    })
-
-    points.grainlineFrom = new Point(points.belly10.x, points.belly02.y * 0.7)
-    points.grainlineTo = new Point(points.belly05.x, points.belly02.y * 0.7)
-
-    macro('grainline', {
-      from: points.grainlineFrom,
-      to: points.grainlineTo,
     })
 
     if (paperless) {

--- a/designs/hi/src/body.mjs
+++ b/designs/hi/src/body.mjs
@@ -395,6 +395,14 @@ function draftHiBody({
   // Reduce precision as size goes up coz performance
   store.set('tolerance', options.size < 1 ? 1 : options.size * 100)
 
+  points.grainlineFrom = points.body13.shiftFractionTowards(points.body03, 0.5)
+  macro('grainline', {
+    from: points.grainlineFrom,
+    to: points.body03,
+  })
+
+  store.cutlist.addCut({ material: 'color1UpperBody' })
+
   // Complete?
   if (complete) {
     points.bodyTailSnippet = new Path()
@@ -458,12 +466,6 @@ function draftHiBody({
       from: points.body13,
       to: points.body01,
       d: -5,
-    })
-
-    points.grainlineFrom = points.body13.shiftFractionTowards(points.body03, 0.5)
-    macro('grainline', {
-      from: points.grainlineFrom,
-      to: points.body03,
     })
 
     points.titleAnchor = points.body04.shiftFractionTowards(points.body17, 0.4)

--- a/designs/hi/src/bottomFin.mjs
+++ b/designs/hi/src/bottomFin.mjs
@@ -95,6 +95,8 @@ function draftHiBottomFin({
     .curve(points.bottomFin03cp1, points.bottomFin01cp2, points.bottomFin01)
     .close()
 
+  store.cutlist.addCut({ material: 'color1UpperBody' })
+
   // Complete?
   if (complete) {
     const finAttachment = new Path()

--- a/designs/hi/src/lowerTeeth.mjs
+++ b/designs/hi/src/lowerTeeth.mjs
@@ -57,11 +57,18 @@ function draftHiLowerTeeth({
     part
   )
 
+  store.cutlist.addCut({ cut: 1, material: 'color4Teeth' })
+
   // Complete?
   if (complete) {
     snippets.lowerTeeth = new Snippet('bnotch', points.lowerTeeth01)
 
     points.titleAnchor = points.lowerTeeth02.shiftFractionTowards(points.lowerTeeth03, 0.5) //.shiftFractionTowards(points.lowerTeeth01, 0.5)
+
+    // Bounding box to prevent title clipping
+    paths.bbox = new Path()
+      .move(points.lowerTeeth02)
+      .move(new Point(points.lowerTeeth03.x, points.lowerTeeth03.y * 1.75))
 
     macro('title', {
       at: points.titleAnchor,

--- a/designs/hi/src/mouth.mjs
+++ b/designs/hi/src/mouth.mjs
@@ -72,6 +72,8 @@ function draftHiMouth({
       .length()
   )
 
+  store.cutlist.addCut({ cut: 1, material: 'color3Mouth' })
+
   // Complete?
   if (complete) {
     points.mouthUpperTeeth1 = new Path()

--- a/designs/hi/src/tail.mjs
+++ b/designs/hi/src/tail.mjs
@@ -81,6 +81,8 @@ function draftHiTail({
     .curve(points.tail05cp1, points.tail01cp2, points.tail01)
     .close()
 
+  store.cutlist.addCut({ material: 'color1UpperBody' })
+
   // Complete?
   if (complete) {
     points.tailSnippet = new Path()

--- a/designs/hi/src/topFin.mjs
+++ b/designs/hi/src/topFin.mjs
@@ -75,6 +75,8 @@ function draftHiTopFin({
       .length()
   )
 
+  store.cutlist.addCut({ material: 'color1UpperBody' })
+
   // Complete?
   if (complete) {
     paths.body = new Path()

--- a/designs/hi/src/upperTeeth.mjs
+++ b/designs/hi/src/upperTeeth.mjs
@@ -60,6 +60,8 @@ function draftHiUpperTeeth({
   )
   //createTeeth(paths.seam, 18 * options.size, 9 * options.size, 15, options.aggressive, paths.teeth)
 
+  store.cutlist.addCut({ cut: 1, material: 'color4Teeth' })
+
   // Complete?
   if (complete) {
     snippets.upperTeeth = new Snippet('bnotch', points.upperTeeth01)


### PR DESCRIPTION
Draft PR, to ask questions about best practices for cutting instructions. This PR is for Hi, to add the cutting instructions listed here: https://freesewing.org/docs/patterns/hi/cutting/

What are the best practices for using custom materials in cutlists?
1. If there are no `fabric` pieces in the cutlist, switching to the Cutting Layout results in a blank screen, until one of the material tabs is selected. Is having `fabric` as one of the materials a best practice?
![Screenshot 2023-04-27 at 5 53 32 PM](https://user-images.githubusercontent.com/109869956/235029367-68d925ba-0f0d-41d3-a120-c682e247db2c.png)

2. If I use a space character in the material name, it appears prefixed with "Plugin". Is the best practice to use words with no spaces? Possibly to assist with translations? Example when setting the material as `color 3`:
![Screenshot 2023-04-27 at 5 56 00 PM](https://user-images.githubusercontent.com/109869956/235029678-63de6a27-86ac-46a2-8413-df0dbf4ada89.png)

3. I'm not sure what determines the order of the material tabs. It might be beyond the scope of current functionality, but it might be nice to be able to specify an order so the most important material is listed first, etc.