### PR TITLE
fix (shared) use node conditional exports instead of sitebuildconfigure

### DIFF
--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -13,7 +13,7 @@ _types:
   design:
     prettier: "npx prettier --write 'src/*.mjs' 'tests/*.mjs'"
     test: &test 'npx mocha tests/*.test.mjs'
-    testci: &testci 'npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js'
+    testci: &testci 'NODE_OPTIONS="--conditions=internal" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js'
   plugin:
     prettier: "npx prettier --write 'src/*.mjs' 'tests/*.mjs'"
     test: *test

--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -28,11 +28,11 @@ core:
 models:
   test: 'npx mocha tests/*.test.mjs'
 new-design:
-  i18n-only: 'SITE="new-design/shared" node ../../sites/shared/prebuild/i18n-only.mjs'
+  i18n-only: 'SITE="new-design/shared" node --conditions=internal ../../sites/shared/prebuild/i18n-only.mjs'
   wbuild: '!'
   lint: "npx eslint 'lib/*.mjs'"
   mbuild: '!'
-  prebuild: 'node ./prebuild.mjs'
+  prebuild: 'node --conditions=internal ./prebuild.mjs'
   test: '!'
   testci: '!'
   vbuild: '!'
@@ -69,10 +69,9 @@ dev:
   clean: &nextClean 'rimraf prebuild/* && rimraf public/locales/*/* && rimraf public/feeds/* && rimraf ../shared/prebuild/data/*'
   dev: &nextDev 'next dev -p 8000'
   develop: *nextDev
-  i18n: "SITE=dev node ../shared/prebuild/i18n-only.mjs"
+  i18n: "SITE=dev node --conditions=internal ../shared/prebuild/i18n-only.mjs"
   lint: &nextLint 'next lint'
-  prebuild: 'cd ../../ && yarn sitebuildconfigure && cd - && node --experimental-json-modules ./prebuild.mjs'
-  predev: 'node --experimental-json-modules ./prebuild.mjs'
+  prebuild: &nextPrebuild 'node --conditions=internal --experimental-json-modules ./prebuild.mjs'
   serve: "pm2 start npm --name 'dev' -- run start"
   start: &nextStart 'yarn prebuild && yarn dev'
 
@@ -85,11 +84,10 @@ lab:
   cibuild: 'yarn build'
   dev: *nextDev
   develop: *nextDev
-  i18n: 'SITE=lab node ../shared/prebuild/i18n-only.mjs'
+  i18n: 'SITE=lab node --conditions=internal ../shared/prebuild/i18n-only.mjs'
   e2e: &e2e 'yarn playwright test'
   lint: *nextLint
-  prebuild: 'cd ../../ && yarn sitebuildconfigure && cd - && node --experimental-json-modules ./prebuild.mjs'
-  predev: 'node --experimental-json-modules ./prebuild.mjs'
+  prebuild: *nextPrebuild
   start: *nextStart
 
 org:
@@ -98,10 +96,9 @@ org:
   clean: *nextClean
   dev: *nextDev
   develop: *nextDev
-  i18n: 'SITE=org node ../shared/prebuild/i18n-only.mjs'
+  i18n: 'SITE=org node --conditions=internal ../shared/prebuild/i18n-only.mjs'
   lint: *nextLint
-  prebuild: 'cd ../../ && yarn sitebuildconfigure && cd - && node --experimental-json-modules ./prebuild.mjs'
-  predev: 'node --experimental-json-modules ./prebuild.mjs'
+  prebuild: *nextPrebuild
   start: *nextStart
 
 sanity:

--- a/config/templates/package.dflt.json
+++ b/config/templates/package.dflt.json
@@ -14,7 +14,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "cibuild_step1": "node build.mjs",

