### PR TITLE
fix(benjamin): Part name changes, instructions, and cutlist

### DIFF
--- a/designs/benjamin/src/bow1.mjs
+++ b/designs/benjamin/src/bow1.mjs
@@ -10,6 +10,7 @@ function draftBenjaminBow1({
   sa,
   store,
   paperless,
+  options,
   part,
 }) {
   points.bandBottomLeft = points.bandBottomLeft.shift(0, 0)
@@ -31,6 +32,14 @@ function draftBenjaminBow1({
     .attr('class', 'fabric')
     .unhide()
 
+  if (options.adjustmentRibbon) {
+    store.cutlist.addCut({ cut: 1 })
+    store.cutlist.addCut({ cut: 1, material: 'interfacing' })
+  } else {
+    store.cutlist.addCut({ cut: 4 })
+    store.cutlist.addCut({ cut: 4, material: 'interfacing' })
+  }
+
   if (complete) {
     // Paperless?
     if (paperless) {
@@ -46,7 +55,7 @@ function draftBenjaminBow1({
     macro('title', {
       at: points.titleAnchor,
       nr: 1,
-      title: 'bowTie',
+      title: options.adjustmentRibbon ? 'Short Bow' : 'Bow',
       scale: store.get('tipWidth') / 75,
     })
     points.scaleboxAnchor = points.bandTopLeft.shift(30, 80)

--- a/designs/benjamin/src/bow2.mjs
+++ b/designs/benjamin/src/bow2.mjs
@@ -34,6 +34,9 @@ function draftBenjaminBow2({
     .attr('class', 'fabric')
     .unhide()
 
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'interfacing' })
+
   if (complete) {
     // Paperless?
     if (paperless) {
@@ -49,7 +52,7 @@ function draftBenjaminBow2({
     macro('title', {
       at: points.titleAnchor,
       nr: 2,
-      title: 'bowTie',
+      title: 'Medium Bow',
       scale: store.get('tipWidth') / 75,
     })
   }

--- a/designs/benjamin/src/bow3.mjs
+++ b/designs/benjamin/src/bow3.mjs
@@ -34,6 +34,9 @@ function draftBenjaminBow3({
     .attr('class', 'fabric')
     .unhide()
 
+  store.cutlist.addCut({ cut: 1 })
+  store.cutlist.addCut({ cut: 1, material: 'interfacing' })
+
   if (complete) {
     // Paperless?
     if (paperless) {
@@ -49,7 +52,7 @@ function draftBenjaminBow3({
     macro('title', {
       at: points.titleAnchor,
       nr: 3,
-      title: 'bowTie',
+      title: 'Long Bow',
       scale: store.get('tipWidth') / 75,
     })
   }

--- a/designs/benjamin/src/ribbon.mjs
+++ b/designs/benjamin/src/ribbon.mjs
@@ -36,12 +36,15 @@ function draftBenjaminRibbon({
     .close()
     .attr('class', 'fabric')
 
+  store.cutlist.addCut()
+  store.cutlist.addCut({ cut: 2, material: 'interfacing' })
+
   if (complete) {
     if (sa) paths.sa = paths.seam.offset(sa).attr('class', 'fabric sa')
     macro('title', {
       at: points.titleAnchor,
       nr: 2,
-      title: 'ribbon',
+      title: 'Collar Band',
       scale: 0.3,
     })
 

--- a/markdown/org/docs/patterns/benjamin/cutting/en.md
+++ b/markdown/org/docs/patterns/benjamin/cutting/en.md
@@ -8,19 +8,19 @@ needs to be cut out. Below are two typical layouts.
 ## Without adjustment ribbon
 
 - **Main fabric**
-  - Cut **4 Knot**
-  - Cut **2 Collar band**
+  - Cut **4 Bow** parts
+  - Cut **2 Collar Band** parts
 - **Interfacing**
-  - Cut **4 interfacing knot**
-  - Cut **2 interfacing collar band**
+  - Cut **4 Bow** parts
+  - Cut **2 Collar Band** parts
 
 ## With adjustment ribbon
 
 - **Main fabric**
-  - Cut **1 Knot 1**
-  - Cut **1 Knot 2**
-  - Cut **2 Knot 3**
+  - Cut **1 Short Bow** part
+  - Cut **2 Medium Bow** parts
+  - Cut **1 Long Bow** part
 - **Interfacing**
-  - Cut **1 interfacing knot 1**
-  - Cut **1 interfacing knot 2**
-  - Cut **2 interfacing knot 3**
+  - Cut **1 Short Bow** part
+  - Cut **2 Medium Bow** parts
+  - Cut **1 Long Bow** part

--- a/markdown/org/docs/patterns/benjamin/instructions/en.md
+++ b/markdown/org/docs/patterns/benjamin/instructions/en.md
@@ -6,7 +6,7 @@ title: "Benjamin bow tie: Sewing Instructions"
 
 ### Precision
 
-Since a bow tie is a rather small item, precission with sewing is key to a good result.
+Since a bow tie is a rather small item, precision with sewing is key to a good result.
 Any slight difference between the upper and lower part of the bow will stand out.
 To get a great result I found it very helpful to trace the actual seam lines
 onto the interfacing and follow that while sewing.
@@ -33,15 +33,28 @@ page on [Fabric grain](/docs/sewing/fabric-grain).
 
 </Note>
 
-### Bow tie adjustment ribbon
+### Bow tie adjustment ribbon and hardware
 
-This pattern allows you to make a bow tie that is the right length for a certain neck
-size. It can also make one that has a ribbon and hardware that makes the bow tie
+By default, this design makes a fixed-length bow tie that is the right length for a certain neck size.
+However, by enabling the Adjustment Ribbon option, it can also make a tie
+that uses an adjustment ribbon and hardware that makes the bow tie
 adjustable to different neck sizes. This is useful if not all of your shirts have
 the same neck measurements, or if you sometimes like shirts with more ease in the
 neck.
 
-These ribbons can be found in the better haberdasheries or can be ordered online.
+These adjustment ribbons and bow tie hardware can be found in the better haberdasheries or can be ordered online.
+
+<Note>
+
+These instructions are for the type of adjustment ribbon that comes with
+holes at regular intervals, to be used in combination with two-piece
+hardware consisting of an oval loop part and a part with a smaller loop
+and attached T-shaped hook.
+
+There are other styles of bow tie ribbons and hardware, but their use is
+outside the scope of these instructions.
+
+</Note>
 
 ### Seam allowance
 
@@ -57,14 +70,16 @@ Apply interfacing to all parts where you feel it's needed.
 
 ### Without adjustment ribbon
 
-#### Step 2: Sew the knot to the collar band
+#### Step 2: Sew the bow to the collar band
 
-Put the collar band part on the bow tie knot part, right sides together.
+Put one of the Collar Band parts on one of the Bow parts, right sides together.
 Align the ends of both parts. Now sew across the end to join the parts.
 
-![Sew the collar band to the knot](step12.png)
+![Sew the collar band to the bow](step12.png)
 
-Do this for each end on both collar bands.
+In a similar fashion, sew a second Bow part to the other end of the same Collar Band.
+
+Repeat these steps to sew the other 2 Bows to the other Collar Band.
 
 Press open all the seams.
 
@@ -75,7 +90,7 @@ You now have two identical single sided bow ties.
 ![Sew both sides together](step13.png)
 
 Lay both the sides you made on top of each other, right sides together. Sew all
-along, but leaving an area of 5cm open in the middle of the collar band. Through
+along the edges, but leave an area of 5 cm open in the middle of the collar band. Through
 this opening we will turn the bow tie right side out.
 
 #### Step 4: Turning
@@ -99,7 +114,7 @@ out before giving it a good press.
 
 ![Closing the bow tie](step15.png)
 
-Now all that is left is closing the litle hole we used to turn the bow tie
+Now all that is left is closing the little hole we used to turn the bow tie
 right side out. You can do this by hand with a slip stitch, or a ladder stitch.
 Or you can use the machine and stitch right at the edge of the band. Since this
 will normally be hidden by the collar of your shirt, it will not be all that obvious.
@@ -112,12 +127,12 @@ Now give it one last press and admire your work.
 
 ![Sew the ribbon to part 1](step22.png)
 
-The first thing to do is to sew the adjustment ribbon to the shortest of the bow
-parts. The ribbon should be 290mm long. If it is different, you have to make sure
+The first thing to do is to sew the adjustment ribbon to the Short Bow part.
+The ribbon should be 290mm long. If it is different, you have to make sure
 that you align it such that the ribbon and short bow piece together are as long as
 the long bow piece.
 
-Put right sides of the short bow piece and the ribbon together.
+Put right sides of the Short Bow piece and the ribbon together.
 
 Now sew across the end to join the parts.
 
@@ -125,12 +140,15 @@ Now sew across the end to join the parts.
 
 ![Sew both sides together](step23.png)
 
-Lay both the parts of the medium bow on top of each other, right sides together.
-And lay the long bow on top of the ribbon and short bow part, also rights sides
+Lay both of the Medium Bow parts on top of each other, right sides together.
+
+Sew all along the edges, but leave the short end open.
+Through this opening we will turn the bow tie part right side out.
+
+Lay the Long Bow on top of the ribbon and Short Bow part, also right sides
 together.
 
-Sew all along, but leave the short ends open. Through these openings we will turn
-the bow tie parts right side out.
+Again, sew all along the edges, leaving the short end open.
 
 #### Step 4: Turning
 
@@ -154,22 +172,25 @@ Do this with both parts.
 #### Step 5: Add hardware
 
 Now we need to add the two pieces of hardware that make the bow tie adjustable.
-The oval looking piece will be attached to the part without the adjustment ribbon.
-And the piece with the T shaped attachment will go on the part with the ribbon.
+The oval loop piece will be attached to the part without the adjustment ribbon.
+And, the piece with the T-hook will go on the part with the ribbon.
 
 First do the part without the ribbon. This is because the fabric tail of the
 ribbon piece will have to go through the oval part before sewing on its hardware.
 If you would do it in the other sequence, you may not be able to feed it through.
 
-To finish the ends, we're going to fold the fabric in three steps:
+To finish the ends, we're going to fold the fabric in three steps,
+before sewing it in a fourth step:
 
 ![Three steps to fold, one step to sew](step25.png)
 
-First we fold the side in under an angle. Then we fold the end over by just a small
-seam allowance, something like 5mm. Then we fold it over again, for about 1cm.
-Finally we stick the oval ring under this last fold and stitch across.
+1. First we fold the sides in at an angle.
+2. Then we fold the end over by just a small seam allowance, something like 5 mm.
+3. Then we fold it over again, for about 1 cm.
+4. Finally we stick the oval loop under this last fold and stitch across.
 
-Now feed the ribbon piece through the oval part and finish it the same way.
+Now feed the adjustment ribbon piece through the oval loop, and
+attach the T-hook to the end of the ribbon, sewing it in the same way.
 
 Hook the T in one of the adjustment holes and your bow tie is done!
 


### PR DESCRIPTION
- Change part names for consistency and improvement, to make the pattern, cutting instructions, and construction instructions consistent in the names they use ("Bow", "Short Bow", "Medium Bow", "Long Bow, and "Collar Band").
- Improve and clarify instructions.
- Fix cutlist instructions (2 Medium Bow/Knot 2 and only 1 Long Bow/Knot 3).