### PR TITLE
fix(org): Avoid confusing about what slug means

### DIFF
--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -403,7 +403,8 @@ shared:
     'remark-mdx-frontmatter': '3.0.0'
     'remark-smartypants': '2.0.0'
     'sharp': '0.32.3'
-    'svg-to-pdfkit': 'https://github.com/eriese/SVG-to-PDFKit'
+    # see: https://github.com/npm/cli/issues/2610#issuecomment-1295371753
+    'svg-to-pdfkit': 'https://git@github.com/eriese/SVG-to-PDFKit'
     'tlds': '1.240.0'
     'to-vfile': '8.0.0'
     'unist-util-visit': *unist-util-visit

--- a/config/dependencies.yaml
+++ b/config/dependencies.yaml
@@ -247,7 +247,8 @@ dev:
     'rehype-sanitize': &rehypeSanitize '5.0.1'
     'rehype-slug': &rehypeSlug '5.1.0'
     'rehype-stringify': &rehypeStringify '9.0.3'
-    'remark-copy-linked-files': &remarkCopyLinkedFiles 'https://github.com/joostdecock/remark-copy-linked-files'
+    # see: https://github.com/npm/cli/issues/2610#issuecomment-1295371753
+    'remark-copy-linked-files': &remarkCopyLinkedFiles 'git+https://git@github.com/joostdecock/remark-copy-linked-files'
     'remark-gfm': &remarkGfm '3.0.1'
   dev: &nextSiteDevDependencies
     '@playwright/test': '^1.32.3'

--- a/sites/dev/package.json
+++ b/sites/dev/package.json
@@ -56,7 +56,7 @@
     "rehype-sanitize": "5.0.1",
     "rehype-slug": "5.1.0",
     "rehype-stringify": "9.0.3",
-    "remark-copy-linked-files": "https://github.com/joostdecock/remark-copy-linked-files",
+    "remark-copy-linked-files": "git+https://git@github.com/joostdecock/remark-copy-linked-files",
     "remark-gfm": "3.0.1"
   },
   "devDependencies": {

--- a/sites/lab/package.json
+++ b/sites/lab/package.json
@@ -60,7 +60,7 @@
     "rehype-sanitize": "5.0.1",
     "rehype-slug": "5.1.0",
     "rehype-stringify": "9.0.3",
-    "remark-copy-linked-files": "https://github.com/joostdecock/remark-copy-linked-files",
+    "remark-copy-linked-files": "git+https://git@github.com/joostdecock/remark-copy-linked-files",
     "remark-gfm": "3.0.1",
     "remark-mdx-frontmatter": "3.0.0"
   },

--- a/sites/org/package.json
+++ b/sites/org/package.json
@@ -61,7 +61,7 @@
     "rehype-sanitize": "5.0.1",
     "rehype-slug": "5.1.0",
     "rehype-stringify": "9.0.3",
-    "remark-copy-linked-files": "https://github.com/joostdecock/remark-copy-linked-files",
+    "remark-copy-linked-files": "git+https://git@github.com/joostdecock/remark-copy-linked-files",
     "remark-gfm": "3.0.1",
     "remark-mdx-frontmatter": "3.0.0",
     "use-persisted-state": "0.3.3",

--- a/sites/org/pages/blog/[dir].mjs
+++ b/sites/org/pages/blog/[dir].mjs
@@ -15,9 +15,9 @@ const namespaces = [...layoutNs, ...postNs, ...pageNs]
  * when path and locale come from static props (as here)
  * or set them manually.
  */
