### PR TITLE
DRAFT: fix(bella): Add bustDartAngle option and keep bust dart location along side seam

### DIFF
--- a/designs/bee/src/cup.mjs
+++ b/designs/bee/src/cup.mjs
@@ -15,6 +15,7 @@ export const cup = {
     sideCurve: { pct: 0, min: -50, max: 50, menu: 'fit' },
     frontCurve: { pct: 0, min: -50, max: 50, menu: 'fit' },
     bellaGuide: { bool: false, menu: 'fit' },
+    bustDartAngle: 0,
   },
   draft: ({
     store,

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -37,7 +37,7 @@ export const back = {
     bustDartLength: { pct: 90, min: 75, max: 100, menu: 'darts' },
     waistDartLength: { pct: 90, min: 75, max: 100, menu: 'darts' },
     bustDartAngle: { count: 0, min: -20, max: 55, menu: 'darts' },
-    waistDartCurve: { pct: 100, min: 0, max: 100, menu: 'darts' },
+    waistDartCurve: { pct: 100, min: -100, max: 100, menu: 'darts' },
     // Armhole
     armholeDepth: { pct: 44, min: 38, max: 46, menu: 'armhole' },
     backArmholeCurvature: { pct: 63, min: 50, max: 85, menu: 'armhole' },

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -36,6 +36,7 @@ export const back = {
     bustDartCurve: { pct: 100, min: 0, max: 100, menu: 'darts' },
     bustDartLength: { pct: 90, min: 75, max: 100, menu: 'darts' },
     waistDartLength: { pct: 90, min: 75, max: 95, menu: 'darts' },
+    bustDartAngle: { count: 0, min: -20, max: 55, menu: 'darts' },
     // Armhole
     armholeDepth: { pct: 44, min: 38, max: 46, menu: 'armhole' },
     backArmholeCurvature: { pct: 63, min: 50, max: 85, menu: 'armhole' },

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -33,7 +33,7 @@ export const back = {
     waistEase: { pct: 5, min: 1, max: 20, menu: 'fit' },
     // Darts
     backDartHeight: { pct: 46, min: 38, max: 54, menu: 'darts' },
-    bustDartCurve: { pct: 100, min: 0, max: 100, menu: 'darts' },
+    bustDartCurve: { pct: 100, min: -100, max: 100, menu: 'darts' },
     bustDartLength: { pct: 90, min: 75, max: 100, menu: 'darts' },
     waistDartLength: { pct: 90, min: 75, max: 95, menu: 'darts' },
     bustDartAngle: { count: 0, min: -20, max: 55, menu: 'darts' },

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -35,8 +35,9 @@ export const back = {
     backDartHeight: { pct: 46, min: 38, max: 54, menu: 'darts' },
     bustDartCurve: { pct: 100, min: -100, max: 100, menu: 'darts' },
     bustDartLength: { pct: 90, min: 75, max: 100, menu: 'darts' },
-    waistDartLength: { pct: 90, min: 75, max: 95, menu: 'darts' },
+    waistDartLength: { pct: 90, min: 75, max: 100, menu: 'darts' },
     bustDartAngle: { count: 0, min: -20, max: 55, menu: 'darts' },
+    waistDartCurve: { pct: 100, min: 0, max: 100, menu: 'darts' },
     // Armhole
     armholeDepth: { pct: 44, min: 38, max: 46, menu: 'armhole' },
     backArmholeCurvature: { pct: 63, min: 50, max: 85, menu: 'armhole' },

--- a/designs/bella/src/front-side-dart.mjs
+++ b/designs/bella/src/front-side-dart.mjs
@@ -184,12 +184,26 @@ export const frontSideDart = {
     )
     points.waistDartLeftCp = points.waistDartLeft.shift(
       90,
-      (points.waistDartHem.dist(points.bust) / 2) * options.waistDartCurve
+      points.waistDartHem.dist(points.bust) / 2
     )
     points.waistDartRightCp = points.waistDartRight.shift(
       90,
-      (points.waistDartHem.dist(points.bust) / 2) * options.waistDartCurve
+      points.waistDartHem.dist(points.bust) / 2
     )
+
+    // Modify waist dart curvature per options
+    points.waistDartLeftMid = new Path()
+      .move(points.bust)
+      .line(points.waistDartLeft)
+      .shiftFractionAlong(0.5)
+    points.waistDartRightMid = new Path()
+      .move(points.bust)
+      .line(points.waistDartRight)
+      .shiftFractionAlong(0.5)
+    const waistDartCpWidth =
+      points.waistDartLeftMid.dist(points.waistDartLeftCp) * options.waistDartCurve
+    points.waistDartLeftCp.x = points.waistDartLeftMid.x - waistDartCpWidth
+    points.waistDartRightCp.x = points.waistDartRightMid.x + waistDartCpWidth
 
     paths.seam = new Path()
       .move(points.cfHem)

--- a/designs/bella/src/front-side-dart.mjs
+++ b/designs/bella/src/front-side-dart.mjs
@@ -152,7 +152,7 @@ export const frontSideDart = {
       points.bust,
       points.bustDartMiddle,
       points.armhole,
-      points.bustDartTop
+      points.sideHem
     )
     points.bustDartCpTop = points.bust
       .shiftFractionTowards(points.bustDartTop, 0.666)

--- a/designs/bella/src/front-side-dart.mjs
+++ b/designs/bella/src/front-side-dart.mjs
@@ -184,11 +184,11 @@ export const frontSideDart = {
     )
     points.waistDartLeftCp = points.waistDartLeft.shift(
       90,
-      points.waistDartHem.dist(points.bust) / 2
+      (points.waistDartHem.dist(points.bust) / 2) * options.waistDartCurve
     )
     points.waistDartRightCp = points.waistDartRight.shift(
       90,
-      points.waistDartHem.dist(points.bust) / 2
+      (points.waistDartHem.dist(points.bust) / 2) * options.waistDartCurve
     )
 
     paths.seam = new Path()

--- a/designs/bella/src/front-side-dart.mjs
+++ b/designs/bella/src/front-side-dart.mjs
@@ -127,7 +127,7 @@ export const frontSideDart = {
     )
     // Prevent bust dart from being located above the armhole
     if (points.bustDartTop.y < points.armhole.y) {
-      points.bustDartTop = points.armhole
+      points.bustDartTop = points.armhole.clone()
       log.info(
         part.name +
           ' Restricted bust dart angle to prevent the dart from starting above the armhole.'

--- a/designs/noble/src/options.mjs
+++ b/designs/noble/src/options.mjs
@@ -2,6 +2,7 @@
 export const shoulderToShoulderCorrection = 0.995
 export const bustDartCurve = 1
 export const bustDartLength = 0.9
+export const bustDartAngle = 0
 // Percentages
 export const bustSpanEase = { pct: 0, min: -5, max: 20, menu: 'fit' }
 export const backHemSlope = { deg: 2.5, min: 0, max: 5, menu: 'advanced' }


### PR DESCRIPTION
This PR:
1. Adds a `bustDartAngle` option to Bella that allows the customer to move the bust dart to a different location on the side seam.
2. Forces the bust dart location to start at the armhole in situations where the calculations would otherwise tell it to start above the armhole.
3. Forces the bust dart location to end at the bottom of the side hem in situations where the calculations would otherwise tell it to be located below the hem.
4. Adds `log.info` messages when the bust dart location is restricted in situations 2 and 3 above.
5. Adds `bustDartAngle` option constants to Bee and Noble, to remove the option, so there is no change in behavior for those two designs.

Edit: Added:
6. Changes `bustDartAngle` min from 0% to -100%, to allow convex side darts.

This fixes a current bug in Bella where, if the dart is located below the bottom of the hem, the side seam is incorrectly increased so the front side seam is longer than the back side seam.
![Screenshot 2023-05-30 at 4 15 17 PM](https://github.com/freesewing/freesewing/assets/109869956/a4583a41-4712-48e0-ba26-27f7444307b5)
https://discord.com/channels/698854858052075530/757632180980547686/1113245412132921374
discord://discord.com/channels/698854858052075530/757632180980547686/1113245412132921374

---

With the fix: Bella's front when `bustDartAngle` settings force the design to restrict bust dart location at top and bottom of seam and the log messages:
![Screenshot 2023-05-30 at 7 52 55 PM](https://github.com/freesewing/freesewing/assets/109869956/bdbb7639-38b5-474b-9b4c-c692420277a8)
![Screenshot 2023-05-30 at 7 53 11 PM](https://github.com/freesewing/freesewing/assets/109869956/0562ace0-8603-4e0d-92ed-0a7f4742adb4)
![Screenshot 2023-05-30 at 7 53 26 PM](https://github.com/freesewing/freesewing/assets/109869956/bf7f4da7-7033-4bf4-869a-56fc30e3b18b)
![Screenshot 2023-05-30 at 7 53 46 PM](https://github.com/freesewing/freesewing/assets/109869956/281d9cb5-eae4-4dc5-a770-1f8c8f6b7cc0)

---

Side dart curvature with `bustDartCurve` set to the new -100% minimum:
![Screenshot 2023-05-31 at 5 51 17 AM](https://github.com/freesewing/freesewing/assets/109869956/2303e76a-6569-4644-8664-ef79a75b35f6)
