### PR TITLE
chore(docs): Add documentation for packages

### DIFF
--- a/markdown/dev/reference/packages/en.md
+++ b/markdown/dev/reference/packages/en.md
@@ -1,0 +1,11 @@
+---
+title: Packages
+---
+
+Aside from the main `core` package that provides our pattern-generating
+library, FreeSewing provides other packages used to provide functionality
+for our designs, websites, and infrastructure.
+
+## Packages we maintain
+
+<ReadMore />

--- a/markdown/dev/reference/packages/i18n/en.md
+++ b/markdown/dev/reference/packages/i18n/en.md
@@ -1,0 +1,75 @@
+---
+title: i18n
+---
+
+Published as [@freesewing/i18n][1], this package provides translations
+for the FreeSewing project.
+
+## Languages
+
+We currently provide translations in 5 languages:
+
+ - English
+ - German
+ - Spanish
+ - French
+ - Dutch
+
+## How to use these translations
+
+We use these translations in our [repository](https://github.com/freesewing/freesewing)
+to translate react components with [react-intl](https://github.com/formatjs/formatjs/tree/main/packages/react-intl):
+
+```js
+import { strings } from "@freesewing/i18n";
+import { IntlProvider } from "react-intl";
+
+class Base extends React.Component {
+  render() {
+    const { language } = this.props;
+
+    return (
+      <IntlProvider locale={language} messages={strings[language]}>
+        {...children}
+      </IntlProvier>
+    )
+  }
+}
+```
+
+Now all components below will be able to translate messages:
+
+```js
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+const Example = props => {
+  return <p><FormattedMessage id={"app.aboutFreesewing"} /></p>
+};
+
+export default Example;
+```
+
+For all details, please refer to
+[the react-intl documentation](https://formatjs.io/docs/react-intl).
+
+We also use it in our backend to translate the emails we send out to users.
+
+## Installation
+
+```sh
+npm install @freesewing/i18n
+```
+
+## Notes
+
+This package provides the translations, but it does not provide the
+mechanism for translation.
+For that, you can use our [plugin-i18n](/reference/plugins/i18n) plugin.
+
+<Related compact>
+To learn more about using translations in a design, see the
+[Translation guide](/guides/translation/)
+</Related>
+
+[1]: https://www.npmjs.com/package/@freesewing/i18n

--- a/markdown/dev/reference/packages/models/en.md
+++ b/markdown/dev/reference/packages/models/en.md
@@ -1,0 +1,102 @@
+---
+title: models
+---
+
+Published as [@freesewing/models][1], this package provides body
+measurements data for a range of size models used by the FreeSewing project.
+
+## Models
+
+Models have names like `cisFemaleAdult34`, `cisMaleDoll30`,
+and `cisFemaleGiant150`.
+
+These names are constructed according to the 3 aspects that make up the model:
+1. Gender: `cisFemale` or `cisMale`
+2. Group: `Adult`, `Doll`, or `Giant`
+3. Size: a number
+   - For Adult models, the size number is the neck circumference in millimeters, Example: `34` for 34 mm.
+   - For Doll and Giant models, the size number is a whole number which is the percentage to scale a base model. Examples: '30' for a 30% size reduction for a doll, and '150' for a 150% size increase for a giant.
+
+## Available models
+
+Available models are:
+- cisFemaleAdult sizes 28, 30, 32, 34, 36, 38, 40, 42, 44, 46
+- cisMaleAdult sizes 32, 34, 36, 38, 40, 42, 44, 46, 48, 50
+- cisFemaleDoll sizes 10, 20, 30, 40, 50, 60
+- cisMaleDoll sizes 10, 20, 30, 40, 50, 60
+- cisFemaleGiant sizes 150, 200, 250, 300
+- cisMaleGiant sizes 150, 200, 250, 300
+
+## Exports
+
+models: Objects with key-value pairs, with measurement name keys and measurement value (in mm) values.
+
+`measurements`: Array of measurement name strings.  
+See [Measurements](/reference/measurements) for a list of measurement names.
+
+`group` Array of the model group name strings (`adult`, `doll`, `giant`).
+
+`sizes` Object with key-value pairs, with genderGroup keys and values that are Arrays of size numbers available for each genderGroup.
+
+genderGroups: Each genderGroup is an object of key-value pairs, with size keys and model values.  
+Available genderGroups: `cisFemaleAdult`, `cisMaleAdult`, `cisFemaleDoll`, `cisMaleDoll`, `cisFemaleGiant`, `cisMaleGiant`.
+
+groups: Each group is an object of key-value pairs, with gender keys and genderGroup values.  
+Available groups: `adult`, `doll`, `giant`.
+
+## Installation
+
+```sh
+npm install @freesewing/models
+```
+
+## Example
+
+In NodeJS:
+```js
+import { cisMaleAdult38 } from @freesewing/models
+
+```
+
+which will give you an object with measurement: value pairs.
+The example above gives you:
+
+```js
+{
+  ankle: 235,
+  biceps: 350,
+  bustFront: 560,
+  bustPointToUnderbust: 60,
+  bustSpan: 190,
+  chesT: 1000,
+  crossSeam: 870
+  crossSeamFront: 410,
+  crotchDepth: 340,
+  heel, 360,
+  head: 590,
+  ...
+}
+```
+
+## Units
+
+All measurements are in mm.
+
+
+## Notes
+
+These model measurement values were arbitrarily chosen by FreeSewing.
+They do __not__ correspond to any existing statistical data or
+official size charts.
+You should not expect that these models will produce garments that fit
+the same as clothing store sizes.
+
+To create our models, measurement values for a base cisFemale
+and cisMale model were first chosen.
+Then, for all other models their measurement values were generated from
+the base values using a mathematical formula which scales and adjusts
+the values.
+The mathematical formula is designed to produce approximate measurements
+which are realistic enough to be useful.
+
+[1]: https://www.npmjs.com/package/@freesewing/models

--- a/markdown/dev/reference/packages/new-design/en.md
+++ b/markdown/dev/reference/packages/new-design/en.md
@@ -1,0 +1,29 @@
+---
+title: new-design
+---
+
+Published as [@freesewing/new-design][1], this is an
+initializer package for a new FreeSewing design.
+
+## Usage
+
+```sh
+npx @freesewing/new-design
+```
+
+## Notes
+
+The package will run an interactive script and install a standalone
+development environment which can be used to develop and test a new
+FreeSewing design and to generate patterns from that design.
+
+<Related>
+
+Please see our
+[Getting Started tutorial](/tutorials/getting-started-linux/dev-setup#stand-alone-development)
+for more information about how to set up and start the standalone
+development environment.
+
+</Related>
+
+[1]: https://www.npmjs.com/package/@freesewing/new-design

--- a/markdown/dev/reference/packages/prettier-config/en.md
+++ b/markdown/dev/reference/packages/prettier-config/en.md
@@ -1,0 +1,44 @@
+---
+title: prettier-config
+---
+
+Published as [@freesewing/prettier-config][1], this package is
+FreeSewing's shared configuration for [Prettier](https://prettier.io/).
+
+## Installation
+
+```sh
+npm install @freesewing/prettier-config
+```
+
+## Usage
+
+Edit package.json:
+
+```json
+{
+  // ...
+  "prettier": "@freesewing/prettier-config"
+}
+```
+
+## Prettier options
+
+The Prettier options configured by this package:
+
+| Option | Value |
+|--------|-------|
+| semi | `false` |
+| singleQuote | `true` |
+| trailingComma | "es5" |
+| printWidth | 100 |
+
+<Related>
+
+Please see the
+[Prettier options documentation](https://prettier.io/docs/en/options.html)
+for information about the effects of each option.
+
+</Related>
+
+[1]: https://www.npmjs.com/package/@freesewing/prettier-config

--- a/markdown/dev/reference/packages/rehype-highlight-lines/en.md
+++ b/markdown/dev/reference/packages/rehype-highlight-lines/en.md
@@ -1,0 +1,74 @@
+---
+title: rehype-highlight-lines
+---
+
+Published as [@freesewing/rehype-highlight-lines][1], this package provides
+a [Rehype](https://github.com/rehypejs/rehype)
+plugin to format highlighted and struck-out lines in code blocks.
+
+## Installation
+
+```sh
+npm install @freesewing/rehype-highlight-lines
+```
+
+## Usage
+
+In NodeJS:
+```js
+import rehypeHighlightLines from @freesewing/rehype-highlight-lines
+
+...
+   rehypePlugins: [
+     [
+       rehypeHighlightLines,
+       {
+         highlightClass: ['highlight-lines', 'border-l-4'],
+         strikeoutClass: [
+           'strikeout-lines',
+           'bg-orange-300',
+           'bg-opacity-5',
+           'border-l-4',
+           'opacity-80',
+           'line-through',
+           'decoration-orange-500',
+         ],
+       },
+     ],
+   ],
+```
+
+### Example
+
+```js
+// These 3 lines will be highlighted:
+// highlight-start
+const a = 1
+const b = 2
+const c = 3
+// highlight-end
+const d = 4
+// These 2 lines will be struck out:
+// strikeout-start
+const e = 5
+const f = 6
+// strikeout-end
+```
+
+## Configuration
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------|
+| commentTag | String | 'span' | Tag that identifies a comment.   |
+| commentClass | String | 'hljs-comment' | CSS class that identifies a comment.|
+| openingCommentHighlight | String | 'highlight-start' | Comment text to start formatting lines as highlighted. |
+| closingCommentHighlight | String | 'highlight-end' | Comment text to stop formatting lines as highlighted. |
+| openingCommentStrikeout | String | 'strikeout-start' | Comment text to start formatting lines as struck-out. |
+| closingCommentStrikeout | String | 'strikeout-end' | Comment text to stop formatting lines as struck-out. |
+| highlightTag | String | 'section' | Tag to apply to the block of highlighted or struck-out lines. |
+| highlightClass | Array|String | 'highlight-lines' | CSS classes to apply to highlighted lines. |
+| strikeoutClass | Array|String | 'strikeout-lines' | CSS classes to apply to struck-out lines. |
+| swallow | Boolean | `true` | Remove extra linebreaks before the start of highlighted/struck-out lines. |
+
+
+[1]: https://www.npmjs.com/package/@freesewing/rehype-highlight-lines

--- a/markdown/dev/reference/packages/rehype-jargon/en.md
+++ b/markdown/dev/reference/packages/rehype-jargon/en.md
@@ -1,0 +1,83 @@
+---
+title: rehype-jargon
+---
+
+Published as [@freesewing/rehype-jargon][1], this package provides
+a [Rehype](https://github.com/rehypejs/rehype)
+plugin for adding HTML markup for jargon terms.
+It allows you to use jargon in your markdown/mdx/html content and use
+a centrally managed file of jargon terms and their definitions.
+
+## Installation
+
+```sh
+npm install @freesewing/rehype-jargon
+```
+
+## Usage
+
+In file `jargon.mjs`:
+```js
+export const jargon = {
+  term: '<b>term</b> has this description',
+  term2: 'A <i>differenti</i> description',
+}
+```
+
+In NodeJS:
+```js
+import rehypeJargon from @freesewing/rehype-jargon
+import { jargon } from './jargon.mjs'
+
+...
+   rehypePlugins: [
+     [rehypeJargon, { jargon: jargon }],
+   ],
+```
+
+### Example
+
+Here is an example of _jargon_ in markdown.
+
+
+## Configuration
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------|
+| jargon | Object |      | Key/Value pairs where the key is a jargon term and the value is the jargon description. The description is a string that can contain HTML tags. Required. |
+| transform | Function | (see below) | Given the jargon term and description, returns a string with the final HTML to output. |
+
+### Default transform function
+
+The default `transform` function is:
+```js
+(term, html) =>
+   `<span class="jargon-term">${term}<span class="jargon-info">${html}</span></span>`
+```
+
+The default `transform` function applies these CSS classes:
+- `jargon-term` is applied to jargon terms
+- `jargon-info` is applied to jargon descriptions
+
+You can style your jargon by adding styles to these CSS classes.
+
+## Notes
+
+- Markup will be added to jargon only if the terms are _emphasized_.
+
+- Keys should be in all lowercase characters in the jargon file.
+This is because terms are converted to lowercase before they are matched
+against the jargon file.
+
+- How terms are capitalized does not matter, for the same reason.
+
+- If you use HTML in your jargon descriptions, use only inline elements such as adding bold/italic formatting and inserting links.
+
+<Related>
+
+Please see [Using Jargon](/guides/markdown/jargon) for information
+about how Jargon is used in the FreeSewing websites.
+
+</Related>
+
+[1]: https://www.npmjs.com/package/@freesewing/rehype-jargon

--- a/markdown/dev/reference/packages/snapseries/en.md
+++ b/markdown/dev/reference/packages/snapseries/en.md
@@ -1,0 +1,61 @@
+---
+title: snapseries
+---
+
+Published as [@freesewing/models][1], this package provides series
+of common sizes for elastics and zippers and series of common intervals
+to be used with snapped percentage options.
+
+## Exports
+
+All exports are plain objects with `metric` and `imperial` properties
+that can be used as the `snap` property for snapped percentage options.
+
+Some exports have `metric` and `imperial` properties that are
+arrays of numbers.
+These exports and their properties are:
+
+- `elastics`: Arrays of common elastic widths
+- `zippers`: Arrays of common zipper lengths
+
+Other exports have `metric` and `imperial` properties that are
+numbers to allow options to be _snapped_ to multiples of the value.
+These exports and properties are:
+
+- `smallSteps`: Intervals of 1 mm or 1/32 inch
+- `steps`: Intervals of 5 mm or 1/8 inch
+- `bigSteps`: Intervals of 10 mm or 1/2 inch
+
+## Installation
+
+```sh
+npm install @freesewing/snapseries
+```
+
+## Example
+
+In NodeJS:
+```js
+import { elastics } from @freesewing/snapseries
+
+myOption: {
+  pct: 10,
+  min: 5
+  max: 35,
+  snap: elasitcs,
+}
+```
+
+## Units
+
+All measurements are in mm.
+
+<Related>
+
+Please see
+[Snapped percentage options](/reference/api/part/config/options/pct/snap)
+to learn more about how snapped percentage options are used.
+
+</Related>
+
+[1]: https://www.npmjs.com/package/@freesewing/snapseries


### PR DESCRIPTION
A first pass at adding documentation for packages.
- I put the documenation files in `/reference`.
- I realize that `models` may be changing soon, and the documentation will need to be updated. However, I chose to document the package as it exists today.
- I had to guess at how some things worked and what the Usage sections should look like. 
- Similarly, I just copied and pasted the same Installation sections.

This PR closes #3214