### PR TITLE
fix(workbench): Do not pre-draft patterns without measurements

### DIFF
--- a/sites/shared/components/wrappers/workbench.mjs
+++ b/sites/shared/components/wrappers/workbench.mjs
@@ -139,7 +139,7 @@ export const WorkbenchWrapper = ({
 
     // draft it for draft and event views. Other views may add plugins, etc and we don't want to draft twice
     try {
-      if (['draft', 'logs'].indexOf(gist._state.view) > -1) draft.draft()
+      if (['draft', 'logs'].indexOf(gist._state.view) > -1 && hasRequiredMeasurements) draft.draft()
     } catch (error) {
       return <DraftError error={error} app={app} draft={draft} at={'draft'} />
     }


### PR DESCRIPTION
In the browser Javascript console I see messages that indicate that the lab is drafting patterns without measurements. This happens in certain circumstances, like when the ClearThing button is used or when visiting the Logs view immediately after browsing to a new design.

For example, if I go to Carlton and use the ClearThing button I see messages like `Warning: The round macro only handles 90 degree angles correctly.` and `Called part.setCutOnFold() but at least one parameter is not a Point instance`. And also things like, `Unable to draft part 'bent.sleeve' (set 0) TypeError: Cannot read properties of undefined (reading 'x')`.