### PR TITLE
fix(brian): Add explicit cutlist for back and (inherited) front parts

### DIFF
--- a/designs/brian/src/back.mjs
+++ b/designs/brian/src/back.mjs
@@ -132,6 +132,8 @@ export const back = {
       grainline: true,
     })
 
+    store.cutlist.addCut({ cut: 1 })
+
     // Complete pattern?
     if (complete) {
       macro('title', { at: points.title, nr: 2, title: 'back' })


### PR DESCRIPTION
This PR adds an explicit cutlist to Brian's Back (and by inheritance, Brian's Front) parts.

My previous PR #3908 to add cutlists to Brian was incomplete. My policy then was to add an explicit cutlist only if it was necessary to "produce the correct cutlist in the cutting layout". So, if a part's cutting layout was already correct due to the no-explicit-cutlist default behavior (like Brian's Back and Front parts), I didn't add the cutlist.

However, the explicit cutlist is required to add the cutting instructions to titles. Brian's Back and Front parts were missing these. (And, by inheritance Bent's parts were also missing these. And, the issue would have affected any other design inheriting from Brian.) So, this PR now adds the missing cutlists.

Before and After (titles now have cutting instructions):
![Screenshot 2023-05-20 at 5 34 34 AM](https://github.com/freesewing/freesewing/assets/109869956/dfca8f8b-42c9-4dfd-a92b-2a11ca4b93fa)
![Screenshot 2023-05-20 at 5 34 04 AM](https://github.com/freesewing/freesewing/assets/109869956/859358df-f388-4dc4-b3a1-21fb728d1e2a)

Before and After (no change in the actual cutting layout, but the titles now have cutting instructions):
![Screenshot 2023-05-20 at 5 35 20 AM](https://github.com/freesewing/freesewing/assets/109869956/3f47454e-0542-42f4-bdf9-d37284b4f944)
![Screenshot 2023-05-20 at 5 35 48 AM](https://github.com/freesewing/freesewing/assets/109869956/f7783afd-1f26-4897-8273-8d000f545690)
