### PR TITLE
fix(core): fixed buggy bounds computation in cutting and printing layout when parts are rotated & fix(dev): fixed invalid PageLink imports

### DIFF
--- a/packages/core/src/utils.mjs
+++ b/packages/core/src/utils.mjs
@@ -803,7 +803,7 @@ function matrixTransform(transformationType, matrix, values) {
       const centerY = values[2]
 
       // if there's a rotation center, we need to move the origin to that center
-      if (centerX) {
+      if (centerX !== undefined) {
         matrix = matrixTransform('translate', matrix, [centerX, centerY])
       }
 
@@ -820,7 +820,7 @@ function matrixTransform(transformationType, matrix, values) {
       ]
 
       // move the origin back to origin
-      if (centerX) {
+      if (centerX !== undefined) {
         matrix = matrixTransform('translate', matrix, [-centerX, -centerY])
       }
       break
@@ -875,35 +875,7 @@ export function applyTransformToPoint(transform, point) {
 
   // The starting matrix
   let matrix = [1, 0, 0, 1, 0, 0]
-
-  // Update matrix for transform
-  switch (name) {
-    case 'matrix':
-      matrix = values
-      break
-    case 'translate':
-      matrix[4] = values[0]
-      matrix[5] = values[1]
-      break
-    case 'scale':
-      matrix[0] = values[0]
-      matrix[3] = values[1]
-      break
-    case 'rotate': {
-      const angle = (values[0] * Math.PI) / 180
-      const cos = Math.cos(angle)
-      const sin = Math.sin(angle)
-      console.log('in rotate', { angle })
-      matrix = [cos, sin, -sin, cos, 0, 0]
-      break
-    }
-    case 'skewX':
-      matrix[2] = Math.tan((values[0] * Math.PI) / 180)
-      break
-    case 'skewY':
-      matrix[1] = Math.tan((values[0] * Math.PI) / 180)
-      break
-  }
+  matrix = matrixTransform(name, matrix, values)
 
   // Apply the matrix transform to the coordinates
   const newX = point.x * matrix[0] + point.y * matrix[2] + matrix[4]

--- a/packages/new-design/lib/config.mjs
+++ b/packages/new-design/lib/config.mjs
@@ -112,7 +112,7 @@ playwright-report
       'shared/components/lightbox.mjs',
       'shared/components/loader.mjs',
       'shared/components/modal.mjs',
-      'shared/components/page-link.mjs',
+      'shared/components/link.mjs',
       'shared/components/picker.mjs',
       'shared/components/popout.mjs',
       'shared/components/raw-span.mjs',

--- a/sites/dev/pages/404.mjs
+++ b/sites/dev/pages/404.mjs
@@ -5,7 +5,7 @@ import Head from 'next/head'
 import { PageWrapper, ns as pageNs } from 'shared/components/wrappers/page.mjs'
 import { Robot } from 'shared/components/robot/index.mjs'
 import { Popout } from 'shared/components/popout/index.mjs'
-import { PageLink } from 'shared/components/page-link.mjs'
+import { PageLink } from 'shared/components/link.mjs'
 import { BaseLayout, BaseLayoutLeft, BaseLayoutWide } from 'shared/components/base-layout.mjs'
 import { NavLinks, MainSections } from 'shared/components/navigation/sitenav.mjs'
 

--- a/sites/dev/pages/index.mjs
+++ b/sites/dev/pages/index.mjs
@@ -3,7 +3,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 // Components
 import Head from 'next/head'
 import { PageWrapper } from 'shared/components/wrappers/page.mjs'
-import { PageLink } from 'shared/components/page-link.mjs'
+import { PageLink } from 'shared/components/link.mjs'
 import { Highlight } from 'shared/components/mdx/highlight.mjs'
 import { FreeSewingIcon } from 'shared/components/icons.mjs'
 import Link from 'next/link'

--- a/sites/dev/pages/search.mjs
+++ b/sites/dev/pages/search.mjs
@@ -4,7 +4,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { PageWrapper, ns as pageNs } from 'shared/components/wrappers/page.mjs'
 import { Search } from 'site/components/search.mjs'
 import { Popout } from 'shared/components/popout/index.mjs'
-import { PageLink } from 'shared/components/page-link.mjs'
+import { PageLink } from 'shared/components/link.mjs'
 import { NavLinks, Breadcrumbs, MainSections } from 'shared/components/navigation/sitenav.mjs'
 import {
   BaseLayout,


### PR DESCRIPTION
A bug in the matrixTransform utils led to rotations being applied around (0, 0) if the X coordinate of the center was 0, leading to the cutting and printing layouts incorrectly calculating the outer bounds of the pattern.
The transformation parsing was also implemented a second time in applyTransformToPoint, in which the rotation center wasn't considered at all, so I replaced that second redundant implementation with a call to the first one.

I also stumbled upon the dev site not being buildable because of some import issues so I put that fix in there too.