### PR TITLE
[proposal]: Keep macro ID in store for removal

### DIFF
--- a/designs/plugintest/src/plugin-annotations.mjs
+++ b/designs/plugintest/src/plugin-annotations.mjs
@@ -34,12 +34,15 @@ const pluginAnnotations = ({
     points.banner_to = new Point(320, y)
     paths.banner = new Path().move(points.banner_from).line(points.banner_to)
     macro('banner', {
-      path: paths.banner,
+      path: 'banner',
       text: 'banner macro',
       dy: options.bannerDy,
       spaces: options.bannerSpaces,
       repeat: options.bannerRepeat,
     })
+    macro('rmbanner', 'banner')
+    paths.banner.addText('banner removed')
+
     macro('bannerbox', {
       topLeft: points.banner_from,
       bottomRight: points.banner_to,

--- a/plugins/plugin-annotations/src/banner.mjs
+++ b/plugins/plugin-annotations/src/banner.mjs
@@ -1,8 +1,9 @@
 // Export macros
 export const bannerMacros = {
-  banner: function (so) {
+  banner: function (so, pattern) {
     // Mix defaults with settings object
     so = {
+      id: 'banner',
       text: '',
       dy: -1,
       spaces: 12,
@@ -10,14 +11,29 @@ export const bannerMacros = {
       className: '',
       ...so,
     }
-    so.path.attr('data-text-dy', so.dy).attr('data-text-class', `${so.className} center`)
-    const spacer = '&#160;'.repeat(so.spaces)
+    // Allow passing of path by ID or the actual object
+    const path = typeof so.path === 'object' ? so.path : pattern.paths[so.path]
 
+    // Store id/path in store for later removal with rmbanner
+    if (path.name) pattern.store.set(`data.plugins.annotations.banner.${so.id}`, path.name || path)
+
+    // Set test dy value
+    path.attr('data-text-dy', so.dy).attr('data-text-class', `${so.className} center`)
+
+    // Set text on path
+    const spacer = '&#160;'.repeat(so.spaces)
     for (let i = 0; i < so.repeat; i++) {
-      so.path.attr('data-text', spacer)
-      so.path.attr('data-text', so.text)
+      path.attr('data-text', spacer)
+      path.attr('data-text', so.text)
     }
 
-    so.path.attr('data-text', spacer)
+    path.attr('data-text', spacer)
+  },
+  rmbanner: function (id = 'banner', pattern) {
+    let path = pattern.store.get(`data.plugins.annotations.banner[${id}]`)
+    if (typeof path !== 'object') path = pattern.paths[path]
+
+    // Remove attributes from path
+    path.attributes.remove('data-text-dy').remove('data-text-class').remove('data-text')
   },
 }


### PR DESCRIPTION
As agreed in the most recent contributor call, I'd put up a proposal to outline how we could handle removing changes made by macros.

This PR has a minimal implementation of this, which boils down to:

- A macro passes an `id` parameter (with a default, so it's optional)
- The plugin stores this id in the store, along with any info it needs to roll back the changes
- The `rm` prefixed macro exists that rolls back these changes after looking up the info in the store

I would also suggest we strive to harmonize the way data is passed to plugins:

- Use `id` everywhere (no more prefix)
- Allow passing objects or strings refering objects (paths or points). Strings are preferred because they point to named Point/Path objects which makes it easier to find and remove them afterwards, but we can support both
- add `rmmacroname` instead of the less-intuitive way of passing `false` to the macro

Marking as DRAFT because this is not supposed to be merged as-is, it's for discussion.