### PR TITLE
fix(various designs): Restore design options omitted during v3 port. Fixes #3004.

### DIFF
--- a/designs/holmes/src/ear.mjs
+++ b/designs/holmes/src/ear.mjs
@@ -97,7 +97,7 @@ export const ear = {
     lengthRatio: { pct: 55, min: 40, max: 60, menu: 'style' },
     earLength: { pct: 100, min: 80, max: 150, menu: 'style' },
     earWidth: { pct: 100, min: 80, max: 150, menu: 'style' },
-    buttonhole: { bool: false },
+    buttonhole: { bool: false, menu: 'style' },
   },
   plugins: [pluginBundle],
   draft: draftHolmesEar,

--- a/designs/jaeger/src/options.mjs
+++ b/designs/jaeger/src/options.mjs
@@ -40,7 +40,7 @@ export const chestShaping = { pct: 30, min: 0, max: 100, menu: 'advanced' }
 export const rollLineCollarHeight = { pct: 6, min: 5, max: 9, menu: 'collar' }
 export const buttonLength = { pct: 30, min: 30, max: 60, menu: 'style' }
 export const buttons = { list: ['1', '2', '3'], dflt: '2', menu: 'style' }
-export const lengthBonus = { pct: 19, min: 10, max: 25 }
+export const lengthBonus = { pct: 19, min: 10, max: 25, menu: 'fit' }
 
 // Constants
 export const chestShapingMax = 5

--- a/designs/simon/src/options.mjs
+++ b/designs/simon/src/options.mjs
@@ -65,9 +65,9 @@ export const hemStyle = {
   menu: 'style',
 }
 export const hipsEase = { pct: 15, min: 10, max: 35, menu: 'fit' }
-export const lengthBonus = { pct: 25, min: -4, max: 60 }
+export const lengthBonus = { pct: 25, min: -4, max: 60, menu: 'fit' }
 // Shoulders
-export const shoulderEase = { pct: 2, min: 0, max: 15 }
+export const shoulderEase = { pct: 2, min: 0, max: 15, menu: 'fit' }
 export const splitYoke = { bool: false, menu: 'style' }
 export const yokeHeight = { pct: 70, min: 40, max: 90, menu: 'style' }
 // Sleeve

--- a/designs/simone/src/fba-front.mjs
+++ b/designs/simone/src/fba-front.mjs
@@ -435,7 +435,7 @@ export const fbaFront = {
       list: ['even', 'split', 'disabled'],
       menu: 'style.closure',
     },
-    lengthBonus: { pct: 25, min: -4, max: 60 },
+    lengthBonus: { pct: 25, min: -4, max: 60, menu: 'fit' },
   },
   draft: simoneFbaFront,
 }

--- a/designs/yuri/src/back.mjs
+++ b/designs/yuri/src/back.mjs
@@ -104,15 +104,15 @@ export const back = {
     options: {
       ...brianBack.options,
       // Overrides
-      collarEase: { pct: 20, min: 10, max: 30 },
-      cuffEase: { pct: 30, min: 20, max: 60 },
-      lengthBonus: { pct: 10, min: 5, max: 15 },
-      sleeveLengthBonus: { pct: 1, min: 0, max: 10 },
+      collarEase: { pct: 20, min: 10, max: 30, menu: 'fit' },
+      cuffEase: { pct: 30, min: 20, max: 60, menu: 'fit' },
+      lengthBonus: { pct: 10, min: 5, max: 15, menu: 'fit' },
+      sleeveLengthBonus: { pct: 1, min: 0, max: 10, menu: 'fit' },
     },
   },
   hide: hidePresets.HIDE_TREE,
   options: {
-    hipsEase: { pct: 0, min: 0, max: 10 },
+    hipsEase: { pct: 0, min: 0, max: 10, menu: 'fit' },
   },
   measurements: ['hips'],
   draft: yuriBack,

--- a/designs/yuri/src/front.mjs
+++ b/designs/yuri/src/front.mjs
@@ -113,15 +113,15 @@ export const front = {
     options: {
       ...brianFront.options,
       // Overrides
-      collarEase: { pct: 20, min: 10, max: 30 },
-      cuffEase: { pct: 30, min: 20, max: 60 },
-      lengthBonus: { pct: 10, min: 5, max: 15 },
-      sleeveLengthBonus: { pct: 1, min: 0, max: 10 },
+      collarEase: { pct: 20, min: 10, max: 30, menu: 'fit' },
+      cuffEase: { pct: 30, min: 20, max: 60, menu: 'fit' },
+      lengthBonus: { pct: 10, min: 5, max: 15, menu: 'fit' },
+      sleeveLengthBonus: { pct: 1, min: 0, max: 10, menu: 'fit' },
     },
   },
   hide: hidePresets.HIDE_TREE,
   options: {
-    hipsEase: { pct: 0, min: 0, max: 10 },
+    hipsEase: { pct: 0, min: 0, max: 10, menu: 'fit' },
   },
   measurements: ['hips', 'hpsToBust'],
   draft: yuriFront,


### PR DESCRIPTION
I checked both localhost lab and lab.freesewing.dev to verify that they have the same design options after this PR is applied.

(The only exception is Simon/Simone's Collar Ease option which will be addressed in a separate PR.)