--- a/designs/aaron/package.json
+++ b/designs/aaron/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/aaron/package.json
+++ b/designs/aaron/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/albert/package.json
+++ b/designs/albert/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/albert/package.json
+++ b/designs/albert/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/bee/package.json
+++ b/designs/bee/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/bee/package.json
+++ b/designs/bee/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/bella/package.json
+++ b/designs/bella/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/bella/package.json
+++ b/designs/bella/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/benjamin/package.json
+++ b/designs/benjamin/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/benjamin/package.json
+++ b/designs/benjamin/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/bent/package.json
+++ b/designs/bent/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/bent/package.json
+++ b/designs/bent/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/bob/package.json
+++ b/designs/bob/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/bob/package.json
+++ b/designs/bob/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/breanna/package.json
+++ b/designs/breanna/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/breanna/package.json
+++ b/designs/breanna/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/brian/package.json
+++ b/designs/brian/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/brian/package.json
+++ b/designs/brian/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/bruce/package.json
+++ b/designs/bruce/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/bruce/package.json
+++ b/designs/bruce/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/carlita/package.json
+++ b/designs/carlita/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/carlita/package.json
+++ b/designs/carlita/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/carlton/package.json
+++ b/designs/carlton/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/carlton/package.json
+++ b/designs/carlton/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/cathrin/package.json
+++ b/designs/cathrin/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/cathrin/package.json
+++ b/designs/cathrin/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/charlie/package.json
+++ b/designs/charlie/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/charlie/package.json
+++ b/designs/charlie/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/cornelius/package.json
+++ b/designs/cornelius/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/cornelius/package.json
+++ b/designs/cornelius/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/diana/package.json
+++ b/designs/diana/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/diana/package.json
+++ b/designs/diana/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/examples/package.json
+++ b/designs/examples/package.json
@@ -22,7 +22,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/examples/package.json
+++ b/designs/examples/package.json
@@ -39,7 +39,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/florence/package.json
+++ b/designs/florence/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/florence/package.json
+++ b/designs/florence/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/florent/package.json
+++ b/designs/florent/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/florent/package.json
+++ b/designs/florent/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/hi/package.json
+++ b/designs/hi/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/hi/package.json
+++ b/designs/hi/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/holmes/package.json
+++ b/designs/holmes/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/holmes/package.json
+++ b/designs/holmes/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/hortensia/package.json
+++ b/designs/hortensia/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/hortensia/package.json
+++ b/designs/hortensia/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/huey/package.json
+++ b/designs/huey/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/huey/package.json
+++ b/designs/huey/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/hugo/package.json
+++ b/designs/hugo/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/hugo/package.json
+++ b/designs/hugo/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/jaeger/package.json
+++ b/designs/jaeger/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/jaeger/package.json
+++ b/designs/jaeger/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/legend/package.json
+++ b/designs/legend/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/legend/package.json
+++ b/designs/legend/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/lucy/package.json
+++ b/designs/lucy/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/lucy/package.json
+++ b/designs/lucy/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/lunetius/package.json
+++ b/designs/lunetius/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/lunetius/package.json
+++ b/designs/lunetius/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/magde/package.json
+++ b/designs/magde/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/magde/package.json
+++ b/designs/magde/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/noble/package.json
+++ b/designs/noble/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/noble/package.json
+++ b/designs/noble/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/octoplushy/package.json
+++ b/designs/octoplushy/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/octoplushy/package.json
+++ b/designs/octoplushy/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/paco/package.json
+++ b/designs/paco/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/paco/package.json
+++ b/designs/paco/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/penelope/package.json
+++ b/designs/penelope/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/penelope/package.json
+++ b/designs/penelope/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/plugintest/package.json
+++ b/designs/plugintest/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/plugintest/package.json
+++ b/designs/plugintest/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/rendertest/package.json
+++ b/designs/rendertest/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/rendertest/package.json
+++ b/designs/rendertest/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/sandy/package.json
+++ b/designs/sandy/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/sandy/package.json
+++ b/designs/sandy/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/shin/package.json
+++ b/designs/shin/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/shin/package.json
+++ b/designs/shin/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/simon/package.json
+++ b/designs/simon/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/simon/package.json
+++ b/designs/simon/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/simone/package.json
+++ b/designs/simone/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/simone/package.json
+++ b/designs/simone/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/sven/package.json
+++ b/designs/sven/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/sven/package.json
+++ b/designs/sven/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/tamiko/package.json
+++ b/designs/tamiko/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/tamiko/package.json
+++ b/designs/tamiko/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/teagan/package.json
+++ b/designs/teagan/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/teagan/package.json
+++ b/designs/teagan/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/tiberius/package.json
+++ b/designs/tiberius/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/tiberius/package.json
+++ b/designs/tiberius/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/titan/package.json
+++ b/designs/titan/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/titan/package.json
+++ b/designs/titan/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/trayvon/package.json
+++ b/designs/trayvon/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/trayvon/package.json
+++ b/designs/trayvon/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/tutorial/package.json
+++ b/designs/tutorial/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/tutorial/package.json
+++ b/designs/tutorial/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/unice/package.json
+++ b/designs/unice/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/unice/package.json
+++ b/designs/unice/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/ursula/package.json
+++ b/designs/ursula/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/ursula/package.json
+++ b/designs/ursula/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/wahid/package.json
+++ b/designs/wahid/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/wahid/package.json
+++ b/designs/wahid/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/walburga/package.json
+++ b/designs/walburga/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/walburga/package.json
+++ b/designs/walburga/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/waralee/package.json
+++ b/designs/waralee/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/waralee/package.json
+++ b/designs/waralee/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/designs/yuri/package.json
+++ b/designs/yuri/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/designs/yuri/package.json
+++ b/designs/yuri/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/nx.json
+++ b/nx.json
@@ -15,12 +15,6 @@
     "wbuild": {
       "dependsOn": ["^wbuild", "prewbuild"]
     },
