### PR TITLE
chore(markdown): Attempt to side-step crowdin issues

### DIFF
--- a/markdown/org/docs/site/apikeys/level/en.md
+++ b/markdown/org/docs/site/apikeys/level/en.md
@@ -12,7 +12,7 @@ The permission level is a number from `0` to `4` with the following significance
 - `3` : Write access to your own patterns and measurements sets
 - `4` : Write access to all your account data
 
-<Link>
+<Tip>
 
 For more details, refer to [the backend documentation on FreeSewing.dev](https://freesewing.dev/reference/backend/rbac#permission-levels)
-</Link>
+</Tip>


### PR DESCRIPTION
Seemingly using `Link` breaks things, so let's use `Tip` instead.
