### PR TITLE
fix(docs): Tutorials doc review corrections and updates

### DIFF
--- a/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
@@ -54,7 +54,7 @@ yarn new plugin
 ### Step by step
 
 <Comment by="joost">
-These docs assume you have git installed. 
+These docs assume you have git installed.
 But if you're running Linux, you have git, right?
 </Comment>
 
@@ -154,12 +154,10 @@ If you're not certain what to pick, just mash some keys, it doesn't matter.
 
 #### What package manager to use
 
-Choose `yarn`. Currently, `npm` does not work.
+You may wish to choose `yarn` since that is the package manager
+that we use when doing work in the monorepo,
+and many of our tutorials are written to use `yarn`.
+However, it doesn't really matter.
+You can choose either `yarn` or `npm` as you wish.
 
 </Note>
-
-<Fixme compact>
-The `npm` issue issue should be fixed by the time v3 is released.
-The _What package manager to use_ section will need to be updated at that
-time.
-</Fixme>

--- a/markdown/dev/tutorials/getting-started-linux/dev-start/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/dev-start/en.md
@@ -40,13 +40,13 @@ If you chose `banana`, you'll have a folder named `banana`.
 You can ignore all other subfolders and files; they are part of the development environment.)
 
 To start the development environment, enter the folder that was created
