### PR TITLE
fix (gitpod) better install command

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,7 @@ tasks:
     before: |
       nvm install lts/hydrogen
       nvm use lts/hydrogen
+      npm i -g yarn
       yarn kickstart
 
 github:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
     before: |
       nvm install lts/hydrogen
       nvm use lts/hydrogen
-    command: yarn tips
+      yarn kickstart
 
 github:
   prebuilds:


### PR DESCRIPTION
Can't run `yarn tips` without running `yarn install`, so may as well just run `yarn kickstart` on creation