### PR TITLE
Fix import errors for ModalThemePicker and ModalLocalePicker

### DIFF
--- a/packages/new-design/shared/lab/components/header.mjs
+++ b/packages/new-design/shared/lab/components/header.mjs
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { ThemePicker } from 'shared/components/theme-picker.js'
-import { LocalePicker } from 'shared/components/locale-picker.js'
+import { ModalThemePicker } from 'shared/components/modal/theme-picker.mjs'
+import { ModalLocalePicker } from 'shared/components/modal/locale-picker.mjs'
 import { CloseIcon, MenuIcon, HelpIcon, DocsIcon } from 'shared/components/icons/close.js'
 import { Ribbon } from 'shared/components/ribbon.js'
 import { WordMark } from 'shared/components/wordmark.js'
@@ -71,8 +71,8 @@ export const Header = ({ app }) => {
             </div>
           </div>
           <div className="hidden md:flex flex-row items-center gap-2">
-            <ThemePicker app={app} />
-            <LocalePicker app={app} />
+            <ModalThemePicker app={app} />
+            <ModalLocalePicker app={app} />
           </div>
         </div>
       </div>

--- a/packages/new-design/shared/lab/components/layouts/lab.mjs
+++ b/packages/new-design/shared/lab/components/layouts/lab.mjs
@@ -1,11 +1,11 @@
-import { ThemePicker } from 'shared/components/theme-picker.mjs'
-import { LocalePicker } from 'shared/components/locale-picker.mjs'
+import { ModalThemePicker } from 'shared/components/modal/theme-picker.mjs'
+import { ModalLocalePicker } from 'shared/components/modal/locale-picker.mjs'
 
 export const BeforeNav = ({ app }) => (
   <>
     <div className="md:hidden flex flex-row flex-wrap sm:flex-nowrap gap-2 mb-2">
-      <ThemePicker app={app} />
-      <LocalePicker app={app} />
+      <ModalThemePicker app={app} />
+      <ModalLocalePicker app={app} />
     </div>
     <div className="md:hidden flex flex-row flex-wrap sm:flex-nowrap gap-2 mb-2"></div>
   </>

--- a/sites/lab/components/layouts/lab.mjs
+++ b/sites/lab/components/layouts/lab.mjs
@@ -1,13 +1,13 @@
-import { ThemePicker } from 'shared/components/theme-picker/index.mjs'
-import { LocalePicker } from 'shared/components/locale-picker/index.mjs'
+import { ModalThemePicker } from 'shared/components/modal/theme-picker.mjs'
+import { ModalLocalePicker } from 'shared/components/modal/locale-picker.mjs'
 
 export const ns = ['']
 
 export const BeforeNav = ({ app }) => (
   <>
     <div className="md:hidden flex flex-row flex-wrap sm:flex-nowrap gap-2 mb-2">
-      <ThemePicker app={app} />
-      <LocalePicker app={app} />
+      <ModalThemePicker app={app} />
+      <ModalLocalePicker app={app} />
     </div>
     <div className="md:hidden flex flex-row flex-wrap sm:flex-nowrap gap-2 mb-2"></div>
   </>


### PR DESCRIPTION
On the current develop branch, trying to run the lab results in the following error:
```
- error ./components/layouts/lab.mjs:1:0
Module not found: Can't resolve 'shared/components/theme-picker/index.mjs'
> 1 | import { ThemePicker } from 'shared/components/theme-picker/index.mjs'
  2 | import { LocalePicker } from 'shared/components/locale-picker/index.mjs'
```

Because those two modules have been moved and renamed. So here's a fix that points those imports to the right place, in every file I found that referenced them