### PR TITLE
fix (org) clean up little errors in draft-for-curated-set flow

### DIFF
--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -48,7 +48,7 @@ carlton:
     '@freesewing/plugin-bust': *freesewing
 charlie:
   peer:
-    '@freesewing/plugin-bartack': *freesewing
+    '@freesewing/plugin-annotations': *freesewing
     '@freesewing/plugin-mirror': *freesewing
     '@freesewing/titan': *freesewing
     '@freesewing/snapseries': *freesewing
@@ -92,8 +92,6 @@ i18n:
   dev:
     'js-yaml': &jsyaml '4.1.0'
     'recursive-readdir': '^2.2.3'
-  peer:
-    '@freesewing/pattern-info': *freesewing
 jaeger:
   peer:
     '@freesewing/brian': *freesewing
@@ -135,7 +133,6 @@ plugintest:
     '@freesewing/plugin-sprinkle': *freesewing
     '@freesewing/plugin-svgattr': *freesewing
     '@freesewing/plugin-theme': *freesewing
-    '@freesewing/plugin-validate': *freesewing
 rehype-jargon:
   _:
     'unist-util-visit': &unist-util-visit '4.1.2'

--- a/designs/charlie/package.json
+++ b/designs/charlie/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "@freesewing/core": "3.0.0-alpha.10",
     "@freesewing/plugin-bundle": "3.0.0-alpha.10",
-    "@freesewing/plugin-bartack": "3.0.0-alpha.10",
+    "@freesewing/plugin-annotations": "3.0.0-alpha.10",
     "@freesewing/plugin-mirror": "3.0.0-alpha.10",
     "@freesewing/titan": "3.0.0-alpha.10",
     "@freesewing/snapseries": "3.0.0-alpha.10"

--- a/designs/plugintest/package.json
+++ b/designs/plugintest/package.json
@@ -58,8 +58,7 @@
     "@freesewing/plugin-round": "3.0.0-alpha.10",
     "@freesewing/plugin-sprinkle": "3.0.0-alpha.10",
     "@freesewing/plugin-svgattr": "3.0.0-alpha.10",
-    "@freesewing/plugin-theme": "3.0.0-alpha.10",
-    "@freesewing/plugin-validate": "3.0.0-alpha.10"
+    "@freesewing/plugin-theme": "3.0.0-alpha.10"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -43,9 +43,7 @@
     "wbuild": "node build.mjs",
     "wcibuild_step7": "node build.mjs"
   },
-  "peerDependencies": {
-    "@freesewing/pattern-info": "3.0.0-alpha.10"
-  },
+  "peerDependencies": {},
   "dependencies": {},
   "devDependencies": {
     "js-yaml": "4.1.0",

--- a/sites/shared/components/designs/design.mjs
+++ b/sites/shared/components/designs/design.mjs
@@ -12,9 +12,13 @@ export const Design = ({ name }) => {
     <div
       className={`flex flex-col flex-nowrap items-start justify-start gap-2 pt-2 pb-4 h-auto w-96
           btn btn-secondary btn-ghost border border-secondary
-          hover:bg-opacity-20 hover:bg-secondary hover:border hover:border-secondary`}
+          hover:bg-opacity-20 hover:bg-secondary hover:border hover:border-secondary
+          relative`}
     >
-      <Link href={`/new/pattern/${name}`} className="static w-full h-full">
+      <Link
+        href={`/new/pattern/${name}`}
+        className="w-full h-full before:absolute before:inset-y-0 before:inset-x-0"
+      >
         <h5 className="flex flex-row items-center justify-between w-full">
           <span>{t(`designs:${name}.t`)}</span>
           <span className="flex flex-col items-end">

--- a/sites/shared/components/designs/design.mjs
+++ b/sites/shared/components/designs/design.mjs
@@ -8,29 +8,29 @@ export const ns = ['design', 'designs', 'tags']
 
 export const Design = ({ name }) => {
   const { t } = useTranslation(ns)
-  console.log(name)
   return (
-    <Link
-      href={`/new/pattern/${name}`}
+    <div
       className={`flex flex-col flex-nowrap items-start justify-start gap-2 pt-2 pb-4 h-auto w-96
-        btn btn-secondary btn-ghost border border-secondary
-        hover:bg-opacity-20 hover:bg-secondary hover:border hover:border-secondary`}
+          btn btn-secondary btn-ghost border border-secondary
+          hover:bg-opacity-20 hover:bg-secondary hover:border hover:border-secondary`}
     >
-      <h5 className="flex flex-row items-center justify-between w-full">
-        <span>{t(`designs:${name}.t`)}</span>
-        <div className="flex flex-col items-end">
-          <span className="text-xs font-medium opacity-70">{t('design:difficulty')}</span>
-          <Difficulty score={designs[name].difficulty} />
-        </div>
-      </h5>
-      <div className={`normal-case text-base font-medium text-base-content text-left grow`}>
-        {t(`designs:${name}.d`)}
-      </div>
-      <div className="flex flex-row flex-wrap gap-1">
+      <Link href={`/new/pattern/${name}`} className="static w-full h-full">
+        <h5 className="flex flex-row items-center justify-between w-full">
+          <span>{t(`designs:${name}.t`)}</span>
+          <span className="flex flex-col items-end">
+            <span className="text-xs font-medium opacity-70">{t('design:difficulty')}</span>
+            <Difficulty score={designs[name].difficulty} />
+          </span>
+        </h5>
+        <span className={`normal-case text-base font-medium text-base-content text-left grow`}>
+          {t(`designs:${name}.d`)}
+        </span>
+      </Link>
+      <span className="flex flex-row flex-wrap gap-1 relative z-10">
         {designs[name].tags.map((tag) => (
           <DesignTag key={tag} tag={tag} />
         ))}
-      </div>
-    </Link>
+      </span>
+    </div>
   )
 }

