### PR TITLE
fix(docs): (waistToHips) Removed ambiguous trousers reference

### DIFF
--- a/markdown/org/docs/measurements/waisttohips/en.md
+++ b/markdown/org/docs/measurements/waisttohips/en.md
@@ -2,4 +2,4 @@
 title: Waist to hips
 ---
 
-The **waist to hips** measurement is measured from your waist down to the top of your hip bone (where your trousers sit). Measure it at the side of your body.
+The **waist to hips** measurement is measured from your waist down to the top of your hip bone. Measure it at the side of your body.


### PR DESCRIPTION
Removed the "where your trousers sit" wording because it is confusing to customers. Also, the hips circumference measurement instructions don't mention trousers.

> To me, "the top of your hip bone" and "where your trousers sit" are two completely different points, with the latter being entirely dependant on your style choices.

https://discord.com/channels/698854858052075530/757632180980547686/1111570194528219146
discord://discord.com/channels/698854858052075530/757632180980547686/1111570194528219146

(The customer mentioned that there was a discrepancy on the v2 org website between the With Breasts and Without Breasts images regarding where the hips were located. However, this PR does not address that issue, and I'm not sure if the problem will still exist in v3. If the issue is seen in v3, then we should address it then.)

> The pictures don't help either. The w/o breasts pic lines up with "where your trousers are" (for a lot of people) but it's definitely not what I would call "the top of your hip bone". The w/breasts image does however line up better with the bones, and is also a height a lot of people wear their pants.