### PR TITLE
fix (new-design) peg new-design downloads to the current tag

### DIFF
--- a/packages/new-design/lib/config.mjs
+++ b/packages/new-design/lib/config.mjs
@@ -1,3 +1,5 @@
+import { version } from '../data.mjs'
+
 export const config = {
   // Whether we're publishing next or latest tags
   tag: 'next',
@@ -8,7 +10,7 @@ export const config = {
   // Repository to download from
   repo: process.env.FS_REPO || 'freesewing/freesewing',
   // Branch to download from
-  branch: process.env.FS_BRANCH || 'develop',
+  branch: process.env.FS_BRANCH || version,
   i18n: [
     'account',
     'common',


### PR DESCRIPTION
Right now, `npx @freesewing/new-design@next` will download the latest *published* packages, but will also download `lab` and `shared` files directly from the `develop` branch, which can lead to the build errors when the next tag is stale.

This PR makes it so that `npx @freesewing/new-design@next` downloads those files from the github tag of the same name as the published package version, enforcing consistency. 

I notice that while the tag is created in `postrelease` we are not consistently pushing the tag every time we publish a version, so this will want us to make sure that we are doing that.