### PR TITLE
Shelly 3 - Code cleanup

### DIFF
--- a/designs/shelly/i18n/en.json
+++ b/designs/shelly/i18n/en.json
@@ -8,7 +8,9 @@
     "neckband": "Neckband",
     "raglanSleeve": "Sleeve"
   },
-  "s": {},
+  "s": {
+	"foldLine": "Fold line"
+  },
   "o": {
     "hemWidth": {
       "t": "Hem width",

--- a/designs/shelly/src/back.mjs
+++ b/designs/shelly/src/back.mjs
@@ -9,8 +9,6 @@ function draftBack({
   options,
   part,
   store,
-  paperless,
-  complete,
   sa,
   macro,
   snippets,
@@ -51,88 +49,84 @@ function draftBack({
     .curve(points.armpitScoopCp1, points.armpitScoopCp2, points.armpitScoopEnd)
     .line(points.neckShoulderCorner)
     .curve(points.neckCP1, points.neckCP2, points.cfNeck)
-    .hide(true)
+    .hide()
 
-  paths.foldBase = new Path().move(points.cfNeck).line(points.cfHem).hide(true)
+  paths.foldBase = new Path().move(points.cfNeck).line(points.cfHem).hide()
 
-  paths.hemBase = new Path().move(points.cfHem).line(points.sideHem).hide(true)
+  paths.hemBase = new Path().move(points.cfHem).line(points.sideHem).hide()
 
-  paths.seam = paths.saBase.join(paths.foldBase).join(paths.hemBase).close().attr('class', 'fabric')
+  paths.seam = paths.saBase.join(paths.foldBase).join(paths.hemBase).close().addClass('fabric')
 
-  if (paperless) {
-    macro('vd', {
-      id: 'hCenterSeam',
-      from: points.cfNeck,
-      to: points.cfHem,
-      x: -(15 + sa),
-    })
-    macro('vd', {
-      id: 'hNeck',
-      from: points.neckShoulderCorner,
-      to: points.cfNeck,
-      x: -(15 + sa),
-      noStartMarker: true,
-      noEndMarker: true,
-    })
-    macro('vd', {
-      id: 'hTotal',
-      from: points.neckShoulderCorner,
-      to: points.cfHem,
-      x: -(30 + sa),
-    })
-    macro('vd', {
-      id: 'hRaglanSeam',
-      from: points.armpitCornerScooped,
-      to: points.neckShoulderCorner,
-      x: points.armpitCornerScooped.x + (15 + sa),
-    })
-    macro('hd', {
-      id: 'wRaglanSeamStraightPortion',
-      from: points.neckShoulderCorner,
-      to: points.armpitScoopEnd,
-      y: 0 - (sa + 0),
-    })
-    macro('hd', {
-      id: 'wRaglanSeam',
-      from: points.neckShoulderCorner,
-      to: points.armpitCornerScooped,
-      y: 0 - (sa + 15),
-    })
-    macro('hd', {
-      id: 'wNeck',
-      from: points.cfNeck,
-      to: points.neckShoulderCorner,
-      y: 0 - (sa + 15),
-      noStartMarker: true,
-      noEndMarker: true,
-    })
-    macro('hd', {
-      id: 'wCenterToArmpit',
-      from: points.cfNeck,
-      to: points.armpitCornerScooped,
-      y: 0 - (sa + 30),
-    })
-  }
+  macro('vd', {
+    id: 'hCenterSeam',
+    from: points.cfNeck,
+    to: points.cfHem,
+    x: -(15 + sa),
+  })
+  macro('vd', {
+    id: 'hNeck',
+    from: points.neckShoulderCorner,
+    to: points.cfNeck,
+    x: -(15 + sa),
+    noStartMarker: true,
+    noEndMarker: true,
+  })
+  macro('vd', {
+    id: 'hTotal',
+    from: points.neckShoulderCorner,
+    to: points.cfHem,
+    x: -(30 + sa),
+  })
+  macro('vd', {
+    id: 'hRaglanSeam',
+    from: points.armpitCornerScooped,
+    to: points.neckShoulderCorner,
+    x: points.armpitCornerScooped.x + (15 + sa),
+  })
+  macro('hd', {
+    id: 'wRaglanSeamStraightPortion',
+    from: points.neckShoulderCorner,
+    to: points.armpitScoopEnd,
+    y: 0 - (sa + 0),
+  })
+  macro('hd', {
+    id: 'wRaglanSeam',
+    from: points.neckShoulderCorner,
+    to: points.armpitCornerScooped,
+    y: 0 - (sa + 15),
+  })
+  macro('hd', {
+    id: 'wNeck',
+    from: points.cfNeck,
+    to: points.neckShoulderCorner,
+    y: 0 - (sa + 15),
+    noStartMarker: true,
+    noEndMarker: true,
+  })
+  macro('hd', {
+    id: 'wCenterToArmpit',
+    from: points.cfNeck,
+    to: points.armpitCornerScooped,
+    y: 0 - (sa + 30),
+  })
 
-  store.cutlist.addCut({ cut: 1 })
+  store.cutlist.addCut({ cut: 1, from: 'fabric' })
 
-  if (complete) {
-    snippets.armpitScoopEnd = new Snippet('bnotch', points.armpitScoopEnd)
+  snippets.armpitScoopEnd = new Snippet('bnotch', points.armpitScoopEnd)
 
-    points.title = new Point(
-      points.armpitCorner.x / 2,
-      (points.cfHem.y + points.armpitCornerScooped.y / 2) / 2
-    )
-    macro('title', { at: points.title, nr: 2, title: 'back' })
+  points.title = new Point(
+    points.armpitCorner.x / 2,
+    (points.cfHem.y + points.armpitCornerScooped.y / 2) / 2
+  )
+  macro('title', { at: points.title, nr: 2, title: 'back' })
 
-    if (sa) {
-      paths.sa = new Path()
-        .move(points.cfHem)
-        .join(paths.hemBase.offset(sa * options.hemWidth))
-        .join(paths.saBase.offset(sa))
-        .line(points.cfNeck)
-        .attr('class', 'fabric sa')
-    }
+  if (sa) {
+    paths.sa = new Path()
+      .move(points.cfHem)
+      .join(paths.hemBase.offset(sa * options.hemWidth))
+      .join(paths.saBase.offset(sa))
+      .line(points.cfNeck)
+      .addClass('fabric sa')
   }
 
   const neckPath = new Path()
@@ -145,8 +139,6 @@ function draftBack({
 
 export const back = {
   name: 'shelly.back',
-  plugins: [],
   draft: draftBack,
   from: base,
-  measurements: ['neck', 'chest', 'hips', 'waistToHips', 'hpsToWaistBack'],
 }

--- a/designs/shelly/src/base.mjs
+++ b/designs/shelly/src/base.mjs
@@ -39,7 +39,13 @@ function draftBase({
   points.raglanCenter = new Point(0, 0)
   points.neckCenter = points.raglanCenter.shift(270, options.neckBalance * neckRadius)
 
-  points.armpitCorner = new Point(chest / 4, armpitYPosition)
+  points.armpitCorner = new Point(chest / 4, armpitYPosition).translate(
+    0,
+    Math.max(
+      0,
+      (measurements.biceps * options.armholeTweakFactor * options.sleeveEase) / (2 * Math.PI)
+    )
+  )
 
   points.neckShoulderCorner = utils.beamIntersectsCircle(
     points.neckCenter,
@@ -182,7 +188,15 @@ export const base = {
   plugins: [bustPlugin],
   draft: draftBase,
   hide: { self: true },
-  measurements: ['neck', 'chest', 'hips', 'waistToHips', 'hpsToWaistBack', 'waistToArmpit'],
+  measurements: [
+    'biceps',
+    'neck',
+    'chest',
+    'hips',
+    'waistToHips',
+    'hpsToWaistBack',
+    'waistToArmpit',
+  ],
   options: {
     // How much ease to give for the neck, as a percentage.
     neckEase: { pct: 50, min: -30, max: 150, menu: 'fit' },
@@ -202,6 +216,10 @@ export const base = {
     hemWidth: { pct: 200, min: 0, max: 800, menu: 'construction' },
     // How the body curves along the side from the armpit to the side of the hips, as a % of the length of the side seam. Negative values form a concave body and positive values form a convex body.
     sideShape: { pct: 0, min: -20, max: 20, menu: 'advanced' },
+    // How much larger to make the armhole as a proportion of the biceps measurement.
+    armholeTweakFactor: 1.1,
+    // How much ease to put vertically around the armhole and the shoulder joint. Transitions gradually towards wristEase as one goes down the sleeve.
+    sleeveEase: { pct: 0, min: -30, max: 50, menu: 'fit' },
   },
   optionalMeasurements: ['highBust'],
 }

--- a/designs/shelly/src/base.mjs
+++ b/designs/shelly/src/base.mjs
@@ -10,8 +10,6 @@ function draftBase({
   options,
   part,
   store,
-  paperless,
-  complete,
   sa,
   macro,
   snippets,
@@ -117,40 +115,38 @@ function draftBase({
     .curve(points.armpitScoopCp1, points.armpitScoopCp2, points.armpitScoopEnd)
     .line(points.neckShoulderCorner)
     .curve(points.neckCP1, points.neckCP2, points.cfNeck)
-    .hide(true)
+    .hide()
 
-  paths.foldBase = new Path().move(points.cfNeck).line(points.cfHem).hide(true)
+  paths.foldBase = new Path().move(points.cfNeck).line(points.cfHem).hide()
 
-  paths.hemBase = new Path().move(points.cfHem).line(points.sideHem).hide(true)
+  paths.hemBase = new Path().move(points.cfHem).line(points.sideHem).hide()
 
-  paths.seam = paths.saBase.join(paths.foldBase).join(paths.hemBase).close().attr('class', 'fabric')
+  paths.seam = paths.saBase.join(paths.foldBase).join(paths.hemBase).close().addClass('fabric')
 
-  if (paperless) {
-    macro('hd', {
-      id: 'wHem',
-      from: points.cfHem,
-      to: points.sideHem,
-      y: points.sideHem.y + (sa + 15),
-    })
-    macro('vd', {
-      id: 'hSide',
-      from: points.sideHem,
-      to: points.armpitCornerScooped,
-      x: Math.max(points.sideHem.x, points.armpitCornerScooped.x) + (15 + sa),
-    })
-    macro('vd', {
-      id: 'hArmpitScoop',
-      from: points.armpitCornerScooped,
-      to: points.armpitScoopEnd,
-      x: points.armpitCornerScooped.x + (30 + sa),
-    })
-    macro('hd', {
-      id: 'wArmpitScoop',
-      from: points.armpitScoopEnd,
-      to: points.armpitCornerScooped,
-      y: 0 - (sa + 0),
-    })
-  }
+  macro('hd', {
+    id: 'wHem',
+    from: points.cfHem,
+    to: points.sideHem,
+    y: points.sideHem.y + (sa + 15),
+  })
+  macro('vd', {
+    id: 'hSide',
+    from: points.sideHem,
+    to: points.armpitCornerScooped,
+    x: Math.max(points.sideHem.x, points.armpitCornerScooped.x) + (15 + sa),
+  })
+  macro('vd', {
+    id: 'hArmpitScoop',
+    from: points.armpitCornerScooped,
+    to: points.armpitScoopEnd,
+    x: points.armpitCornerScooped.x + (30 + sa),
+  })
+  macro('hd', {
+    id: 'wArmpitScoop',
+    from: points.armpitScoopEnd,
+    to: points.armpitCornerScooped,
+    y: 0 - (sa + 0),
+  })
 
   points.cutonfoldFrom = points.cfNeck
   points.cutonfoldTo = points.cfHem
@@ -160,24 +156,22 @@ function draftBase({
     grainline: true,
   })
 
-  if (complete) {
-    points.title = new Point(
-      points.armpitCorner.x / 2,
-      (points.cfHem.y + points.armpitCornerScooped.y / 2) / 2
-    )
-    macro('title', { at: points.title, nr: 5, title: 'base' })
+  points.title = new Point(
+    points.armpitCorner.x / 2,
+    (points.cfHem.y + points.armpitCornerScooped.y / 2) / 2
+  )
+  macro('title', { at: points.title, nr: 5, title: 'base' })
 
-    points.logo = points.title.shift(-90, 70 * scale)
-    snippets.logo = new Snippet('logo', points.logo)
+  points.logo = points.title.shift(-90, 70 * scale)
+  snippets.logo = new Snippet('logo', points.logo)
 
-    if (sa) {
-      paths.sa = new Path()
-        .move(points.cfHem)
-        .join(paths.hemBase.offset(sa * options.hemWidth))
-        .join(paths.saBase.offset(sa))
-        .line(points.cfNeck)
-        .attr('class', 'fabric sa')
-    }
+  if (sa) {
+    paths.sa = new Path()
+      .move(points.cfHem)
+      .join(paths.hemBase.offset(sa * options.hemWidth))
+      .join(paths.saBase.offset(sa))
+      .line(points.cfNeck)
+      .addClass('fabric sa')
   }
 
   return part

--- a/designs/shelly/src/front.mjs
+++ b/designs/shelly/src/front.mjs
@@ -1,19 +1,6 @@
 import { base } from './base.mjs'
 
-function draftFront({
-  utils,
-  Path,
-  Point,
-  points,
-  part,
-  store,
-  paperless,
-  complete,
-  sa,
-  macro,
-  snippets,
-  Snippet,
-}) {
+function draftFront({ utils, Path, Point, points, part, store, sa, macro, snippets, Snippet }) {
   const raglanAngle = store.get('raglanAngle')
   const neckRadius = store.get('neckRadius')
 
@@ -42,72 +29,68 @@ function draftFront({
   const frontNecklineToRaglanAngle = raglanAngle - (necklineAngleAtRaglan + 180)
   store.set('frontNecklineToRaglanAngle', frontNecklineToRaglanAngle)
 
-  if (paperless) {
-    macro('vd', {
-      id: 'hCenterSeam',
-      from: points.cfNeck,
-      to: points.cfHem,
-      x: -(15 + sa),
-    })
-    macro('vd', {
-      id: 'hNeck',
-      from: points.neckShoulderCorner,
-      to: points.cfNeck,
-      x: -(15 + sa),
-      noStartMarker: true,
-      noEndMarker: true,
-    })
-    macro('vd', {
-      id: 'hTotal',
-      from: points.neckShoulderCorner,
-      to: points.cfHem,
-      x: -(30 + sa),
-    })
-    macro('vd', {
-      id: 'hRaglanSeam',
-      from: points.armpitCornerScooped,
-      to: points.neckShoulderCorner,
-      x: points.armpitCornerScooped.x + (15 + sa),
-    })
-    macro('hd', {
-      id: 'wRaglanSeamStraightPortion',
-      from: points.neckShoulderCorner,
-      to: points.armpitScoopEnd,
-      y: 0 - (sa + 0),
-    })
-    macro('hd', {
-      id: 'hArmpitScoop',
-      from: points.neckShoulderCorner,
-      to: points.armpitCornerScooped,
-      y: 0 - (sa + 15),
-    })
-    macro('hd', {
-      id: 'wRaglanSeam',
-      from: points.cfNeck,
-      to: points.neckShoulderCorner,
-      y: 0 - (sa + 15),
-      noStartMarker: true,
-      noEndMarker: true,
-    })
-    macro('hd', {
-      id: 'wCenterToArmpit',
-      from: points.cfNeck,
-      to: points.armpitCornerScooped,
-      y: 0 - (sa + 30),
-    })
-  }
+  macro('vd', {
+    id: 'hCenterSeam',
+    from: points.cfNeck,
+    to: points.cfHem,
+    x: -(15 + sa),
+  })
+  macro('vd', {
+    id: 'hNeck',
+    from: points.neckShoulderCorner,
+    to: points.cfNeck,
+    x: -(15 + sa),
+    noStartMarker: true,
+    noEndMarker: true,
+  })
+  macro('vd', {
+    id: 'hTotal',
+    from: points.neckShoulderCorner,
+    to: points.cfHem,
+    x: -(30 + sa),
+  })
+  macro('vd', {
+    id: 'hRaglanSeam',
+    from: points.armpitCornerScooped,
+    to: points.neckShoulderCorner,
+    x: points.armpitCornerScooped.x + (15 + sa),
+  })
+  macro('hd', {
+    id: 'wRaglanSeamStraightPortion',
+    from: points.neckShoulderCorner,
+    to: points.armpitScoopEnd,
+    y: 0 - (sa + 0),
+  })
+  macro('hd', {
+    id: 'hArmpitScoop',
+    from: points.neckShoulderCorner,
+    to: points.armpitCornerScooped,
+    y: 0 - (sa + 15),
+  })
+  macro('hd', {
+    id: 'wRaglanSeam',
+    from: points.cfNeck,
+    to: points.neckShoulderCorner,
+    y: 0 - (sa + 15),
+    noStartMarker: true,
+    noEndMarker: true,
+  })
+  macro('hd', {
+    id: 'wCenterToArmpit',
+    from: points.cfNeck,
+    to: points.armpitCornerScooped,
+    y: 0 - (sa + 30),
+  })
 
-  store.cutlist.addCut({ cut: 1 })
+  store.cutlist.addCut({ cut: 1, from: 'fabric' })
 
-  if (complete) {
-    snippets.armpitScoopEnd = new Snippet('notch', points.armpitScoopEnd)
+  snippets.armpitScoopEnd = new Snippet('notch', points.armpitScoopEnd)
 
-    points.title = new Point(
-      points.armpitCorner.x / 2,
-      (points.cfHem.y + points.armpitCornerScooped.y / 2) / 2
-    )
-    macro('title', { at: points.title, nr: 1, title: 'front' })
-  }
+  points.title = new Point(
+    points.armpitCorner.x / 2,
+    (points.cfHem.y + points.armpitCornerScooped.y / 2) / 2
+  )
+  macro('title', { at: points.title, nr: 1, title: 'front' })
 
   const neckPath = new Path()
     .move(points.neckShoulderCorner)
@@ -119,8 +102,6 @@ function draftFront({
 
 export const front = {
   name: 'shelly.front',
-  plugins: [],
   draft: draftFront,
   from: base,
-  measurements: ['neck', 'chest', 'hips', 'waistToHips', 'hpsToWaistBack', 'waistToArmpit'],
 }

--- a/designs/shelly/src/neckband.mjs
+++ b/designs/shelly/src/neckband.mjs
@@ -1,5 +1,3 @@
-import { front } from './front.mjs'
-import { back } from './back.mjs'
 import { raglanSleeve } from './raglansleeve.mjs'
 
 function draftNeckband({
@@ -11,7 +9,6 @@ function draftNeckband({
   options,
   part,
   store,
-  paperless,
   complete,
   sa,
   macro,
@@ -34,35 +31,33 @@ function draftNeckband({
     .line(points.bottomRightCorner)
     .line(points.topRightCorner)
     .line(points.topLeftCorner)
-    .attr('class', 'fabric')
-    .hide(true)
+    .addClass('fabric')
+    .hide()
 
-  paths.foldBase = new Path().move(points.topLeftCorner).line(points.bottomLeftCorner).hide(true)
+  paths.foldBase = new Path().move(points.topLeftCorner).line(points.bottomLeftCorner).hide()
 
-  paths.foldLine = new Path()
-    .move(points.leftCenter)
-    .line(points.rightCenter)
-    .attr('class', 'various dashed')
-    .attr('data-text', 'Fold Line')
-    .attr('data-text-class', 'center')
-    .hide(false)
-
-  paths.seam = paths.saBase.join(paths.foldBase).close().attr('class', 'fabric')
-
-  if (paperless) {
-    macro('vd', {
-      id: 'hWidth',
-      from: points.topLeftCorner,
-      to: points.bottomLeftCorner,
-      x: -(15 + sa),
-    })
-    macro('hd', {
-      id: 'wLength',
-      from: points.topLeftCorner,
-      to: points.topRightCorner,
-      y: -(sa + 15),
-    })
+  if (complete) {
+    paths.foldLine = new Path()
+      .move(points.leftCenter)
+      .line(points.rightCenter)
+      .addClass('various dashed')
+      .addText('shelly:foldLine', 'center')
   }
+
+  paths.seam = paths.saBase.join(paths.foldBase).close().addClass('fabric')
+
+  macro('vd', {
+    id: 'hWidth',
+    from: points.topLeftCorner,
+    to: points.bottomLeftCorner,
+    x: -(15 + sa),
+  })
+  macro('hd', {
+    id: 'wLength',
+    from: points.topLeftCorner,
+    to: points.topRightCorner,
+    y: -(sa + 15),
+  })
 
   points.cutonfoldFrom = points.topLeftCorner
   points.cutonfoldTo = points.bottomLeftCorner
@@ -72,20 +67,19 @@ function draftNeckband({
     grainline: true,
   })
 
-  store.cutlist.addCut({ cut: 1 })
+  store.cutlist.addCut({ cut: 1, from: 'fabric' })
 
-  if (complete) {
-    points.title = new Point(neckbandLength / 4, neckbandWidth / 2)
-    macro('title', { at: points.title, nr: 4, title: 'neckband' })
+  points.title = new Point(neckbandLength / 4, neckbandWidth / 2)
+  macro('title', { at: points.title, nr: 4, title: 'neckband' })
 
-    if (sa) {
-      paths.sa = new Path()
-        .move(points.bottomLeftCorner)
-        .join(paths.saBase.offset(sa))
-        .line(points.topLeftCorner)
-        .attr('class', 'fabric sa')
-    }
+  if (sa) {
+    paths.sa = new Path()
+      .move(points.bottomLeftCorner)
+      .join(paths.saBase.offset(sa))
+      .line(points.topLeftCorner)
+      .addClass('fabric sa')
   }
+
   return part
 }
 
@@ -93,8 +87,7 @@ export const neckband = {
   name: 'shelly.neckband',
   plugins: [],
   draft: draftNeckband,
-  after: [front, back, raglanSleeve],
-  measurements: ['neck', 'chest', 'biceps', 'wrist'],
+  after: [raglanSleeve],
   options: {
     // How long the neckband should be, as a percentage of the length of the neck hole.
     neckbandLength: { pct: 80, min: 50, max: 100, menu: 'fit' },

--- a/designs/shelly/src/raglansleeve.mjs
+++ b/designs/shelly/src/raglansleeve.mjs
@@ -15,8 +15,6 @@ function draftRaglanSleeve({
   options,
   part,
   store,
-  paperless,
-  complete,
   sa,
   macro,
   snippets,
@@ -121,131 +119,151 @@ function draftRaglanSleeve({
     .line(points.frontArmholeScoopEnd)
     .curve(points.frontArmholeScoopCP2, points.frontArmholeScoopCP1, points.frontArmholeScooped)
     .line(points.frontSleeve)
-    .hide(true)
+    .hide()
 
-  paths.hemBase = new Path().move(points.frontSleeve).line(points.backSleeve).hide(true)
+  paths.hemBase = new Path().move(points.frontSleeve).line(points.backSleeve).hide()
 
-  paths.seam = paths.saBase.join(paths.hemBase).close().attr('class', 'fabric')
+  paths.seam = paths.saBase.join(paths.hemBase).close().addClass('fabric')
 
-  if (paperless) {
-    macro('vd', {
-      from: points.frontNeck,
-      to: points.frontArmholeScoopEnd,
-      x: points.frontArmholeScooped.x - (15 + sa),
-    })
-    macro('vd', {
-      from: points.frontArmholeScoopEnd,
-      to: points.frontArmholeScooped,
-      x: points.frontArmholeScooped.x - (15 + sa),
-    })
-    macro('vd', {
-      from: points.frontNeck,
-      to: points.frontArmholeScooped,
-      x: points.frontArmholeScooped.x - (30 + sa),
-    })
-    macro('vd', {
-      from: points.frontArmholeScooped,
-      to: points.frontSleeve,
-      x: points.frontArmholeScooped.x - (15 + sa),
-    })
-    macro('vd', {
-      from: points.frontNeck,
-      to: points.frontSleeve,
-      x: points.frontArmholeScooped.x - (45 + sa),
-    })
+  macro('vd', {
+    id: 'hFrontRaglanSleeveStraightPortion',
+    from: points.frontNeck,
+    to: points.frontArmholeScoopEnd,
+    x: points.frontArmholeScooped.x - (sa + 15),
+  })
+  macro('vd', {
+    id: 'hFrontRaglanSleeveCurvedPortion',
+    from: points.frontArmholeScoopEnd,
+    to: points.frontArmholeScooped,
+    x: points.frontArmholeScooped.x - (sa + 15),
+  })
+  macro('vd', {
+    id: 'hFrontRaglanSleeve',
+    from: points.frontNeck,
+    to: points.frontArmholeScooped,
+    x: points.frontArmholeScooped.x - (sa + 30),
+  })
+  macro('vd', {
+    id: 'hFrontSleeve',
+    from: points.frontArmholeScooped,
+    to: points.frontSleeve,
+    x: points.frontArmholeScooped.x - (sa + 15),
+  })
+  macro('vd', {
+    id: 'hFrontTotal',
+    from: points.frontNeck,
+    to: points.frontSleeve,
+    x: points.frontArmholeScooped.x - (sa + 45),
+  })
 
-    macro('hd', {
-      from: points.frontArmholeScooped,
-      to: points.frontSleeve,
-      y: points.frontSleeve.y + (15 + sa),
-      noStartMarker: true,
-      noEndMarker: true,
-    })
-    macro('hd', {
-      from: points.frontSleeve,
-      to: points.backSleeve,
-      y: points.frontSleeve.y + (15 + sa),
-    })
-    macro('hd', {
-      from: points.backSleeve,
-      to: points.backArmholeScooped,
-      y: points.backSleeve.y + (15 + sa),
-      noStartMarker: true,
-      noEndMarker: true,
-    })
-    macro('hd', {
-      from: points.frontArmholeScooped,
-      to: points.backArmholeScooped,
-      y: points.frontSleeve.y + (30 + sa),
-    })
+  macro('vd', {
+    id: 'hBackRaglanSleeveStraightPortion',
+    from: points.backNeck,
+    to: points.backArmholeScoopEnd,
+    x: points.backArmholeScooped.x + (sa + 15),
+  })
+  macro('vd', {
+    id: 'hBackRaglanSleeveCurvedPortion',
+    from: points.backArmholeScoopEnd,
+    to: points.backArmholeScooped,
+    x: points.backArmholeScooped.x + (sa + 15),
+  })
+  macro('vd', {
+    id: 'hBackRaglanSleeve',
+    from: points.backNeck,
+    to: points.backArmholeScooped,
+    x: points.backArmholeScooped.x + (sa + 30),
+  })
+  macro('vd', {
+    id: 'hBackSleeve',
+    from: points.backArmholeScooped,
+    to: points.backSleeve,
+    x: points.backArmholeScooped.x + (sa + 15),
+  })
+  macro('vd', {
+    id: 'hBackTotal',
+    from: points.backNeck,
+    to: points.backSleeve,
+    x: points.backArmholeScooped.x + (sa + 45),
+  })
 
-    macro('vd', {
-      from: points.backNeck,
-      to: points.backArmholeScoopEnd,
-      x: points.backArmholeScooped.x + (15 + sa),
-    })
-    macro('vd', {
-      from: points.backArmholeScoopEnd,
-      to: points.backArmholeScooped,
-      x: points.backArmholeScooped.x + (15 + sa),
-    })
-    macro('vd', {
-      from: points.backNeck,
-      to: points.backArmholeScooped,
-      x: points.backArmholeScooped.x + (30 + sa),
-    })
-    macro('vd', {
-      from: points.backArmholeScooped,
-      to: points.backSleeve,
-      x: points.backArmholeScooped.x + (15 + sa),
-    })
-    macro('vd', {
-      from: points.backNeck,
-      to: points.backSleeve,
-      x: points.backArmholeScooped.x + (45 + sa),
-    })
+  macro('hd', {
+    id: 'wFrontSleeve',
+    from: points.frontArmholeScooped,
+    to: points.frontSleeve,
+    y: points.frontSleeve.y + (sa + 15),
+    noStartMarker: true,
+    noEndMarker: true,
+  })
+  macro('hd', {
+    id: 'wSleeveHem',
+    from: points.frontSleeve,
+    to: points.backSleeve,
+    y: points.frontSleeve.y + (sa + 15),
+  })
+  macro('hd', {
+    id: 'wBackSleeve',
+    from: points.backSleeve,
+    to: points.backArmholeScooped,
+    y: points.backSleeve.y + (sa + 15),
+    noStartMarker: true,
+    noEndMarker: true,
+  })
+  macro('hd', {
+    id: 'wWidthAtArmpit',
+    from: points.frontArmholeScooped,
+    to: points.backArmholeScooped,
+    y: points.frontSleeve.y + (sa + 30),
+  })
+  macro('hd', {
+    id: 'wWidthAtArmpit2',
+    from: points.frontArmholeScooped,
+    to: points.backArmholeScooped,
+    y: Math.min(points.frontNeck.y, points.backNeck.y) - (sa + 45),
+  })
 
-    macro('hd', {
-      from: points.frontArmholeScooped,
-      to: points.frontArmholeScoopEnd,
-      y: Math.min(points.frontNeck.y, points.backNeck.y) - (15 + sa),
-    })
-    macro('hd', {
-      from: points.frontArmholeScoopEnd,
-      to: points.frontNeck,
-      y: Math.min(points.frontNeck.y, points.backNeck.y) - (15 + sa),
-    })
-    macro('hd', {
-      from: points.frontNeck,
-      to: points.backNeck,
-      y: Math.min(points.frontNeck.y, points.backNeck.y) - (15 + sa),
-    })
-    macro('hd', {
-      from: points.backNeck,
-      to: points.backArmholeScoopEnd,
-      y: Math.min(points.frontNeck.y, points.backNeck.y) - (15 + sa),
-    })
-    macro('hd', {
-      from: points.backArmholeScoopEnd,
-      to: points.backArmholeScooped,
-      y: Math.min(points.frontNeck.y, points.backNeck.y) - (15 + sa),
-    })
-    macro('hd', {
-      from: points.backNeck,
-      to: points.backArmholeScooped,
-      y: Math.min(points.frontNeck.y, points.backNeck.y) - (30 + sa),
-    })
-    macro('hd', {
-      from: points.frontArmholeScooped,
-      to: points.frontNeck,
-      y: Math.min(points.frontNeck.y, points.backNeck.y) - (30 + sa),
-    })
-    macro('hd', {
-      from: points.frontArmholeScooped,
-      to: points.backArmholeScooped,
-      y: Math.min(points.frontNeck.y, points.backNeck.y) - (45 + sa),
-    })
-  }
+  macro('hd', {
+    id: 'wFrontRaglanSleeveCurvedPortion',
+    from: points.frontArmholeScooped,
+    to: points.frontArmholeScoopEnd,
+    y: Math.min(points.frontNeck.y, points.backNeck.y) - (sa + 15),
+  })
+  macro('hd', {
+    id: 'wFrontRaglanSleeveStraightPortion',
+    from: points.frontArmholeScoopEnd,
+    to: points.frontNeck,
+    y: Math.min(points.frontNeck.y, points.backNeck.y) - (sa + 15),
+  })
+  macro('hd', {
+    id: 'wNeck',
+    from: points.frontNeck,
+    to: points.backNeck,
+    y: Math.min(points.frontNeck.y, points.backNeck.y) - (sa + 15),
+  })
+  macro('hd', {
+    id: 'wBackRaglanSleeveStraightPortion',
+    from: points.backNeck,
+    to: points.backArmholeScoopEnd,
+    y: Math.min(points.frontNeck.y, points.backNeck.y) - (sa + 15),
+  })
+  macro('hd', {
+    id: 'wBackRaglanSleeveCurvedPortion',
+    from: points.backArmholeScoopEnd,
+    to: points.backArmholeScooped,
+    y: Math.min(points.frontNeck.y, points.backNeck.y) - (sa + 15),
+  })
+  macro('hd', {
+    id: 'wBackRaglanSleeve',
+    from: points.backNeck,
+    to: points.backArmholeScooped,
+    y: Math.min(points.frontNeck.y, points.backNeck.y) - (sa + 30),
+  })
+  macro('hd', {
+    id: 'wFrontRaglanSleeve',
+    from: points.frontArmholeScooped,
+    to: points.frontNeck,
+    y: Math.min(points.frontNeck.y, points.backNeck.y) - (sa + 30),
+  })
 
   points.grainlineBottom = points.backSleeve.shiftFractionTowards(points.frontSleeve, 0.5)
   points.grainlineTop = points.raglanCenter.shift(270, neckRadius)
@@ -254,27 +272,25 @@ function draftRaglanSleeve({
     to: points.grainlineBottom,
   })
 
-  store.cutlist.addCut({ cut: 2 })
+  store.cutlist.addCut({ cut: 2, from: 'fabric' })
 
-  if (complete) {
-    snippets.frontArmholeScoopEnd = new Snippet('notch', points.frontArmholeScoopEnd)
-    snippets.backArmholeScoopEnd = new Snippet('bnotch', points.backArmholeScoopEnd)
+  snippets.frontArmholeScoopEnd = new Snippet('notch', points.frontArmholeScoopEnd)
+  snippets.backArmholeScoopEnd = new Snippet('bnotch', points.backArmholeScoopEnd)
 
-    points.title = new Point(0, points.backSleeve.y / 3)
-    macro('title', { at: points.title, nr: 3, title: 'sleeve' })
+  points.title = new Point(0, points.backSleeve.y / 3)
+  macro('title', { at: points.title, nr: 3, title: 'sleeve' })
 
-    points.logo = points.title.shift(-90, 70 * scale)
-    snippets.logo = new Snippet('logo', points.logo)
-    points.scalebox = points.logo.shift(-90, 70 * scale)
-    macro('scalebox', { at: points.scalebox })
+  points.logo = points.title.shift(-90, 70 * scale)
+  snippets.logo = new Snippet('logo', points.logo)
+  points.scalebox = points.logo.shift(-90, 70 * scale)
+  macro('scalebox', { at: points.scalebox })
 
-    if (sa) {
-      paths.sa = paths.saBase
-        .offset(sa)
-        .join(paths.hemBase.offset(sa * options.sleeveHem))
-        .close()
-        .attr('class', 'fabric sa')
-    }
+  if (sa) {
+    paths.sa = paths.saBase
+      .offset(sa)
+      .join(paths.hemBase.offset(sa * options.sleeveHem))
+      .close()
+      .addClass('fabric sa')
   }
 
   const neckPath = new Path()
@@ -288,9 +304,8 @@ function draftRaglanSleeve({
 export const raglanSleeve = {
   name: 'shelly.raglanSleeve',
   after: [front, back],
-  plugins: [],
   draft: draftRaglanSleeve,
-  measurements: ['neck', 'chest', 'wrist', 'shoulderToWrist'],
+  measurements: ['wrist', 'shoulderToWrist'],
   options: {
     bicepsPosition: 0.2,
     // How much ease to put around the wrist. For sleeves that don't reach the wrist, this value is interpolated with sleeveEase.

--- a/designs/shelly/src/raglansleeve.mjs
+++ b/designs/shelly/src/raglansleeve.mjs
@@ -290,13 +290,9 @@ export const raglanSleeve = {
   after: [front, back],
   plugins: [],
   draft: draftRaglanSleeve,
-  measurements: ['neck', 'chest', 'biceps', 'wrist', 'shoulderToWrist'],
+  measurements: ['neck', 'chest', 'wrist', 'shoulderToWrist'],
   options: {
-    // How much larger to make the armhole as a proportion of the biceps measurement.
-    armholeTweakFactor: 1.1,
     bicepsPosition: 0.2,
-    // How much ease to put vertically around the armhole and the shoulder joint. Transitions gradually towards wristEase as one goes down the sleeve.
-    sleeveEase: { pct: 0, min: -30, max: 50, menu: 'fit' },
     // How much ease to put around the wrist. For sleeves that don't reach the wrist, this value is interpolated with sleeveEase.
     wristEase: { pct: 0, min: -30, max: 50, menu: 'fit' },
     // How long the sleeve is. 100 is a long sleeve ending at the wrist. 20 is a typical short sleeve.


### PR DESCRIPTION
Changes how the armpit is calculated on the body so that it moves down as sleeveEase grows. In other words, the sleeve now gains ease equally on the shoulder and the armpit, instead of entirely on the shoulder.

Cleans up Shelly's code as follows:
 - replaces .hide(true) with .hide()
 - replaces .attr('class', ...) with .addClass(...)
 - removes redundant measurement declarations
 - removes empty plugins[] declarations
 - removes unneeded if(paperless) checks
 - removes unneeded if(complete) checks
 - SA now works without needed complete to be set to true
 - fixed a bug causing the fold line on the neckband to not render.