### PR TITLE
Changing Math.ceil to Math.round in pattern-drafter for snap options.

### DIFF
--- a/packages/core/src/pattern/pattern-drafter.mjs
+++ b/packages/core/src/pattern/pattern-drafter.mjs
@@ -208,7 +208,7 @@ PatternDrafter.prototype.__snappedPercentageOption = function (optionName, set) 
   if (!Array.isArray(snapConf) && snapConf.metric && snapConf.imperial)
     snapConf = snapConf[this.pattern.settings[set].units]
   // Simple steps
-  if (typeof snapConf === 'number') return Math.ceil(abs / snapConf) * snapConf
+  if (typeof snapConf === 'number') return Math.round(abs / snapConf) * snapConf
   // List of snaps
   if (Array.isArray(snapConf) && snapConf.length > 1) {
     for (const snap of snapConf


### PR DESCRIPTION
Problem:
When using pctBasedOn options the snap was always rounding up rather than to the closest snap interger.

Example:
```
waistbandWidth: {
      pct: 4.2,
      min: 1,
      max: 6,
      snap: 5,
      ...pctBasedOn('waistToFloor'),
      menu: 'style',
    },
```
measurements.waistToFloor = 119.8cm
Exact output = 119.8 x 0.042  = 5.0316
Expected rounded output = 5cm
Current rounded output = 5.5cm

![image](https://github.com/freesewing/freesewing/assets/16866285/7e8fae3a-dcb4-4f17-84bc-5708d0068c2c)
![image](https://github.com/freesewing/freesewing/assets/16866285/20ce8db9-d677-48d2-972a-776a74703b2a)

Looking into the code I found that the toAbs: value of pctBasedOn was not being rounded like fromAbs:

```
export function pctBasedOn(measurement) {
  return {
    toAbs: (val, { measurements }) => measurements[measurement] * val,
    fromAbs: (val, { measurements }) =>
      Math.round((10000 * val) / measurements[measurement]) / 10000,
  }
}
```

Solution:

Add Math.round to pctBaseOn in core.

```
export function pctBasedOn(measurement) {
  return {
    toAbs: (val, { measurements }) => Math.round(measurements[measurement] * val),
    fromAbs: (val, { measurements }) =>
      Math.round((10000 * val) / measurements[measurement]) / 10000,
  }
}
```

![image](https://github.com/freesewing/freesewing/assets/16866285/9daad638-072d-4044-bdbe-9af24218d3ba)


