### PR TITLE
fix(core): (part) Add warning message if invalid macro name used

### DIFF
--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -345,6 +345,7 @@ Part.prototype.__macroClosure = function (props) {
   const method = function (key, args) {
     const macro = utils.__macroName(key)
     if (typeof self[macro] === 'function') self[macro](args, props)
+    else self.context.store.log.warning('Unknown macro `' + key + '` used in ' + self.name)
   }
 
   return method

--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -345,7 +345,8 @@ Part.prototype.__macroClosure = function (props) {
   const method = function (key, args) {
     const macro = utils.__macroName(key)
     if (typeof self[macro] === 'function') self[macro](args, props)
-    else self.context.store.log.warning('Unknown macro `' + key + '` used in ' + self.name)
+    else if ('context' in self)
+      self.context.store.log.warning('Unknown macro `' + key + '` used in ' + self.name)
   }
 
   return method


### PR DESCRIPTION
(This will help in situations such as the pattern coder accidentally using `sewtogether` as the macro name, rather than the correct `sewTogether`.)

![Screenshot 2023-05-07 at 1 19 59 PM](https://user-images.githubusercontent.com/109869956/236700917-2c2acaa8-8427-47b8-b3c9-44774e7f815a.png)