-const BlogPage = ({ locale, slug, page }) => {
+const BlogPage = ({ locale, dir, page }) => {
   // function to load the correct markdown
-  const loader = useCallback(() => import(`orgmarkdown/blog/${slug}/${locale}.md`), [slug, locale])
+  const loader = useCallback(() => import(`orgmarkdown/blog/${dir}/${locale}.md`), [dir, locale])
   // load the markdown
   const { frontmatter, MDX } = useDynamicMdx(loader)
 
@@ -28,14 +28,7 @@ const BlogPage = ({ locale, slug, page }) => {
       title={frontmatter.title}
       layout={(props) => <PostLayout {...props} {...{ slug: page.path.join('/'), frontmatter }} />}
     >
-      <PostArticle
-        {...{
-          slug,
-          frontmatter,
-          MDX,
-          page,
-        }}
-      />
+      <PostArticle {...{ frontmatter, MDX }} />
     </PageWrapper>
   )
 }
@@ -51,19 +44,19 @@ const BlogPage = ({ locale, slug, page }) => {
  * To learn more, see: https://nextjs.org/docs/basic-features/data-fetching
  */
 export async function getStaticProps({ params, locale }) {
-  const { slug } = params
+  const { dir } = params
 
-  // if the slug isn't present in the prebuilt posts, return 404
-  if (!Object.keys(posts).includes(`blog/${slug}`)) return { notFound: true }
+  // if the dir isn't present in the prebuilt posts, return 404
+  if (!Object.keys(posts[locale]).includes(`blog/${dir}`)) return { notFound: true }
 
   return {
     props: {
-      slug,
+      dir,
       locale,
       ...(await serverSideTranslations(locale, namespaces)),
       page: {
         locale,
-        path: ['blog', slug],
+        path: ['blog', dir],
       },
     },
   }

--- a/sites/org/pages/showcase/[dir].mjs
+++ b/sites/org/pages/showcase/[dir].mjs
@@ -15,11 +15,11 @@ const namespaces = [...layoutNs, ...postNs, ...pageNs]
  * when path and locale come from static props (as here)
  * or set them manually.
  */
-const ShowcasePage = ({ locale, slug, page }) => {
+const ShowcasePage = ({ locale, dir, page }) => {
   // function to load the correct markdown
   const loader = useCallback(
-    () => import(`orgmarkdown/showcase/${slug}/${locale}.md`),
-    [slug, locale]
+    () => import(`orgmarkdown/showcase/${dir}/${locale}.md`),
+    [dir, locale]
   )
 
   const { frontmatter, MDX } = useDynamicMdx(loader)
@@ -31,14 +31,7 @@ const ShowcasePage = ({ locale, slug, page }) => {
       title={frontmatter.title}
       layout={(props) => <PostLayout {...props} {...{ slug: page.path.join('/'), frontmatter }} />}
     >
-      <PostArticle
-        {...{
-          slug,
-          frontmatter,
-          MDX,
-          page,
-        }}
-      />
+      <PostArticle {...{ frontmatter, MDX }} />
     </PageWrapper>
   )
 }
@@ -54,19 +47,19 @@ const ShowcasePage = ({ locale, slug, page }) => {
  * To learn more, see: https://nextjs.org/docs/basic-features/data-fetching
  */
 export async function getStaticProps({ params, locale }) {
-  const { slug } = params
+  const { dir } = params
 
-  // if the slug isn't present in the prebuilt posts, return 404
-  if (!Object.keys(posts).includes(`showcase/${slug}`)) return { notFound: true }
+  // if the dir isn't present in the prebuilt posts, return 404
+  if (!Object.keys(posts[locale]).includes(`showcase/${dir}`)) return { notFound: true }
 
   return {
     props: {
-      slug,
+      dir,
       locale,
       ...(await serverSideTranslations(locale, namespaces)),
       page: {
         locale,
-        path: ['showcase', slug],
+        path: ['showcase', dir],
       },
     },
   }

--- a/sites/shared/package.json
+++ b/sites/shared/package.json
@@ -52,7 +52,7 @@
     "remark-mdx-frontmatter": "3.0.0",
     "remark-smartypants": "2.0.0",
     "sharp": "0.32.3",
-    "svg-to-pdfkit": "https://github.com/eriese/SVG-to-PDFKit",
+    "svg-to-pdfkit": "https://git@github.com/eriese/SVG-to-PDFKit",
     "tlds": "1.240.0",
     "to-vfile": "8.0.0",
     "unist-util-visit": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16799,7 +16799,7 @@ remark-cli@^11.0.0:
 
 "remark-copy-linked-files@https://github.com/joostdecock/remark-copy-linked-files":
   version "1.5.0"
-  resolved "git+ssh://git@github.com/joostdecock/remark-copy-linked-files.git#73f8e407d7c7055bc3d56cec32657ed401d43362"
+  resolved "https://github.com/joostdecock/remark-copy-linked-files#73f8e407d7c7055bc3d56cec32657ed401d43362"
   dependencies:
     apr-for-each "^3.0.3"
     apr-intercept "^3.0.4"


### PR DESCRIPTION
These pages used `slug` in two different meanings, so I got rid of that footgun.