### PR TITLE
fix(plugin-annotation,title): Supress warning message if cutlist not defined

### DIFF
--- a/plugins/plugin-annotations/src/title.mjs
+++ b/plugins/plugin-annotations/src/title.mjs
@@ -49,7 +49,7 @@ const titleMacro = function (so, { points, scale, locale, store, part }) {
   }
 
   // Cut List instructions
-  const partCutlist = store.get(['cutlist', part.name])
+  const partCutlist = store.get(['cutlist', part.name], null)
   // if there's a cutlist and it should be included
   if (so.cutlist && partCutlist?.materials) {
     // get the default cutonfold


### PR DESCRIPTION
The `title` macro is displaying warning messages For designs with no set cutlist or ones that set the cutlist after `title` macro. For example, for Waralee (which has not yet had cutlist info added):
![Screenshot 2023-05-03 at 7 11 40 PM](https://user-images.githubusercontent.com/109869956/236096234-94ca67b7-ad81-44dc-baaa-39e8b86408bf.png)
