### PR TITLE
chore(docs): Move sample setting docs from Pattern.sample() to its own doc

### DIFF
--- a/markdown/dev/reference/api/pattern/sample/en.md
+++ b/markdown/dev/reference/api/pattern/sample/en.md
@@ -15,15 +15,9 @@ Under the hood, this method will call one of
 an option, a measurement, or different models respectively.
 
 Unlike those three methods where you pass the relevant info to to the method,
-this `Pattern.sample()` method will instead read the `settings.sample`
+this `Pattern.sample()` method will instead read the
+[`settings.sample`](/reference/settings/sample)
 object to determine what needs to be done.
-
-The `settings.sample` object can hold the following properties:
-
-- **type**: One of `option`, `measurement`, or `models`
-- **option**: An option name as defined in the pattern config file (only used when `type` is option).
-- **measurement**: A measurement name as defined in the pattern config file (only used when `type` is measurement).
-- **models**: A plain object of different models where the key is the model name and the value an object with the required measurements.
 
 See the specific sample methods below for more details:
 

--- a/markdown/dev/reference/settings/sample/en.md
+++ b/markdown/dev/reference/settings/sample/en.md
@@ -1,0 +1,47 @@
+---
+title: sample
+---
+
+The `sample` setting holds an object that is used by pass information
+to the [`Pattern.sample()`][1] method.
+[1]: /reference/api/pattern/sample
+
+
+## Signature
+
+```js
+const settings = {
+  Object sample = {}
+}
+```
+
+## Example
+
+```js
+import { Aaron } from "@freesewing/aaron"
+
+const pattern = new Aaron({
+  settings = {
+    Object sample = {
+      type: 'option',
+      option: 'headEase',
+    }
+  }
+})
+```
+
+## Notes
+
+The `sample` setting object can hold the following properties:
+
+- __type__: One of `option`, `measurement`, or `models`
+- __option__: An option name as defined in the pattern config file (only used when `type` is option).
+- __measurement__: A measurement name as defined in the pattern config file (only used when `type` is measurement).
+- __models__: A plain object of different models where the key is the model name and the value an object with the required measurements.
+
+<Related>
+
+Please see the [`Pattern.sample()`][1] documentation for more information
+about pattern sampling.
+
+</Related>


### PR DESCRIPTION
(The `sample` setting was previously undocumented in the reference Settings section.) 