### PR TITLE
Parts renamed to stacks in layout reference docs

### DIFF
--- a/markdown/dev/reference/settings/layout/en.md
+++ b/markdown/dev/reference/settings/layout/en.md
@@ -58,7 +58,9 @@ import { Aaron } from "@freesewing/aaron"
 
 const pattern = new Aaron({
   layout: {
-    parts: {
+    width: 600,
+    height: 1000,
+    stacks: {
       front: {
         move: {
           x: 14,


### PR DESCRIPTION
After troubleshooting on discord we found a solution to own object layout in v3. It renamed parts to stacks in this object and some other pieces seem to require width and height so I added them to the example too.