### PR TITLE
fix(simon): Restore collarEase option from Style.Collar to Fit menu

### DIFF
--- a/designs/simon/src/options.mjs
+++ b/designs/simon/src/options.mjs
@@ -29,7 +29,7 @@ export const extraTopButton = { bool: true, menu: 'style.closure' }
 export const seperateButtonPlacket = { bool: false, menu: 'style.closure' }
 export const seperateButtonholePlacket = { bool: false, menu: 'style.closure' }
 // Collar
-export const collarEase = { pct: 2, min: 0, max: 10, menu: 'style.collar' }
+export const collarEase = { pct: 2, min: 0, max: 10, menu: 'fit' }
 export const collarAngle = { deg: 85, min: 60, max: 130, menu: 'style.collar' }
 export const collarBend = { pct: 3.5, min: 0, max: 10, menu: 'style.collar' }
 export const collarFlare = { deg: 3.5, min: 0, max: 10, menu: 'style.collar' }


### PR DESCRIPTION
This PR moves Simon's `collarEase` option from the Style.Collar menu to the Fit menu.

I suspect that the option was inadvertently moved from Fit to Style.Collar during the port to v3. The lab.freesewing.dev version of Simon has the option in the Fit menu. Pinging @joostdecock , the pattern's designer.

If instead the change was intentional, please close this PR.