-and run `npm run dev` (or `yarn dev` if you're using Yarn as a package manager).
+and run `yarn dev` (or `npm run dev` if you're using npm as a package manager).
 
 Then open your browser and go to http://localhost:8000
 
 <Tip>
 The development environment will watch for any changes you make to
-the pattern's source code or configuration. 
+the pattern's source code or configuration.
 When you do, it will update automatically in your browser.
 </Tip>
 

--- a/markdown/dev/tutorials/getting-started-mac/dev-setup/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/dev-setup/en.md
@@ -54,8 +54,8 @@ yarn new plugin
 ### Step by step
 
 <Comment by="joost">
-These docs assume you have git installed. 
-But if you're running Linux, you have git, right?
+These docs assume you have git installed.
+But if you're running macOS, you have git, right?
 </Comment>
 
 #### Install yarn
@@ -154,12 +154,10 @@ If you're not certain what to pick, just mash some keys, it doesn't matter.
 
 #### What package manager to use
 
-Choose `yarn`. Currently, `npm` does not work.
+You may wish to choose `yarn` since that is the package manager
+that we use when doing work in the monorepo,
+and many of our tutorials are written to use `yarn`.
+However, it doesn't really matter.
+You can choose either `yarn` or `npm` as you wish.
 
 </Note>
-
-<Fixme compact>
-The `npm` issue issue should be fixed by the time v3 is released.
-The _What package manager to use_ section will need to be updated at that
-time.
-</Fixme>

--- a/markdown/dev/tutorials/getting-started-mac/dev-start/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/dev-start/en.md
@@ -40,13 +40,13 @@ If you chose `banana`, you'll have a folder named `banana`.
 You can ignore all other subfolders and files; they are part of the development environment.)
 
 To start the development environment, enter the folder that was created
-and run `npm run dev` (or `yarn dev` if you're using Yarn as a package manager).
+and run `yarn dev` (or `npm run dev` if you're using npm as a package manager).
 
 Then open your browser and go to http://localhost:8000
 
 <Tip>
 The development environment will watch for any changes you make to
-the pattern's source code or configuration. 
+the pattern's source code or configuration.
 When you do, it will update automatically in your browser.
 </Tip>
 

--- a/markdown/dev/tutorials/getting-started-mac/installing-nvm/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/installing-nvm/en.md
@@ -9,7 +9,7 @@ You'll need to install Node.js on your system, and to do so, we'll
 use [`nvm`](https://github.com/nvm-sh/nvm), short for _Node Version Manager_.
 
 Using `nvm` has a number of benefits in comparison with installing Node.js from
-the Node.js website, or from a package provided by your Linux distribution:
+the Node.js website, or from a package that came with macOS.
 
 - You can easily switch between different Node.js versions
 - Everything gets installed in your home folder, avoiding permission problems

--- a/markdown/dev/tutorials/getting-started-windows/en.md
+++ b/markdown/dev/tutorials/getting-started-windows/en.md
@@ -84,10 +84,10 @@ installed or configured correctly. As such it's recommended to have git
 installed on the WSL environment even if you're going to be using a GUI client
 from the windows side.
 
-```bash 
-sudo apt install git 
-git config --global user.email "<the email address you use for your git account>" 
-git config --global user.name "<your display name for your git account>" 
+```bash
+sudo apt install git
+git config --global user.email "<the email address you use for your git account>"
+git config --global user.name "<your display name for your git account>"
 ```
 
 ### Install VSCode (optional)
@@ -105,8 +105,8 @@ editor please ensure that your settings.json file is configured to not trim
 trailing whitespace from Markdown files. The following snippet can be added to
 your settings.json file to add an exemption for this file type:
 
-```json 
-  "[markdown]": { "files.trimTrailingWhitespace": false }, 
+```json
+  "[markdown]": { "files.trimTrailingWhitespace": false },
 ```
 
 </Note>
@@ -144,11 +144,11 @@ string of the version you wish to use) to activate the newly installed version.
 You will receive a prompt for elevated permissions and will need to accept it in
 order to activate the new version of Node.js.
 
-<Warning> 
+<Warning>
 At the time this guide was written the latest version of Node.js/npm has
 a bug in the dependency resolution process which causes the freesewing project
 to fail to build. Use the latest LTS version (currently 16.17.0) or the specific
-version used by the main project to avoid this issue.  
+version used by the main project to avoid this issue.
 </Warning>
 
 Node.js comes with the Node Package Manager (npm) by default which can be used to
@@ -188,15 +188,13 @@ If you're not certain what to pick, just mash some keys, it doesn't matter.
 
 #### What package manager to use
 
-Choose `yarn`. Currently, `npm` does not work.
+You may wish to choose `yarn` since that is the package manager
+that we use when doing work in the monorepo,
+and many of our tutorials are written to use `yarn`.
+However, it doesn't really matter.
+You can choose either `yarn` or `npm` as you wish.
 
 </Note>
-
-<Fixme compact>
-The `npm` issue issue should be fixed by the time v3 is released.
-The _What package manager to use_ section will need to be updated at that
-time.
-</Fixme>
 
 ## Start the development environment
 

--- a/markdown/dev/tutorials/getting-started-windows/en.md
+++ b/markdown/dev/tutorials/getting-started-windows/en.md
@@ -73,7 +73,7 @@ set up the project. The default package manager uses a fairly simplistic approac
 to dependency resolution which can make builds take a long time. Yarn is an
 alternative package manager which makes builds faster, especially for monolithic
 projects like FreeSewing. If you'd like to install yarn run `npm install yarn
--g` (optional).
+--global` (optional, but recommended).
 
 #### Install and configure Git (recommended)
 
@@ -205,7 +205,7 @@ If you chose `banana`, you'll have a folder named `banana`.
 You can ignore all other subfolders and files; they are part of the development environment.)
 
 To start the development environment, navigate to the folder that was created
-and run `npm run dev` (or `yarn dev` if you're using Yarn as a package manager).
+and run `yarn dev` (or `npm run dev` if you're using npm as a package manager).
 
 Then open your browser and go to http://localhost:8000
 

--- a/markdown/dev/tutorials/pattern-design/structure/en.md
+++ b/markdown/dev/tutorials/pattern-design/structure/en.md
@@ -26,7 +26,7 @@ If you'd like to learn about those other files and folders, here's what they do:
 ### files
 
 - `next.config.mjs`: The [NextJS][next] configuration file
-- `next-i18next.config.js`: The configuration file for [next-i18next][i81n] which handles translation within NextJS
+- `next-i18next.config.js`: The configuration file for [next-i18next][i18n] which handles translation within NextJS
 - `package.json`: Every Node.js project has a [package.json][pkg] file which holds important metadata and lists dependencies
 - `package-lock.json`: This *lockfile* will only exist if we use the npm package manager
 - `postcss.config.js`: Configuration file for [PostCSS][postcss], a tool to transform CSS with JavaScript
@@ -39,3 +39,4 @@ If you'd like to learn about those other files and folders, here's what they do:
 [yarn]: https://yarnpkg.com/
 [pkg]: https://docs.npmjs.com/cli/v8/configuring-npm/package-json
 [react]: https://reactjs.org/
+[i18n]: https://next.i18next.com


### PR DESCRIPTION
Continuing work for #3024.

I made an editorial change to nudge users towards using `yarn` rather than `npm` as the recommended option.