--- a/sites/shared/components/sponsors/index.mjs
+++ b/sites/shared/components/sponsors/index.mjs
@@ -15,10 +15,9 @@ export const Sponsors = () => {
   return Object.keys(sponsors).map((sponsor) => {
     const Component = sponsors[sponsor]
     return (
-      <div className="flex flex-col items-center gap-4">
+      <div className="flex flex-col items-center gap-4" key={sponsor}>
         <span className="opacity-70 text-sm">{t(sponsor.toLowerCase())}</span>
         <a
-          key={sponsor}
           title={t(sponsor.toLowerCase())}
           href={`https://www.${sponsor.toLowerCase()}.com/?utm_source=freesewing&utm_campaign=oss`}
         >

--- a/sites/shared/components/workbench/index.mjs
+++ b/sites/shared/components/workbench/index.mjs
@@ -69,7 +69,7 @@ export const Workbench = ({ design, Design, set = false, DynamicDocs = false }) 
   }
 
   // Generate the pattern here so we can pass it down to both the view and the options menu
-  const pattern = draftViews.includes(view) ? new Design(settings) : false
+  const pattern = settings.measurements && draftViews.includes(view) ? new Design(settings) : false
 
   // Return early if the pattern is not initialized yet
   if (typeof pattern.getConfig !== 'function') return null

--- a/sites/shared/components/workbench/menus/core-settings/index.mjs
+++ b/sites/shared/components/workbench/menus/core-settings/index.mjs
@@ -107,7 +107,11 @@ export const Setting = ({
   const openButtons = []
   if (loadDocs)
     openButtons.push(
-      <button className="btn btn-xs btn-ghost px-0" onClick={(evt) => loadDocs(evt, name)}>
+      <button
+        className="btn btn-xs btn-ghost px-0"
+        key="help"
+        onClick={(evt) => loadDocs(evt, name)}
+      >
         <HelpIcon className="w-4 h-4" />
       </button>
     )
@@ -115,6 +119,7 @@ export const Setting = ({
     buttons.push(
       <button
         className="btn btn-accent"
+        key="clear"
         onClick={(evt) => {
           evt.stopPropagation()
           update.settings([name], config.dflt)
@@ -126,6 +131,7 @@ export const Setting = ({
     openButtons.push(
       <button
         className="btn btn-ghost btn-xs px-0"
+        key="clear"
         onClick={(evt) => {
           evt.stopPropagation()
           update.settings([name], config.dflt)
@@ -194,7 +200,11 @@ export const CoreSettings = ({
   const openButtons = []
   if (loadDocs)
     openButtons.push(
-      <button className="btn btn-xs btn-ghost px-0 z-10" onClick={(evt) => loadDocs(evt)}>
+      <button
+        className="btn btn-xs btn-ghost px-0 z-10"
+        key="help"
+        onClick={(evt) => loadDocs(evt)}
+      >
         <HelpIcon className="w-4 h-4" />
       </button>
     )

--- a/sites/shared/components/workbench/views/draft/menu.mjs
+++ b/sites/shared/components/workbench/views/draft/menu.mjs
@@ -6,9 +6,9 @@ import {
   CoreSettings,
   ns as coreMenuNs,
 } from 'shared/components/workbench/menus/core-settings/index.mjs'
-import { XrayMenu } from 'shared/components/workbench/menus/xray/index.mjs'
+import { XrayMenu, ns as xrayNs } from 'shared/components/workbench/menus/xray/index.mjs'
 
-export const ns = [...coreMenuNs, ...designMenuNs]
+export const ns = [...coreMenuNs, ...designMenuNs, ...xrayNs]
 
 export const DraftMenu = ({
   design,

--- a/sites/shared/components/wrappers/modal.mjs
+++ b/sites/shared/components/wrappers/modal.mjs
@@ -56,13 +56,17 @@ export const ModalWrapper = ({
       className={`fixed top-0 left-0 m-0 p-0 shadow w-full h-screen
         transform-all duration-150 ${animation}
         bg-${bg} bg-opacity-${bgOpacity} z-50 hover:cursor-pointer
-        flex flex-${flex} justify-${justify} overflow-auto items-${items} lg:p-12`}
+        flex flex-${flex} justify-${justify} items-${items} lg:p-12`}
       onClick={keepOpenOnClick ? null : close}
     >
       {bare ? (
         children
       ) : (
-        <div className={`bg-base-100 p-4 lg:px-8 lg:rounded-lg lg:shadow-lg`}>{children}</div>
+        <div
+          className={`bg-base-100 p-4 lg:px-8 lg:rounded-lg lg:shadow-lg max-h-100 overflow-auto`}
+        >
+          {children}
+        </div>
       )}
     </div>
   )

--- a/sites/shared/components/wrappers/page.mjs
+++ b/sites/shared/components/wrappers/page.mjs
@@ -49,7 +49,7 @@ export const PageWrapper = (props) => {
    */
   useEffect(() => {
     // Only update if a new page was loaded
-    if (path.join('/') !== 'slug') {
+    if (path.join('/') !== slug) {
       setNavigation({
         title: pageTitle,
         locale,


### PR DESCRIPTION
- remove sdead dependencies
- fixes link-in-link in `Design` component because it was causing ssr issues. Links are technically not allowed to have other interactive elements inside them, so I moved the tags out of the main link and used css to create the same ux without the compiler complaints
- adds keys where we were getting errors about them
- fixes error on reload of new pattern with set/cset page where pattern tries to draft before measurements are loaded
- imports xrayNS where needed
- moves overflow on modal to properly contain oversize content
- fixes infinite loop in slug comparison in page wrapper