### PR TITLE
feat(shared): Keep pattern settings in URL

### DIFF
--- a/sites/shared/components/workbench/index.mjs
+++ b/sites/shared/components/workbench/index.mjs
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'next-i18next'
 import { useView } from 'shared/hooks/use-view.mjs'
+import { usePatternSettings } from 'shared/hooks/use-pattern-settings.mjs'
 import { useAccount } from 'shared/hooks/use-account.mjs'
 import { useControlState } from 'shared/components/account/control.mjs'
 // Dependencies
@@ -65,14 +66,21 @@ export const Workbench = ({ design, Design, baseSettings, DynamicDocs, from }) =
 
   // State
   const [view, setView] = useView()
-  const [settings, setSettings] = useState({ ...baseSettings, embed: true })
+  const [settings, setSettings] = usePatternSettings()
   const [ui, setUi] = useState(defaultUi)
   const [error, setError] = useState(false)
+  const [mounted, setMounted] = useState(false)
 
   // Effect
   useEffect(() => {
-    // Force re-render when baseSettings changes. Required when they are loaded async.
-    setSettings({ ...baseSettings, embed: true })
+    /*
+     * baseSettings can be loaded async.
+     * So we need be careful when to trust the state in the URL or when to use the one from props.
+     */
+    if (!mounted && !settings && baseSettings) {
+      setMounted(true)
+      setSettings({ ...baseSettings, embed: true })
+    }
   }, [baseSettings])
 
   // Helper methods for settings/ui updates

--- a/sites/shared/hooks/use-pattern-settings.mjs
+++ b/sites/shared/hooks/use-pattern-settings.mjs
@@ -1,0 +1,6 @@
+import { useAtom } from 'jotai'
+import { atomWithHash } from 'jotai-location'
+
+const baseSettings = atomWithHash('settings', false, { delayInit: true })
+
+export const usePatternSettings = () => useAtom(baseSettings)


### PR DESCRIPTION
This moves patterns settings from React state to the URL, which has some great advantages:

- It's page-reload proof
- Don't like a change you just made? Just use the back button of your browser to revert to the previous state
- This makes it trivial to update measurements in state, without changing them permanently
- This also allows us to pre-generate a URL that will display a pattern in a particular state

We could make this a little neater by filtering the measurements so that only the ones used by the design are included, as that will keep the URLs a lot shorter.

One potential concern is that this *leaks* measurement data in the URL. Which is perhaps fine because browser history is private, but it's worth pointing it out anyway.