### PR TITLE
fix(new-design): Import using absolute identifier

### DIFF
--- a/packages/new-design/lib/utils.mjs
+++ b/packages/new-design/lib/utils.mjs
@@ -8,7 +8,7 @@ import prompts from 'prompts'
 import { oraPromise } from 'ora'
 import { execa } from 'execa'
 import axios from 'axios'
-import { fileURLToPath } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 
 // Current working directory
 let filename
@@ -439,7 +439,7 @@ export const createEnvironment = async (choices) => {
     shared: (await rdir(config.source.shared)).map((file) => relative(config.source.shared, file)),
   }
 
-  config.templateData = await import(config.source.templateData)
+  config.templateData = await import(pathToFileURL(config.source.templateData))
   // does this base have parts with a lot of attending config?
   config.complexParts = typeof config.templateData.parts[0] === 'object'
 


### PR DESCRIPTION
Fixes #4290

Prepends `file://` schema during the import of template data to support windows paths.


Testing:  
1.  Check out branch and navigate to root directory
2. Run:  `node packages/new-design/index.mjs` 
3. Follow prompts and answer questions
4. After completion - verify that a new directory has been created with templated files.
FAILIF:  ERR_UNSUPPORTED_ESM_URL_SCHEME is thrown

Note:  This should be tested on *nix system for regression, and a windows system to verify the fix works.