### PR TITLE
fix(shared): Silence no-menu warnings for constant options

### DIFF
--- a/sites/shared/utils.mjs
+++ b/sites/shared/utils.mjs
@@ -187,8 +187,9 @@ export const optionsMenuStructure = (options) => {
   // Fixme: One day we should sort this based on the translation
   for (const option of orderBy(sorted, ['menu', 'name'], ['asc'])) {
     if (typeof option === 'object') {
+      const isAConstant = Object.keys(option).length === 1
       if (option.menu) set(menu, `${option.menu}.${option.name}`, optionType(option))
-      else if (typeof option.menu === 'undefined') {
+      else if (typeof option.menu === 'undefined' && !isAConstant) {
         console.log(
           `Warning: Option ${option.name} does not have a menu config. ` +
             'Either configure it, or set it to false to hide this option.'


### PR DESCRIPTION
This PR eliminates `console.log()` warnings for constant options. The current behavior is to give a warning when there is no menu configured for the option.

Example, for Benjamin:
```
utils.mjs:192 Warning: Option adjustmentRibbonWidth does not have a menu config. Either configure it, or set it to false to hide this option.
utils.mjs:192 Warning: Option bandLength does not have a menu config. Either configure it, or set it to false to hide this option.
utils.mjs:192 Warning: Option transitionLength does not have a menu config. Either configure it, or set it to false to hide this option.
```
Resulting from these contants in `designs/benjamin/src/base.mjs`:
```js
 options: {
    // Static options
    transitionLength: 2, //Twice the knot
    bandLength: 0.17,
    adjustmentRibbonWidth: 20,
...
```

This PR takes advantage of the the fact that constant options have only one key (`option.name`). From testing it was seen that all other options configured as objects have at least 2 keys.