### PR TITLE
fix(noble,octoplushy,simon): Add/modify options hide, with workarounds

### DIFF
--- a/designs/noble/src/options.mjs
+++ b/designs/noble/src/options.mjs
@@ -11,11 +11,16 @@ export const shoulderDartPosition = {
   pct: 50,
   min: 10,
   max: 90,
-  menu: ({ options }) => (options.dartPosition != 'shoulder' ? 'darts' : false),
+  menu: 'darts',
+  hide: ({ options }) => options?.dartPosition === 'armhole',
 }
 export const armholeDartPosition = {
   pct: 50,
   min: 10,
   max: 90,
-  menu: ({ options }) => (options.dartPosition == 'shoulder' ? 'darts' : false),
+  menu: 'darts',
+  hide: ({ options }) =>
+    options === undefined ||
+    options?.dartPosition === undefined ||
+    options.dartPosition === 'shoulder',
 }

--- a/designs/octoplushy/src/head.mjs
+++ b/designs/octoplushy/src/head.mjs
@@ -611,25 +611,28 @@ const options = {
     pct: 90,
     min: 75,
     max: 125,
-    menu: ({ options }) => (options.type == 'octoplushy' ? 'style' : false),
+    menu: 'style',
+    hide: ({ options }) =>
+      options === undefined || options?.type === undefined || options === 'octoplushy',
   },
   bottomArmReductionPlushy: {
     pct: 80,
     min: 75,
     max: 125,
-    menu: ({ options }) => (options.type != 'octoplushy' ? 'style' : false),
+    menu: 'style',
+    hide: ({ options }) => options?.type === 'squid' || options?.type === 'octopus',
   },
 }
 
 export const headSection1 = {
   name: 'octoplushy.headSection1',
   options,
-  plugins: [ pluginBundle ],
+  plugins: [pluginBundle],
   draft: (params) => octoplushyHeadSection(0, params),
 }
 export const headSection2 = {
   name: 'octoplushy.headSection2',
   options,
-  plugins: [ pluginBundle ],
+  plugins: [pluginBundle],
   draft: (params) => octoplushyHeadSection(1, params),
 }

--- a/designs/simon/src/options.mjs
+++ b/designs/simon/src/options.mjs
@@ -13,7 +13,7 @@ export const buttonFreeLength = { pct: 2, min: 0, max: 15, menu: 'style.closure'
 export const buttonholePlacketStyle = {
   list: ['classic', 'seamless'],
   dflt: 'seamless',
-  hide: ({ options }) => options.seperateButtonholePlacket,
+  hide: ({ options }) => options?.seperateButtonholePlacket,
   menu: 'style.closure',
 }
 export const buttonholePlacketWidth = { pct: 8, min: 4, max: 12, menu: 'style.closure' }
@@ -21,7 +21,7 @@ export const buttonholePlacketFoldWidth = { pct: 16, min: 8, max: 24, menu: 'sty
 export const buttonPlacketStyle = {
   list: ['classic', 'seamless'],
   dflt: 'classic',
-  hide: ({ options }) => options.seperateButtonPlacket,
+  hide: ({ options }) => options?.seperateButtonPlacket,
   menu: 'style.closure',
 }
 export const buttonPlacketWidth = { pct: 5, min: 2, max: 8, menu: 'style.closure' }


### PR DESCRIPTION
This PR closes #2779 by updating Hi and Noble's part configurations to use functions in `hide` rather than `menu`.

However, this PR also includes workarounds for bugs #3955 and #3956, including an update to Simon's part configuration with one of the workarounds. It might be that we want those bugs to be fixed before merging this PR. If that is the case, then the workarounds can be removed from this PR.
