### PR TITLE
chore(accessory designs): Add cutlist

### DIFF
--- a/designs/albert/src/front.mjs
+++ b/designs/albert/src/front.mjs
@@ -126,6 +126,11 @@ export const front = {
       .attr('data-text', 'hem')
       .attr('data-text-class', 'text-xs center')
 
+    macro('cutonfold', {
+      from: points.topCOF,
+      to: points.bottomCOF,
+    })
+
     // Complete?
     if (complete) {
       points.logo = points.topRightBack.shiftFractionTowards(points.pocketRightBottom, 0.5)
@@ -153,11 +158,6 @@ export const front = {
       if (sa) {
         paths.sa = paths.seam.offset(sa).attr('class', 'fabric sa')
       }
-
-      macro('cutonfold', {
-        from: points.topCOF,
-        to: points.bottomCOF,
-      })
     }
 
     // Paperless?

--- a/designs/albert/src/strap.mjs
+++ b/designs/albert/src/strap.mjs
@@ -84,6 +84,8 @@ export const strap = {
       .attr('data-text', 'fold')
       .attr('data-text-class', 'text-xs center')
 
+    store.cutlist.addCut()
+
     // Complete?
     if (complete) {
       points.logo = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/bob/src/bib.mjs
+++ b/designs/bob/src/bib.mjs
@@ -24,6 +24,7 @@ export const bib = {
     snippets,
     Snippet,
     paperless,
+    store,
     part,
   }) => {
     // Head size
@@ -178,6 +179,8 @@ export const bib = {
     log.info(['biasTapeLength', { mm: paths.seam.length() }])
     log.info(['fabricHeight', { mm: points.tipRightTopStart.dy(points.bottomLeftEnd) }])
     log.info(['fabricWidth', { mm: points.bottomLeftStart.dx(points.bottomRightEnd) }])
+
+    store.cutlist.addCut({ cut: 1 })
 
     // Complete?
     if (complete) {

--- a/designs/florence/src/mask.mjs
+++ b/designs/florence/src/mask.mjs
@@ -14,6 +14,7 @@ function florenceMask({
   snippets,
   macro,
   utils,
+  store,
   part,
 }) {
   points.topLeft = new Point(0, 0)
@@ -57,6 +58,8 @@ function florenceMask({
     .close()
     .attr('class', 'fabric')
 
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lining' })
   if (complete) {
     points.logo = new Point(points.tipCenter.x / 2, points.tipCenterCp1.y)
     snippets.logo = new Snippet('logo', points.logo).attr('data-scale', 0.5)

--- a/designs/florent/src/brimbottom.mjs
+++ b/designs/florent/src/brimbottom.mjs
@@ -48,16 +48,17 @@ function draftFlorentBrimBottom({
     .close()
     .attr('class', 'fabric')
 
+  macro('grainline', {
+    from: points.outerMid,
+    to: points.innerMid,
+  })
+
   if (complete) {
     points.title = points.innerMid.shiftFractionTowards(points.outerMidCp2, 0.35)
     macro('title', {
       at: points.title,
       nr: 3,
       title: 'brimBottom',
-    })
-    macro('grainline', {
-      from: points.outerMid,
-      to: points.innerMid,
     })
     macro('sprinkle', {
       snippet: 'notch',

--- a/designs/florent/src/briminterfacing.mjs
+++ b/designs/florent/src/briminterfacing.mjs
@@ -8,6 +8,7 @@ function draftFlorentBrimInterfacing({
   macro,
   paths,
   Path,
+  store,
   part,
 }) {
   paths.hint = paths.seam.clone().attr('class', 'dashed stroke-sm')
@@ -46,16 +47,20 @@ function draftFlorentBrimInterfacing({
     if (['seam', 'inset', 'outset'].indexOf(i) === -1) delete paths[i]
   }
 
+  macro('grainline', {
+    from: points.outerMid,
+    to: points.innerMid,
+  })
+
+  store.cutlist.removeCut()
+  store.cutlist.addCut({ cut: 1, material: 'plastic' })
+
   if (complete) {
     points.title = points.innerMid.shiftFractionTowards(points.outerMidCp2, 0.35)
     macro('title', {
       at: points.title,
       nr: 5,
       title: 'brimInterfacing',
-    })
-    macro('grainline', {
-      from: points.outerMid,
-      to: points.innerMid,
     })
 
     if (paperless) {

--- a/designs/florent/src/brimtop.mjs
+++ b/designs/florent/src/brimtop.mjs
@@ -14,16 +14,17 @@ function draftFlorentBrimTop({ paperless, sa, complete, points, macro, paths, Pa
 
   paths.seam = paths.hint.offset(3).join(paths.rest).close().attr('class', 'fabric')
 
+  macro('grainline', {
+    from: points.outerMid,
+    to: points.innerMid,
+  })
+
   if (complete) {
     points.title = points.innerMid.shiftFractionTowards(points.outerMidCp2, 0.35)
     macro('title', {
       at: points.title,
       nr: 4,
       title: 'brimTop',
-    })
-    macro('grainline', {
-      from: points.outerMid,
-      to: points.innerMid,
     })
 
     if (sa)

--- a/designs/florent/src/side.mjs
+++ b/designs/florent/src/side.mjs
@@ -21,6 +21,17 @@ function draftFlorentSide({
   paths.seam = paths.side.clone().line(points.foldTop).attr('class', 'fabric')
   paths.seam.unhide()
 
+  macro('cutonfold', {
+    from: points.foldBottom,
+    to: points.foldTop,
+    offset: 15,
+    grainline: true,
+  })
+
+  store.cutlist.removeCut()
+  store.cutlist.addCut({ cut: 1 })
+  store.cutlist.addCut({ cut: 1, material: 'lining' })
+
   if (complete) {
     if (points.__miniscaleMetric) delete points.__miniscaleMetric
     if (points.__miniscaleImperial) delete points.__miniscaleImperial
@@ -33,12 +44,6 @@ function draftFlorentSide({
     })
     points.logo = points.tipCp2.shiftFractionTowards(points.outerTopCp1, 0.5)
     snippets.logo = new Snippet('logo', points.logo).attr('data-scale', 0.75)
-    macro('cutonfold', {
-      from: points.foldBottom,
-      to: points.foldTop,
-      offset: 15,
-      grainline: true,
-    })
     points.notch1 = new Path()
       .move(points.tip)
       .curve(points.tipCp1, points.outerTopCp2, points.outerTop)

--- a/designs/florent/src/top.mjs
+++ b/designs/florent/src/top.mjs
@@ -137,6 +137,16 @@ function draftFlorentTop({
   // Uncomment to see the side part here
   paths.side.hide()
 
+  points.grainlineFrom = new Point(points.midSideCp1.x, points.midBack.y)
+  points.grainlineTo = points.midBack.clone()
+  macro('grainline', {
+    from: points.grainlineFrom,
+    to: points.grainlineTo,
+  })
+
+  store.cutlist.addCut({ cut: 2 })
+  store.cutlist.addCut({ cut: 2, material: 'lining' })
+
   if (complete) {
     points.title = new Point(points.midMid.x, points.midFrontCp2.y)
     macro('title', {
@@ -146,12 +156,6 @@ function draftFlorentTop({
     })
     points.logo = new Point(points.title.x / 2, points.title.y)
     snippets.logo = new Snippet('logo', points.logo).attr('data-scale', 0.75)
-    points.grainlineFrom = new Point(points.midSideCp1.x, points.midBack.y)
-    points.grainlineTo = points.midBack.clone()
-    macro('grainline', {
-      from: points.grainlineFrom,
-      to: points.grainlineTo,
-    })
     macro('miniscale', { at: new Point(points.title.x * 0.75, points.title.y) })
     macro('sprinkle', {
       snippet: 'notch',

--- a/designs/holmes/src/ear.mjs
+++ b/designs/holmes/src/ear.mjs
@@ -14,6 +14,7 @@ function draftHolmesEar({
   paperless,
   macro,
   absoluteOptions,
+  store,
   part,
 }) {
   // Design pattern here
@@ -34,9 +35,13 @@ function draftHolmesEar({
     .hide()
   paths.hemBase = new Path().move(points.bottomFlipped).line(points.bottom).hide()
   paths.seam = paths.saBase.join(paths.hemBase).close()
+
+  macro('grainline', { from: points.top, to: new Point(0, points.bottom.y) })
+
+  store.cutlist.addCut({ cut: 4 })
+
   // Complete?
   if (complete) {
-    macro('grainline', { from: points.top, to: new Point(0, points.bottom.y) })
     points.logo = new Point(-0.5 * points.bottom.x, 0.75 * points.bottom.y)
     snippets.logo = new Snippet('logo', points.logo).attr('data-scale', 0.7)
     points.title = new Point(0.3 * points.bottom.x, 0.75 * points.bottom.y)

--- a/designs/holmes/src/gore.mjs
+++ b/designs/holmes/src/gore.mjs
@@ -13,6 +13,7 @@ function draftHolmesGore({
   sa,
   paperless,
   absoluteOptions,
+  store,
   part,
 }) {
   //Radius of the head
@@ -29,17 +30,20 @@ function draftHolmesGore({
     prefix: 'gore_',
   })
 
+  macro('cutonfold', {
+    from: points.p0,
+    to: points.gore_p1.shift(180, 20),
+    offset: -points.gore_p2.y / 6,
+    grainline: true,
+  })
+
+  store.cutlist.addCut({ cut: Number(options.gores) })
+  store.cutlist.addCut({ cut: Number(options.gores), material: 'lining' })
+
   // Complete?
   if (complete) {
     points.title = new Point(points.gore_p1.x / 10, points.gore_p2.y / 1.8)
     macro('title', { at: points.title, nr: 1, title: 'crown', scale: 0.5 })
-
-    macro('cutonfold', {
-      from: points.p0,
-      to: points.gore_p1.shift(180, 20),
-      offset: -points.gore_p2.y / 6,
-      grainline: true,
-    })
 
     if (sa) {
       paths.saCurve = new Path()

--- a/designs/holmes/src/visor.mjs
+++ b/designs/holmes/src/visor.mjs
@@ -13,6 +13,7 @@ function draftHolmesVisor({
   paperless,
   macro,
   absoluteOptions,
+  store,
   part,
 }) {
   let headCircumference = measurements.head + absoluteOptions.headEase
@@ -62,9 +63,14 @@ function draftHolmesVisor({
     .hide()
 
   paths.seam = paths.saOuter.join(paths.saInner).close()
+
+  macro('grainline', { from: points.in1, to: points.ex1 })
+
+  store.cutlist.addCut({ cut: 4 })
+  store.cutlist.addCut({ cut: 2, material: 'insert' })
+
   // Complete?
   if (complete) {
-    macro('grainline', { from: points.in1, to: points.ex1 })
     macro('title', { at: points.ex1.shift(45, 20), nr: 2, title: 'visor', scale: 0.4 })
 
     if (sa) {

--- a/designs/hortensia/src/bottompanel.mjs
+++ b/designs/hortensia/src/bottompanel.mjs
@@ -32,6 +32,9 @@ function draftHortensiaBottompanel({
     .close()
     .attr('class', 'fabric')
 
+  store.cutlist.addCut({ cut: 1 })
+  store.cutlist.addCut({ cut: 1, material: 'lining' })
+
   // Complete?
   if (complete) {
     points.logo = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/hortensia/src/frontpanel.mjs
+++ b/designs/hortensia/src/frontpanel.mjs
@@ -80,6 +80,9 @@ function draftHortensiaFrontpanel({
     text: 'attachment',
   })
 
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lining' })
+
   // Complete?
   if (complete) {
     points.logo = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)

--- a/designs/hortensia/src/sidepanel.mjs
+++ b/designs/hortensia/src/sidepanel.mjs
@@ -132,6 +132,9 @@ function draftHortensiaSidepanel({
     .close()
     .attr('class', 'fabric')
 
+  store.cutlist.addCut()
+  store.cutlist.addCut({ material: 'lining' })
+
   // Complete?
   if (complete) {
     if (options.size > 0.4) {

--- a/designs/hortensia/src/sidepanelreinforcement.mjs
+++ b/designs/hortensia/src/sidepanelreinforcement.mjs
@@ -35,6 +35,8 @@ function draftHortensiaSidepanelreinforcement({
     .close()
     .attr('class', 'fabric')
 
+  store.cutlist.addCut()
+
   // Complete?
   if (complete) {
     points.title = points.topLeft

--- a/designs/hortensia/src/strap.mjs
+++ b/designs/hortensia/src/strap.mjs
@@ -42,6 +42,8 @@ function draftHortensiaStrap({
     .attr('data-text-class', 'center text-xs')
     .attr('class', 'lining dashed')
 
+  store.cutlist.addCut()
+
   // Complete?
   if (complete) {
     points.title = points.topMiddle.shiftFractionTowards(points.bottomMiddle, 0.25)

--- a/designs/hortensia/src/zipperpanel.mjs
+++ b/designs/hortensia/src/zipperpanel.mjs
@@ -30,6 +30,8 @@ function draftHortensiaZipperpanel({
     .close()
     .attr('class', 'fabric')
 
+  store.cutlist.addCut({ cut: 1 })
+
   // Complete?
   if (complete) {
     paths.text = new Path()

--- a/designs/lucy/src/pocket.mjs
+++ b/designs/lucy/src/pocket.mjs
@@ -12,6 +12,7 @@ function draft({
   sa,
   paperless,
   macro,
+  store,
   part,
 }) {
   // Pocket seams here
@@ -55,6 +56,8 @@ function draft({
     .line(points.centerRight)
     .line(points.centerLeft)
     .close()
+
+  store.cutlist.addCut()
 
   // Complete?
   if (complete) {

--- a/designs/octoplushy/src/eye.mjs
+++ b/designs/octoplushy/src/eye.mjs
@@ -60,7 +60,6 @@ function octoplushyEye(
       .curve(points.rightCp1, points.topCp2, points.top)
       .close()
       .attr('class', 'fabric')
-      .hide()
     points.logo = points.top.shiftFractionTowards(points.bottom, 0.3)
     points.titleAnchor = points.bottom
       .shiftFractionTowards(points.top, 0.25)
@@ -83,7 +82,6 @@ function octoplushyEye(
       .line(points.tl)
       .close()
       .attr('class', 'fabric')
-      .hide()
 
     points.logo = points.tl
       .shiftFractionTowards(points.bl, 0.5)

--- a/designs/octoplushy/src/eye.mjs
+++ b/designs/octoplushy/src/eye.mjs
@@ -60,6 +60,7 @@ function octoplushyEye(
       .curve(points.rightCp1, points.topCp2, points.top)
       .close()
       .attr('class', 'fabric')
+      .hide()
     points.logo = points.top.shiftFractionTowards(points.bottom, 0.3)
     points.titleAnchor = points.bottom
       .shiftFractionTowards(points.top, 0.25)
@@ -82,6 +83,7 @@ function octoplushyEye(
       .line(points.tl)
       .close()
       .attr('class', 'fabric')
+      .hide()
 
     points.logo = points.tl
       .shiftFractionTowards(points.bl, 0.5)

--- a/designs/trayvon/src/fabric.mjs
+++ b/designs/trayvon/src/fabric.mjs
@@ -14,6 +14,8 @@ function trayvonFabricTail(params) {
   draftTieShape(params, store.get('backTip') * 2.5, absoluteOptions.knotWidth * 2.5, true)
   paths.seam.attributes.add('class', 'fabric')
 
+  store.cutlist.addCut({ cut: 1 })
+
   // Complete pattern?
   if (complete) {
     macro('title', {
@@ -62,11 +64,14 @@ function trayvonFabricTip(params) {
     sa,
     snippets,
     absoluteOptions,
+    store,
   } = params
 
   calculateHelpers(params)
   draftTieShape(params, absoluteOptions.tipWidth * 2.5, absoluteOptions.knotWidth * 2.5, true)
   paths.seam.attributes.add('class', 'fabric')
+
+  store.cutlist.addCut({ cut: 1 })
 
   // Complete pattern?
   if (complete) {

--- a/designs/trayvon/src/interfacing.mjs
+++ b/designs/trayvon/src/interfacing.mjs
@@ -8,6 +8,8 @@ function trayvonInterfacingTail(params) {
   draftTieShape(params, store.get('backTip'), absoluteOptions.knotWidth)
   paths.seam.attributes.add('class', 'interfacing')
 
+  store.cutlist.addCut({ cut: 1, material: 'interfacing' })
+
   // Complete pattern?
   if (complete) {
     macro('title', {
@@ -33,11 +35,13 @@ function trayvonInterfacingTail(params) {
 }
 
 function trayvonInterfacingTip(params) {
-  const { paths, points, macro, complete, paperless, Path, absoluteOptions } = params
+  const { paths, points, macro, complete, paperless, Path, absoluteOptions, store } = params
 
   calculateHelpers(params)
   draftTieShape(params, absoluteOptions.tipWidth, absoluteOptions.knotWidth)
   paths.seam.attributes.add('class', 'interfacing')
+
+  store.cutlist.addCut({ cut: 1, material: 'interfacing' })
 
   // Complete pattern?
   if (complete) {

--- a/designs/trayvon/src/lining.mjs
+++ b/designs/trayvon/src/lining.mjs
@@ -41,6 +41,8 @@ function trayvonLiningTail(params) {
     .close()
     .attr('class', 'lining')
 
+  store.cutlist.addCut({ cut: 1, material: 'lining' })
+
   // Complete pattern?
   if (complete) {
     macro('title', {
@@ -72,6 +74,7 @@ function trayvonLiningTip(params) {
     sa,
     snippets,
     absoluteOptions,
+    store,
   } = params
 
   calculateHelpers(params)
@@ -91,6 +94,8 @@ function trayvonLiningTip(params) {
     .line(points.tip)
     .close()
     .attr('class', 'lining')
+
+  store.cutlist.addCut({ cut: 1, material: 'lining' })
 
   // Complete pattern?
   if (complete) {

--- a/designs/trayvon/src/loop.mjs
+++ b/designs/trayvon/src/loop.mjs
@@ -25,6 +25,8 @@ function trayvonFabricLoop({
     .close()
     .attr('class', 'fabric')
 
+  store.cutlist.addCut({ cut: 1, material: 'lining' })
+
   if (complete) {
     points.title = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)
 


### PR DESCRIPTION
This PR adds cutlist info to our Accessory designs, with the exceptions of:
- Hi (covered under PR #3924)
- Octoplushy (covered under PR #4098)
- Magde (no cutlist info available yet, pattern designer asked on Discord for info)

This PR also moves `cutonfold` and `grainline` macros out of `complete` blocks.
It does not add any titles to parts that don't already have them.