### PR TITLE
fix(docs): Move optional measurements info from Part config to Part draft

### DIFF
--- a/markdown/dev/reference/api/part/config/measurements/en.md
+++ b/markdown/dev/reference/api/part/config/measurements/en.md
@@ -37,13 +37,3 @@ const part = {
   draft: ({ part }) => part
 }
 ```
-
-<Tip>
-
-Although they are specified via the part configuration `optionalMeasurements`
-property, optional measurements are accessed via the 'measurements'
-settings property.
-
-(There is no `optionalMeasurements` settings property.)`
-
-</Tip>

--- a/markdown/dev/reference/api/part/draft/en.md
+++ b/markdown/dev/reference/api/part/draft/en.md
@@ -3,14 +3,14 @@ title: "The part's draft method"
 ---
 
 Each part **must** have a `draft` property that holds a method that will draft the part.
-In other words, this method is where the actual work happens. The method's signature 
+In other words, this method is where the actual work happens. The method's signature
 is as follows:
 
 ```js
 function draft(props)
 ```
 
-The draft method receives a single parameter, an object which you can _destructure_ to 
+The draft method receives a single parameter, an object which you can _destructure_ to
 access the following properties:
 
 | Property | Description |
@@ -45,3 +45,11 @@ access the following properties:
 | `Bezier`          | The [bezier-js](https://pomax.github.io/bezierjs/) library's `Bezier` named export |
 || **_Return value_**   |
 | `part`            | Your draft method **must** return this |
+
+<Tip>
+
+Please note that there is no `optionalMeasurements` property.
+Instead, optional measurements are accessed via the 'measurements'
+property.
+
+</Tip>


### PR DESCRIPTION
This PR addresses the concerns in #3974, suggesting that information about optional measurements did not belong in the Part config documentation and instead should be moved to Part draft documentation.