### PR TITLE
fix (workbench) allow designs with no measurements to draft

### DIFF
--- a/sites/shared/components/workbench/new.mjs
+++ b/sites/shared/components/workbench/new.mjs
@@ -80,6 +80,7 @@ export const Workbench = ({ design, Design, DynamicDocs }) => {
     // protect against loops
     if (!mounted) return
 
+    setMounted(true)
     const [ok, missing] = hasRequiredMeasurements(Design, settings.measurements)
     if (ok) setMissingMeasurements(false)
     // Force the measurements view if we have missing measurements
@@ -117,8 +118,11 @@ export const Workbench = ({ design, Design, DynamicDocs }) => {
     setControl: controlState.update,
   }
 
-  // Don't bother without a Design
-  if (!Design) return <ModalSpinner />
+  // wait for mount. this helps prevent hydration issues
+  if (!mounted) return <ModalSpinner />
+
+  // Warn that the design is somehow missing
+  if (!Design) return <ErrorView>{t('workbench.noDesignFound')}</ErrorView>
 
   // Short-circuit errors early
   if (error)
@@ -163,7 +167,8 @@ export const Workbench = ({ design, Design, DynamicDocs }) => {
       const layout = ui.layouts?.[view] || settings.layout || true
       // Generate the pattern here so we can pass it down to both the view and the options menu
       const pattern =
-        settings.measurements !== undefined && new Design({ layout, embed: true, ...settings })
+        (Design.patternConfig.measurements.length === 0 || settings.measurements !== undefined) &&
+        new Design({ layout, embed: true, ...settings })
 
       // Return early if the pattern is not initialized yet
       if (typeof pattern.getConfig !== 'function') return null

--- a/sites/shared/components/workbench/workbench.en.yaml
+++ b/sites/shared/components/workbench/workbench.en.yaml
@@ -31,3 +31,4 @@ patternInspector: Pattern Inspector
 docs: Documentation
 configurePattern: Configure pattern
 measies: Pattern Measurements
+noDesignFound: We could not find this design. This shouldn't happen, so we'd really appreciate you reporting it.


### PR DESCRIPTION
Turns out we were still using the presence of measurements as a check for allowing patterns to draft, which means measurement-free designs were just showing a blank page. I also noticed that we were returning null if the design was missing, so I changed that to showing an error because the design is loaded synchronously so we should never be without it unless something has gone wrong.