### PR TITLE
fix (designs) add missing measurements to design configs

### DIFF
--- a/designs/aaron/src/front.mjs
+++ b/designs/aaron/src/front.mjs
@@ -5,6 +5,7 @@ import { dimensions } from './shared.mjs'
 export const front = {
   from: base,
   name: 'aaron.front',
+  measurements: ['hips'],
   options: {
     brianFitCollar: false,
     brianFitSleeve: false,

--- a/designs/bee/src/cup.mjs
+++ b/designs/bee/src/cup.mjs
@@ -8,6 +8,7 @@ export const cup = {
     inherited: true,
   },
   after: neckTie,
+  measurements: ['bustPointToUnderbust'],
   options: {
     topDepth: { pct: 54, min: 50, max: 80, menu: 'fit' },
     bottomCupDepth: { pct: 8, min: 0, max: 20, menu: 'fit' },

--- a/designs/carlton/src/front.mjs
+++ b/designs/carlton/src/front.mjs
@@ -483,7 +483,7 @@ export const front = {
   name: 'carlton.front',
   from: bentFront,
   hide: hidePresets.HIDE_TREE,
-  measurements: ['waist', 'waistToFloor', 'waistToSeat'],
+  measurements: ['waist', 'waistToFloor', 'waistToSeat', 'seat'],
   options: {
     chestEase: { pct: 10, min: 5, max: 20, menu: 'fit' },
     buttonSpacingHorizontal: { pct: 43.5, min: 15, max: 60, menu: 'style' },

--- a/designs/simone/src/fba-front.mjs
+++ b/designs/simone/src/fba-front.mjs
@@ -415,7 +415,7 @@ function simoneFbaFront({
 export const fbaFront = {
   name: 'simone.fbaFront',
   from: front,
-  measurements: ['highBust'],
+  measurements: ['highBust', 'bustSpan', 'hpsToBust'],
   hide: {
     self: true,
     from: true,

--- a/packages/core/src/part.mjs
+++ b/packages/core/src/part.mjs
@@ -176,7 +176,7 @@ Part.prototype.shorthand = function () {
     get: function (measurements, name) {
       if (typeof measurements[name] === 'undefined')
         self.context.store.log.warning(
-          `Tried to access \`measurements.${name}\` but it is \`undefined\``
+          `${self.name} tried to access \`measurements.${name}\` but it is \`undefined\``
         )
       return Reflect.get(...arguments)
     },

--- a/packages/models/tests/models.test.mjs
+++ b/packages/models/tests/models.test.mjs
@@ -1,5 +1,5 @@
 import chai from 'chai'
-import * as all from './dist/index.mjs'
+import * as all from '../src/index.mjs'
 
 const expect = chai.expect
 const { measurements, sizes } = all

--- a/tests/designs/config.mjs
+++ b/tests/designs/config.mjs
@@ -1,4 +1,4 @@
-import { measurements } from '@freesewing/models'
+import { measurements, cisFemaleAdult28 } from '@freesewing/models'
 import designs from '../../config/software/designs.json' assert { type: 'json' }
 import chai from 'chai'
 
@@ -89,6 +89,28 @@ export const testPatternConfig = (Pattern) => {
         expect(measurements.indexOf(measurement)).to.not.equal(-1)
       })
     }
+    it('Requests all measurements it uses', () => {
+      const requested = {}
+      const patternMeasies = patternConfig.measurements.concat(patternConfig.optionalMeasurements)
+      for (let measurement of patternMeasies) {
+        requested[measurement] = cisFemaleAdult28[measurement]
+      }
+
+      const draft = new Pattern({
+        measurements: requested,
+      }).draft()
+
+      const missWarnings = draft.setStores[0].logs.warning.filter((w, i, a) => {
+        return w.match(/tried to access \`measurements/) && a.indexOf(w) === i
+      })
+      chai.assert(
+        missWarnings.length === 0,
+        `expected part to request all used measurements. \nThe following measurements were requested in the config: ${patternMeasies.join(
+          ', '
+        )} \nbut got the following warnings: \n${missWarnings.join('\n')}
+        `
+      )
+    })
   }
 
   // Test validity of the pattern's options


### PR DESCRIPTION
While working on the new front end I discovered that a few designs didn't actually include all necessary measurements in their configs, which meant that sets that didn't have all the needed measurements could in some cases be used, which obviously caused errors.

This PR adds the measurements to the correct parts and implements a test to catch this issue in the future