### PR TITLE
fix(wahid): Hide inadvertently exposed inherited options. Fixes #3005 

### DIFF
--- a/designs/wahid/src/front.mjs
+++ b/designs/wahid/src/front.mjs
@@ -22,6 +22,14 @@ import {
   lengthBonus,
   acrossBackFactor,
   frontArmholeDeeper,
+  bicepsEase,
+  collarEase,
+  cuffEase,
+  shoulderEase,
+  s3Collar,
+  s3Armhole,
+  shoulderSlopeReduction,
+  backNeckCutout,
 } from './options.mjs'
 
 function wahidFront({
@@ -517,6 +525,14 @@ export const front = {
     lengthBonus,
     acrossBackFactor,
     frontArmholeDeeper,
+    bicepsEase,
+    collarEase,
+    cuffEase,
+    shoulderEase,
+    s3Collar,
+    s3Armhole,
+    shoulderSlopeReduction,
+    backNeckCutout,
   },
   draft: wahidFront,
 }

--- a/designs/wahid/src/options.mjs
+++ b/designs/wahid/src/options.mjs
@@ -26,3 +26,13 @@ export const frontInset = { pct: 15, min: 10, max: 20, menu: 'advanced' }
 export const shoulderInset = { pct: 10, min: 0, max: 20, menu: 'advanced' }
 export const neckInset = { pct: 5, min: 0, max: 10, menu: 'advanced' }
 export const pocketAngle = { deg: 5, min: 0, max: 5, menu: 'advanced' }
+
+// Hide inherited options
+export const bicepsEase = { pct: 15, min: 0, max: 50, menu: false }
+export const collarEase = { pct: 5, min: 0, max: 10, menu: false }
+export const cuffEase = { pct: 20, min: 0, max: 200, menu: false }
+export const shoulderEase = { pct: 0, min: -2, max: 6, menu: false }
+export const s3Armhole = { pct: 0, min: -100, max: 100, menu: false }
+export const s3Collar = { pct: 0, min: -100, max: 100, menu: false }
+export const shoulderSlopeReduction = { pct: 0, min: 0, max: 80, menu: false }
+export const backNeckCutout = { pct: 5, min: -2, max: 8, menu: false }


### PR DESCRIPTION
In v2, only explicitly specified inherited options appeared in menus in the lab UI.
In v3, inherited options also inherit their menus and appear in the lab UI by default.

In Wahid, this exposed some options, causing them to appear in the lab UI. This PR adds overrides to hide them to match the previous behavior.

I tested the PR in the lab to verify that the same patterns are generated and the same options are seen between the PR and lab.freesewing.dev.