### PR TITLE
fix (gitpod) update to lts/hydrogen

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,9 +7,9 @@ image: gitpod/workspace-node:latest
 tasks:
   - name: Freesewing Lab
     before: |
-      nvm install lts/gallium
-      nvm use lts/gallium
-    command: yarn kickstart && yarn lab
+      nvm install lts/hydrogen
+      nvm use lts/hydrogen
+    command: yarn tips
 
 github:
   prebuilds:


### PR DESCRIPTION
updates gitpod config to lts/hydrogen
also changes the script it runs on start to `yarn tips` because `yarn kickstart` isn't necessary every time you re-open a workspace