### PR TITLE
fix(core): Add strictMax property to bin pack() call

### DIFF
--- a/packages/core/src/pattern/pattern-renderer.mjs
+++ b/packages/core/src/pattern/pattern-renderer.mjs
@@ -131,7 +131,11 @@ PatternRenderer.prototype.__pack = function () {
   }
   if (settings[activeSet].layout === true) {
     // some plugins will add a width constraint to the settings, but we can safely pass undefined if not
-    let size = pack(bins, { inPlace: true, maxWidth: settings[0].maxWidth })
+    let size = pack(bins, {
+      inPlace: true,
+      maxWidth: settings[0].maxWidth,
+      strictMax: settings[0].maxWidth ? true : false,
+    })
     this.autoLayout.width = size.width
     this.autoLayout.height = size.height
 


### PR DESCRIPTION
This PR adds a `strictMax` property to the bin `pack()` call to take advantage of packing improvements to be implemented in https://github.com/freesewing/bin-pack-with-constraints/pull/1 .

With that PR and this one, there will be improvements in parts packing in cutting layouts, as described in #3909.

This PR can be merged before or after https://github.com/eriese/bin-pack-with-constraints/pull/1. Currently, the `strictMax` property is ignored by `bin-pack-with-constraints`, so merging this PR before that one will result in no change in behavior.