### PR TITLE
fix(workbench): Accept measurement-less edited YAML for designs with no required measurements

### DIFF
--- a/sites/shared/components/workbench/edit/gist-validator.mjs
+++ b/sites/shared/components/workbench/edit/gist-validator.mjs
@@ -29,7 +29,7 @@ class GistValidator {
 
   /** check that the required measurements are all there and the correct type */
   validateMeasurements() {
-    if (!this.givenGist.measurements) {
+    if (!this.givenGist.measurements && this.design.patternConfig.measurements.length) {
       this.errors.measurements = 'MissingMeasurements'
       this.valid = false
       return


### PR DESCRIPTION
The "Edit YAML" function was giving a MissingMeasurements warning message when saving edited YAML for Bob which has no required measurements.