-    "testci": {
-      "dependsOn": ["^build"]
-    },
-    "lint": {
-      "dependsOn": []
-    },
     "e2e": {
       "dependsOn": ["prebuild"]
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -24,7 +24,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/packages/new-design/package.json
+++ b/packages/new-design/package.json
@@ -26,10 +26,10 @@
     "lab": "cd ../../sites/lab && yarn start",
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'lib/*.mjs'",
-    "i18n-only": "SITE=\"new-design/shared\" node ../../sites/shared/prebuild/i18n-only.mjs",
-    "prebuild": "node ./prebuild.mjs",
+    "i18n-only": "SITE=\"new-design/shared\" node --conditions=internal ../../sites/shared/prebuild/i18n-only.mjs",
+    "prebuild": "node --conditions=internal ./prebuild.mjs",
     "wbuild": "node build.mjs",
-    "prewbuild": "node ./prebuild.mjs",
+    "prewbuild": "node --conditions=internal ./prebuild.mjs",
     "wbuild:all": "yarn wbuild",
     "prebuild:all": "yarn prebuild",
     "prewbuild:all": "yarn prewbuild"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -20,7 +20,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/packages/rehype-highlight-lines/package.json
+++ b/packages/rehype-highlight-lines/package.json
@@ -20,7 +20,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/rehype-jargon/package.json
+++ b/packages/rehype-jargon/package.json
@@ -20,7 +20,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/packages/snapseries/package.json
+++ b/packages/snapseries/package.json
@@ -20,7 +20,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-annotations/package.json
+++ b/plugins/plugin-annotations/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-annotations/package.json
+++ b/plugins/plugin-annotations/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-bundle/package.json
+++ b/plugins/plugin-bundle/package.json
@@ -45,7 +45,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-bundle/package.json
+++ b/plugins/plugin-bundle/package.json
@@ -28,7 +28,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-bust/package.json
+++ b/plugins/plugin-bust/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-bust/package.json
+++ b/plugins/plugin-bust/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-flip/package.json
+++ b/plugins/plugin-flip/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-flip/package.json
+++ b/plugins/plugin-flip/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-gore/package.json
+++ b/plugins/plugin-gore/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-gore/package.json
+++ b/plugins/plugin-gore/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-i18n/package.json
+++ b/plugins/plugin-i18n/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-i18n/package.json
+++ b/plugins/plugin-i18n/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-measurements/package.json
+++ b/plugins/plugin-measurements/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-measurements/package.json
+++ b/plugins/plugin-measurements/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-mirror/package.json
+++ b/plugins/plugin-mirror/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-mirror/package.json
+++ b/plugins/plugin-mirror/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-round/package.json
+++ b/plugins/plugin-round/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-round/package.json
+++ b/plugins/plugin-round/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-sprinkle/package.json
+++ b/plugins/plugin-sprinkle/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-sprinkle/package.json
+++ b/plugins/plugin-sprinkle/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-svgattr/package.json
+++ b/plugins/plugin-svgattr/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-svgattr/package.json
+++ b/plugins/plugin-svgattr/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-theme/package.json
+++ b/plugins/plugin-theme/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-theme/package.json
+++ b/plugins/plugin-theme/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-timing/package.json
+++ b/plugins/plugin-timing/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-timing/package.json
+++ b/plugins/plugin-timing/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/plugins/plugin-versionfree-svg/package.json
+++ b/plugins/plugin-versionfree-svg/package.json
@@ -44,7 +44,7 @@
     "tips": "node ../../scripts/help.mjs",
     "lint": "npx eslint 'src/**' 'tests/*.mjs'",
     "prettier": "npx prettier --write 'src/*.mjs' 'tests/*.mjs'",
-    "testci": "npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
+    "testci": "NODE_OPTIONS=\"--conditions=internal\" npx mocha tests/*.test.mjs --reporter ../../tests/reporters/terse.js",
     "wbuild": "node build.mjs",
     "wbuild:all": "yarn wbuild"
   },

