### PR TITLE
fix(bella): Prevent negative width back dart

### DIFF
--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -104,7 +104,7 @@ export const back = {
     let backDartWidth = reduction * (1 - options.backCenterWaistReduction * 0.5)
     if (backDartWidth < 0) {
       backDartWidth = 0
-      log.info('Back dart is not necessary (width is 0.0 mm/inches).')
+      log.info('Bella: Back dart is not necessary (width is 0.0 mm/inches).')
     }
     points.dartBottomLeft = points.dartBottomCenter.shift(180, backDartWidth / 2)
     points.dartBottomRight = points.dartBottomLeft.rotate(180, points.dartBottomCenter)

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -101,10 +101,12 @@ export const back = {
       points.waistSide,
       points.dartTip.x
     )
-    points.dartBottomLeft = points.dartBottomCenter.shift(
-      180,
-      (reduction * (1 - options.backCenterWaistReduction * 0.5)) / 2
-    )
+    let backDartWidth = reduction * (1 - options.backCenterWaistReduction * 0.5)
+    if (backDartWidth < 0) {
+      backDartWidth = 0
+      log.info('Back dart is not necessary (width is 0.0 mm/inches).')
+    }
+    points.dartBottomLeft = points.dartBottomCenter.shift(180, backDartWidth / 2)
     points.dartBottomRight = points.dartBottomLeft.rotate(180, points.dartBottomCenter)
     points.dartLeftCp = points.dartBottomLeft.shift(
       90,

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -305,30 +305,34 @@ export const back = {
           to: points.waistCenter,
           y: points.waistCenter.y + sa + 15,
         })
-        macro('hd', {
-          from: points.cbNeck,
-          to: points.dartBottomLeft,
-          y: points.waistCenter.y + sa + 30,
-        })
-        macro('hd', {
-          from: points.cbNeck,
-          to: points.dartBottomRight,
-          y: points.waistCenter.y + sa + 45,
-        })
-        macro('hd', {
-          from: points.dartBottomLeft,
-          to: points.dartBottomRight,
-          y: points.waistCenter.y + sa + 15,
-        })
+        let dimensionsOffset = 0
+        if (backDartWidth > 0) {
+          dimensionsOffset = 30
+          macro('hd', {
+            from: points.cbNeck,
+            to: points.dartBottomLeft,
+            y: points.waistCenter.y + sa + 30,
+          })
+          macro('hd', {
+            from: points.cbNeck,
+            to: points.dartBottomRight,
+            y: points.waistCenter.y + sa + 45,
+          })
+          macro('hd', {
+            from: points.dartBottomLeft,
+            to: points.dartBottomRight,
+            y: points.waistCenter.y + sa + 15,
+          })
+        }
         macro('hd', {
           from: points.cbNeck,
           to: points.waistSide,
-          y: points.waistCenter.y + sa + 60,
+          y: points.waistCenter.y + sa + 30 + dimensionsOffset,
         })
         macro('hd', {
           from: points.cbNeck,
           to: points.armhole,
-          y: points.waistCenter.y + sa + 75,
+          y: points.waistCenter.y + sa + 45 + dimensionsOffset,
         })
         macro('vd', {
           from: points.waistSide,

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -102,9 +102,13 @@ export const back = {
       points.dartTip.x
     )
     let backDartWidth = reduction * (1 - options.backCenterWaistReduction * 0.5)
-    if (backDartWidth < 0) {
+    if (backDartWidth <= 0) {
       backDartWidth = 0
-      log.info('Bella: Back dart is not necessary (width is 0.0 mm/inches).')
+      log.info(
+        '`' +
+          part.name +
+          '`: Back dart omitted (because the calculated dart width was 0.0 mm/inches or less).'
+      )
     }
     points.dartBottomLeft = points.dartBottomCenter.shift(180, backDartWidth / 2)
     points.dartBottomRight = points.dartBottomLeft.rotate(180, points.dartBottomCenter)
@@ -231,8 +235,12 @@ export const back = {
       .move(points.cbNeck)
       .curve_(points.cbNeckCp2, points.waistCenter)
       .line(points.dartBottomLeft)
-      .curve_(points.dartLeftCp, points.dartTip)
-      ._curve(points.dartRightCp, points.dartBottomRight)
+    if (backDartWidth > 0)
+      paths.seam
+        .curve_(points.dartLeftCp, points.dartTip)
+        ._curve(points.dartRightCp, points.dartBottomRight)
+    else paths.seam.line(points.dartBottomRight)
+    paths.seam
       .line(points.waistSide)
       .curve_(points.waistSideCp2, points.armhole)
       .curve(points.armholeCp2, points.armholePitchCp1, points.armholePitch)


### PR DESCRIPTION
This PR prevents negative width back darts by setting the width to 0 in those situations. An `info` message is also logged: `Back dart is not necessary (width is 0.0 mm/inches).`

Before:
![Screenshot 2023-05-05 at 12 47 15 PM](https://user-images.githubusercontent.com/109869956/236555980-94bc4a87-b79a-4589-acaa-07541c17cb3c.png)

After:
![Screenshot 2023-05-05 at 12 47 30 PM](https://user-images.githubusercontent.com/109869956/236555998-8e3d77ce-4d0b-4499-b280-41b58ab40fa9.png)
![Screenshot 2023-05-05 at 12 48 01 PM](https://user-images.githubusercontent.com/109869956/236556014-6b9dc016-9359-45f9-9842-1647987f79b7.png)
