### PR TITLE
fix (core) draft after dependencies before from dependencies

### DIFF
--- a/packages/core/tests/fixtures/part.mjs
+++ b/packages/core/tests/fixtures/part.mjs
@@ -1,0 +1,6 @@
+export const fixtureDraft = ({ part }) => part
+export const fixturePart = (name, config = {}) => ({
+  name,
+  draft: fixtureDraft,
+  ...config,
+})


### PR DESCRIPTION
Resolves #4049 brings draft order in line with expectations, adds tests to specifically check correct draft order resolution