### PR TITLE
fix(CONTRIBUTING.md)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@ Use your best judgment, and feel free to propose changes to this document in a p
 ## Code of Conduct
 
 When you engage with us, or when you engage with others, 
-please remember [the FreeSewing community standards](https://freesewing.org/docs/about/community-standards/).
+please remember [the FreeSewing community standards](https://freesewing.org/docs/various/community-standards/).
 
-As a contributor, you are also expected to uphold [the FreeSewing Code of Conduct](https://freesewing.dev/contributors/code-of-conduct/). 
+As a contributor, you are also expected to uphold [the FreeSewing Code of Conduct](https://freesewing.dev/guides/code-of-conduct). 
 
 <Tip>
 


### PR DESCRIPTION
Fixes #5205 

Replaces dead links in the [CONTRIBUTING.md](https://github.com/freesewing/freesewing/blob/develop/CONTRIBUTING.md#:~:text=When%20you%20engage,of%20Conduct.) with supposed proper replacements. 

Would need cross-verification of the replacements.