### PR TITLE
feat(backend): Track lastSeen and jwtCalls/keyCalls in middleware

### DIFF
--- a/sites/backend/prisma/schema.prisma
+++ b/sites/backend/prisma/schema.prisma
@@ -42,7 +42,6 @@ model User {
   id            Int       @id @default(autoincrement())
   apikeys       Apikey[]
   bio           String    @default("")
-  calls         Int       @default(0)
   compare       Boolean   @default(true)
   confirmations Confirmation[]
   consent       Int       @default(0)
@@ -55,6 +54,8 @@ model User {
   img           String?
   initial       String
   imperial      Boolean   @default(false)
+  jwtCalls      Int       @default(0)
+  keyCalls      Int       @default(0)
   language      String    @default("en")
   lastSeen      DateTime?
   lusername     String    @unique

--- a/sites/backend/prisma/schema.prisma
+++ b/sites/backend/prisma/schema.prisma
@@ -42,6 +42,7 @@ model User {
   id            Int       @id @default(autoincrement())
   apikeys       Apikey[]
   bio           String    @default("")
+  calls         Int       @default(0)
   compare       Boolean   @default(true)
   confirmations Confirmation[]
   consent       Int       @default(0)
@@ -55,7 +56,7 @@ model User {
   initial       String
   imperial      Boolean   @default(false)
   language      String    @default("en")
-  lastSignIn    DateTime?
+  lastSeen      DateTime?
   lusername     String    @unique
   mfaSecret     String    @default("")
   mfaEnabled    Boolean   @default(false)

--- a/sites/backend/src/middleware.mjs
+++ b/sites/backend/src/middleware.mjs
@@ -10,9 +10,9 @@ import { UserModel } from './models/user.mjs'
  * this field. It's a bit of a perf hit to write to the database on ever API call
  * but it's worth it to actually know which accounts are used and which are not.
  */
-async function updateLastSeen(uid, tools) {
+async function updateLastSeen(uid, tools, type) {
   const User = new UserModel(tools)
-  await User.seen(uid)
+  await User.seen(uid, type)
 }
 
 function loadExpressMiddleware(app) {
@@ -27,7 +27,7 @@ function loadPassportMiddleware(passport, tools) {
       /*
        * Update lastSeen field
        */
-      if (Apikey.verified) await updateLastSeen(Apikey.record.userId, tools)
+      if (Apikey.verified) await updateLastSeen(Apikey.record.userId, tools, 'key')
 
       return Apikey.verified
         ? done(null, { ...Apikey.record, apikey: true, uid: Apikey.record.userId })
@@ -44,7 +44,7 @@ function loadPassportMiddleware(passport, tools) {
         /*
          * Update lastSeen field
          */
-        await updateLastSeen(jwt_payload._id, tools)
+        await updateLastSeen(jwt_payload._id, tools, 'jwt')
 
         return done(null, {
           ...jwt_payload,

--- a/sites/backend/src/middleware.mjs
+++ b/sites/backend/src/middleware.mjs
@@ -2,6 +2,18 @@ import cors from 'cors'
 import http from 'passport-http'
 import jwt from 'passport-jwt'
 import { ApikeyModel } from './models/apikey.mjs'
+import { UserModel } from './models/user.mjs'
+
+/*
+ * In v2 we ended up with a bug where we did not properly track the last login
+ * So in v3 we switch to `lastSeen` and every authenticated API call we update
+ * this field. It's a bit of a perf hit to write to the database on ever API call
+ * but it's worth it to actually know which accounts are used and which are not.
+ */
+async function updateLastSeen(uid, tools) {
+  const User = new UserModel(tools)
+  await User.seen(uid)
+}
 
 function loadExpressMiddleware(app) {
   app.use(cors())
@@ -12,6 +24,11 @@ function loadPassportMiddleware(passport, tools) {
     new http.BasicStrategy(async (key, secret, done) => {
       const Apikey = new ApikeyModel(tools)
       await Apikey.verify(key, secret)
+      /*
+       * Update lastSeen field
+       */
+      if (Apikey.verified) await updateLastSeen(Apikey.record.userId, tools)
+
       return Apikey.verified
         ? done(null, { ...Apikey.record, apikey: true, uid: Apikey.record.userId })
         : done(false)
@@ -23,7 +40,12 @@ function loadPassportMiddleware(passport, tools) {
         jwtFromRequest: jwt.ExtractJwt.fromAuthHeaderAsBearerToken(),
         ...tools.config.jwt,
       },
-      (jwt_payload, done) => {
+      async (jwt_payload, done) => {
+        /*
+         * Update lastSeen field
+         */
+        await updateLastSeen(jwt_payload._id, tools)
+
         return done(null, {
           ...jwt_payload,
           uid: jwt_payload._id,

--- a/sites/backend/src/models/user.mjs
+++ b/sites/backend/src/models/user.mjs
@@ -1089,7 +1089,6 @@ UserModel.prototype.asAccount = function () {
   return {
     id: this.record.id,
     bio: this.clear.bio,
-    calls: this.record.calls,
     compare: this.record.compare,
     consent: this.record.consent,
     control: this.record.control,
@@ -1100,6 +1099,8 @@ UserModel.prototype.asAccount = function () {
     img: this.clear.img,
     imperial: this.record.imperial,
     initial: this.clear.initial,
+    jwtCalls: this.record.jwtCalls,
+    keyCalls: this.record.keyCalls,
     language: this.record.language,
     lastSeen: this.record.lastSeen,
     mfaEnabled: this.record.mfaEnabled,

--- a/sites/backend/src/models/user.mjs
+++ b/sites/backend/src/models/user.mjs
@@ -461,10 +461,7 @@ UserModel.prototype.passwordSignIn = async function (req) {
    * have their password and we know it's good, let's rehash it the v3 way
    * if this happens to be a v2 user.
    */
-  if (updatedPasswordField) {
-    update.password = updatedPasswordField
-    await this.update(update)
-  }
+  if (updatedPasswordField) await this.update({ password: updatedPasswordField })
 
   /*
    * Final check for account status and other things before returning

--- a/sites/backend/src/models/user.mjs
+++ b/sites/backend/src/models/user.mjs
@@ -1089,6 +1089,7 @@ UserModel.prototype.asAccount = function () {
   return {
     id: this.record.id,
     bio: this.clear.bio,
+    calls: this.record.calls,
     compare: this.record.compare,
     consent: this.record.consent,
     control: this.record.control,
@@ -1215,17 +1216,21 @@ UserModel.prototype.isLusernameAvailable = async function (lusername) {
  * This is called from middleware with the user ID passed in.
  *
  * @param {id} string - The user ID
- * @returns {isTest} boolean - True if it's a test. False if not.
+ * @param {type} string - The authentication type (one of 'jwt' or 'key')
+ * @returns {success} boolean - True if it worked, false if not
  */
-UserModel.prototype.seen = async function (id) {
+UserModel.prototype.seen = async function (id, type) {
+  /*
+   * Construct data object for update operation
+   */
+  const data = { lastSeen: new Date() }
+  data[`${type}Calls`] = { increment: 1 }
+
+  /*
+   * Now update the dabatase record
+   */
   try {
-    await this.prisma.user.update({
-      where: { id },
-      data: {
-        lastSeen: new Date(),
-        calls: { increment: 1 },
-      },
-    })
+    await this.prisma.user.update({ where: { id }, data })
   } catch (err) {
     /*
      * An error means it's not good. Return false


### PR DESCRIPTION
After realizing (late) that there was a bug in how we track user activity in the v2 backend (see #4698) I said I would:

- Add a `lastSeen` field to the database to be less ambiguous
- Ensure this `lastSeen` field is updated each time a user checks in

This PR implements that by extending the Express middleware to:

- Update the `lastSeen` record of the authenticated user (both when using JWT and API Keys authentication)
- Increment the `jwtCals` or `keyCalls` field based on whether JWT or KEY authentication is used

I've also dropped the `lastSignIn` record in favor of `lastSeen` as it is less ambiguous.

The different *calls* fields (`jwtCalls` and `keyCalls`) will keep a tally of the amount of backend API calls made by a user.