### PR TITLE
fix(simon): Correct cuff button placement

### DIFF
--- a/designs/simon/src/shared.mjs
+++ b/designs/simon/src/shared.mjs
@@ -147,7 +147,7 @@ export const decorateBarrelCuff = (part) => {
   for (let i = 1; i <= options.cuffButtonRows; i++) {
     points['button' + i] = points.buttonLineTop.shiftFractionTowards(
       points.buttonLineBottom,
-      (1 / (options.cuffButtonRows + 1)) * i
+      (1 / (Number(options.cuffButtonRows) + 1)) * i
     )
     snippets['button' + i] = new Snippet('button', points['button' + i])
     points['buttonhole' + i] = new Point(points.buttonholeLineTop.x, points['button' + i].y)


### PR DESCRIPTION
Fixes #3967.

`options.cuffButtonRows` was getting cast to a string, so instead of correct row spacing of 1/2 or 1/3, the incorrect spacing of 1/11 or 1/22 was used.

After:
![Screenshot 2023-05-11 at 12 25 18 PM](https://github.com/freesewing/freesewing/assets/109869956/e7434185-1abb-496b-b4a4-c6f18391688e)
![Screenshot 2023-05-11 at 12 25 27 PM](https://github.com/freesewing/freesewing/assets/109869956/546f4d78-2368-4eb2-982d-630bfe1e9f51)
