### PR TITLE
fix(bee) Hiding inherited Bella frontSideDart part

### DIFF
--- a/designs/bee/src/cup.mjs
+++ b/designs/bee/src/cup.mjs
@@ -5,6 +5,7 @@ export const cup = {
   name: 'bee.cup',
   from: frontSideDart,
   hide: {
+    from: true,
     inherited: true,
   },
   after: neckTie,


### PR DESCRIPTION
Problem
- bella.frontSideDart was still visible when drafting Bee

Solution
- Add `from: true` to `hide {}`

Simply was missed during port and option update.
