### PR TITLE
fix(bob,penelope,docs): Access optional measurements via `measurements`

### DIFF
--- a/designs/bob/src/bib.mjs
+++ b/designs/bob/src/bib.mjs
@@ -16,7 +16,7 @@ export const bib = {
     points,
     Path,
     paths,
-    optionalMeasurements,
+    measurements,
     options,
     macro,
     log,
@@ -27,7 +27,7 @@ export const bib = {
     part,
   }) => {
     // Head size
-    const head = (optionalMeasurements?.head || 360) * options.headSize
+    const head = (`head` in measurements ? measurements.head : 360) * options.headSize
 
     // Construct the neck opening
     let tweak = 1

--- a/designs/penelope/src/back.mjs
+++ b/designs/penelope/src/back.mjs
@@ -1,5 +1,5 @@
 import { pluginBundle } from '@freesewing/plugin-bundle'
-import { measurements, options, BuildMainShape } from './shape.mjs'
+import { measurements, optionalMeasurements, options, BuildMainShape } from './shape.mjs'
 
 function penelopeBack(params) {
   const {
@@ -135,6 +135,7 @@ function penelopeBack(params) {
 export const back = {
   name: 'penelope.back',
   measurements,
+  optionalMeasurements,
   options,
   plugins: [pluginBundle],
   draft: penelopeBack,

--- a/designs/penelope/src/front.mjs
+++ b/designs/penelope/src/front.mjs
@@ -1,5 +1,5 @@
 import { pluginBundle } from '@freesewing/plugin-bundle'
-import { measurements, options, BuildMainShape } from './shape.mjs'
+import { measurements, optionalMeasurements, options, BuildMainShape } from './shape.mjs'
 
 function penelopeFront(params) {
   const { options, Path, points, paths, Snippet, snippets, complete, sa, paperless, macro, part } =
@@ -60,6 +60,7 @@ function penelopeFront(params) {
 export const front = {
   name: 'penelope.front',
   measurements,
+  optionalMeasurements,
   options,
   plugins: [pluginBundle],
   draft: penelopeFront,

--- a/designs/penelope/src/shape.mjs
+++ b/designs/penelope/src/shape.mjs
@@ -38,21 +38,7 @@ export const options = {
 }
 
 export function BuildMainShape(
-  {
-    sa,
-    options,
-    measurements,
-    optionalMeasurements,
-    Point,
-    Path,
-    points,
-    paths,
-    store,
-    paperless,
-    macro,
-    part,
-    log,
-  },
+  { sa, options, measurements, Point, Path, points, paths, store, paperless, macro, part, log },
   frontPart
 ) {
   let skirtLength = measurements.waistToKnee * (1 + options.lengthBonus) // + options.hem;

--- a/designs/penelope/src/shape.mjs
+++ b/designs/penelope/src/shape.mjs
@@ -82,14 +82,13 @@ export function BuildMainShape(
   store.set('nrOfDarts', nrOfDarts)
   store.set('dartSize', dartSize)
 
-  if (optionalMeasurements?.seatBack) {
-    seat = (frontPart ? seat - optionalMeasurements.seatBack : optionalMeasurements.seatBack) * 2
+  if ('seatBack' in measurements) {
+    seat = (frontPart ? seat - measurements.seatBack : measurements.seatBack) * 2
   } else {
     seat *= 1 + (frontPart ? -1 : 1) * options.sideSeamShiftPercentage
   }
-  if (optionalMeasurements?.waistBack) {
-    waist =
-      (frontPart ? waist - optionalMeasurements.waistBack : optionalMeasurements.waistBack) * 2
+  if ('waistBack' in measurements) {
+    waist = (frontPart ? waist - measurements.waistBack : measurements.waistBack) * 2
   } else {
     waist *= 1 + (frontPart ? -1 : 1) * options.sideSeamShiftPercentage
   }

--- a/markdown/dev/reference/api/part/config/measurements/en.md
+++ b/markdown/dev/reference/api/part/config/measurements/en.md
@@ -38,3 +38,12 @@ const part = {
 }
 ```
 
+<Tip>
+
+Although they are specified via the part configuration `optionalMeasurements`
+property, optional measurements are accessed via the 'measurements'
+settings property.
+
+(There is no `optionalMeasurements` settings property.)`
+
+</Tip>

--- a/markdown/dev/reference/settings/measurements/en.md
+++ b/markdown/dev/reference/settings/measurements/en.md
@@ -39,3 +39,12 @@ const pattern = new Aaron({
 
 Measurements should always be specified in millimeter, unless it's an angle
 measurement (like `shoulderSlope`) which should be provided in degrees.
+
+<Tip>
+
+The `measurements` settings property is used to hold __all__ measurements,
+both regular measurements as well as any optional measurements.
+
+(There is no `optionalMeasurements` settings property.)
+
+</Tip>


### PR DESCRIPTION
Fixes #3933.