--- a/plugins/plugin-versionfree-svg/package.json
+++ b/plugins/plugin-versionfree-svg/package.json
@@ -27,7 +27,10 @@
   "type": "module",
   "module": "dist/index.mjs",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "internal": "./src/index.mjs",
+      "default": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "node build.mjs",

--- a/scripts/reconfigure.mjs
+++ b/scripts/reconfigure.mjs
@@ -274,14 +274,7 @@ function packageJson(pkg) {
   }
   pkgConf.keywords = pkgConf.keywords.concat(keywords(pkg))
   pkgConf.scripts = scripts(pkg)
-  /*
-   * If we building a site simply override the module entry so that we don't have
-   * to build any dependencies, but instead can just load them from source
-   */
-  if (SITEBUILD) {
-    pkgConf.module = 'src/index.mjs'
-    pkgConf.exports = { '.': './src/index.mjs' }
-  }
+
   if (repo.exceptions.skipTests.indexOf(pkg.name) !== -1) {
     pkgConf.scripts.test = `echo "skipping tests for ${pkg.name}"`
     pkgConf.scripts.testci = `echo "skipping tests for ${pkg.name}"`

--- a/sites/dev/package.json
+++ b/sites/dev/package.json
@@ -19,14 +19,13 @@
     "clean": "rimraf prebuild/* && rimraf public/locales/*/* && rimraf public/feeds/* && rimraf ../shared/prebuild/data/*",
     "dev": "next dev -p 8000",
     "develop": "next dev -p 8000",
-    "i18n": "SITE=dev node ../shared/prebuild/i18n-only.mjs",
+    "i18n": "SITE=dev node --conditions=internal ../shared/prebuild/i18n-only.mjs",
     "lint": "next lint",
-    "prebuild": "cd ../../ && yarn sitebuildconfigure && cd - && node --experimental-json-modules ./prebuild.mjs",
-    "predev": "node --experimental-json-modules ./prebuild.mjs",
+    "prebuild": "node --conditions=internal --experimental-json-modules ./prebuild.mjs",
     "serve": "pm2 start npm --name 'dev' -- run start",
     "start": "yarn prebuild && yarn dev",
     "wbuild": "next build",
-    "prewbuild": "cd ../../ && yarn sitebuildconfigure && cd - && node --experimental-json-modules ./prebuild.mjs"
+    "prewbuild": "node --conditions=internal --experimental-json-modules ./prebuild.mjs"
   },
   "peerDependencies": {},
   "dependencies": {

--- a/sites/lab/package.json
+++ b/sites/lab/package.json
@@ -18,14 +18,13 @@
     "cibuild": "yarn build",
     "dev": "next dev -p 8000",
     "develop": "next dev -p 8000",
-    "i18n": "SITE=lab node ../shared/prebuild/i18n-only.mjs",
+    "i18n": "SITE=lab node --conditions=internal ../shared/prebuild/i18n-only.mjs",
     "e2e": "yarn playwright test",
     "lint": "next lint",
-    "prebuild": "cd ../../ && yarn sitebuildconfigure && cd - && node --experimental-json-modules ./prebuild.mjs",
-    "predev": "node --experimental-json-modules ./prebuild.mjs",
+    "prebuild": "node --conditions=internal --experimental-json-modules ./prebuild.mjs",
     "start": "yarn prebuild && yarn dev",
     "wbuild": "next build",
-    "prewbuild": "cd ../../ && yarn sitebuildconfigure && cd - && node --experimental-json-modules ./prebuild.mjs"
+    "prewbuild": "node --conditions=internal --experimental-json-modules ./prebuild.mjs"
   },
   "peerDependencies": {},
   "dependencies": {

--- a/sites/org/package.json
+++ b/sites/org/package.json
@@ -19,13 +19,12 @@
     "clean": "rimraf prebuild/* && rimraf public/locales/*/* && rimraf public/feeds/* && rimraf ../shared/prebuild/data/*",
     "dev": "next dev -p 8000",
     "develop": "next dev -p 8000",
-    "i18n": "SITE=org node ../shared/prebuild/i18n-only.mjs",
+    "i18n": "SITE=org node --conditions=internal ../shared/prebuild/i18n-only.mjs",
     "lint": "next lint",
-    "prebuild": "cd ../../ && yarn sitebuildconfigure && cd - && node --experimental-json-modules ./prebuild.mjs",
-    "predev": "node --experimental-json-modules ./prebuild.mjs",
+    "prebuild": "node --conditions=internal --experimental-json-modules ./prebuild.mjs",
     "start": "yarn prebuild && yarn dev",
     "wbuild": "next build",
-    "prewbuild": "cd ../../ && yarn sitebuildconfigure && cd - && node --experimental-json-modules ./prebuild.mjs"
+    "prewbuild": "node --conditions=internal --experimental-json-modules ./prebuild.mjs"
   },
   "peerDependencies": {},
   "dependencies": {


### PR DESCRIPTION
If my understanding of  https://github.com/freesewing/freesewing/commit/009e1c1cc93c76bc860970a62249e8f55d8334b3 is correct, the goal is to change the entry points  on all our packages to `src/index.mjs`  when (pre)building sites *on vercel* but leave them pointing to `dist.index.mjs` the rest of the time.

Instead of rewriting `package.json`s, we can use [node --conditions](https://nodejs.org/api/cli.html#-c-condition---conditionscondition) to switch to a different, always-defined entry point.

This PR implements the following `exports` property in the `package.json`s
```json
"exports": {
    ".": {
      "internal": "./src/index.mjs",
      "default": "./dist/index.mjs"
    }
  },
  ```

this allows us to not have to run `reconfigure` at all on site builds (it shouldn't be needed. everything should be up to date), and to run site prebuild scripts using `--conditions=internal --experimental-json-modules ./prebuild.mjs`. The same script can now be used for both local and ci builds. We also don't have to build dependencies before testing, so I removed that from nx
 