### PR TITLE
fixes #3957 Re-use existing part for out-of-cycle draft

### DIFF
--- a/packages/core/src/pattern/pattern-drafter.mjs
+++ b/packages/core/src/pattern/pattern-drafter.mjs
@@ -113,7 +113,8 @@ PatternDrafter.prototype.__createPartForSet = function (partName, set = 0) {
   }
   // Create parts
   this.activeStore.log.debug(`📦 Creating part \`${partName}\` (set ${set})`)
-  this.pattern.parts[set][partName] = this.__createPartWithContext(partName, set)
+  this.pattern.parts[set][partName] =
+    this.pattern.parts[set][partName] || this.__createPartWithContext(partName, set)
 
   // Handle inject/inheritance
   const parent = this.pattern.config.inject[partName]


### PR DESCRIPTION
PDF exports were missing page markup because it get drafted in the `postLayout` hook, at which point stacks are already generated with parts added to them. After the recent refactor I must have changed the order or operations somewhat, so now when `Pattern.draftPartForSet` creates a new `Part` out of cycle, it never gets added to the correct stack, so it is not included in SVG renders. This PR makes it so that `Pattern.draftPartForSet` check to see if there is an existing part and calls `draft` on it instead, which will mean that the part that was put in the stack is the one that's used.

I don't foresee side effects in a rare instance where a part is double drafted (which would only happen if someone was doing something very advanced in a plugin) because existing points and paths will be overwritten by the next call to `Part.__inject` and `Part.draft`