### PR TITLE
Onyx - Tweak to armhole ease

### DIFF
--- a/designs/onyx/src/base.mjs
+++ b/designs/onyx/src/base.mjs
@@ -60,7 +60,13 @@ function draftBase({
   points.raglanCenter = new Point(0, 0)
   points.neckCenter = points.raglanCenter.shift(270, options.neckBalance * neckRadius)
 
-  points.armpitCorner = new Point(chest / 4, armpitYPosition)
+  points.armpitCorner = new Point(chest / 4, armpitYPosition).translate(
+    0,
+    Math.max(
+      0,
+      (measurements.biceps * options.armholeTweakFactor * options.sleeveEase) / (2 * Math.PI)
+    )
+  )
 
   points.neckShoulderCorner = utils.beamIntersectsCircle(
     points.neckCenter,
@@ -284,6 +290,7 @@ export const base = {
   draft: draftBase,
   hide: { self: true },
   measurements: [
+    'biceps',
     'neck',
     'chest',
     'waist',
@@ -362,7 +369,10 @@ export const base = {
         pct,
       menu: 'construction',
     },
-    // How wide to make the section of fabric keeping the zipper away from the wearer's skin. Optional on one-piece pajamas. Crucial on swimwear.
+    // How much ease to put vertically around the armhole and the shoulder joint. Transitions gradually towards wristEase as one goes down the sleeve.
+    sleeveEase: { pct: 0, min: -30, max: 50, menu: 'fit' },
+    // How much larger to make the armhole as a proportion of the biceps measurement.
+    armholeTweakFactor: 1.1,
   },
   optionalMeasurements: ['highBust'],
 }

--- a/designs/onyx/src/raglansleeve.mjs
+++ b/designs/onyx/src/raglansleeve.mjs
@@ -310,13 +310,11 @@ export const raglanSleeve = {
   name: 'onyx.raglanSleeve',
   after: [front, back],
   draft: draftRaglanSleeve,
-  measurements: ['biceps', 'wrist', 'shoulderToWrist'],
+  measurements: ['wrist', 'shoulderToWrist'],
   options: {
     // How much larger to make the armhole as a proportion of the biceps measurement.
     armholeTweakFactor: 1.1,
     bicepsPosition: 0.2,
-    // How much ease to put vertically around the armhole and the shoulder joint. Transitions gradually towards wristEase as one goes down the sleeve.
-    sleeveEase: { pct: 0, min: -30, max: 50, menu: 'fit' },
     // How much ease to put around the wrist. For sleeves that don't reach the wrist, this value is interpolated with sleeveEase.
     wristEase: { pct: 0, min: -30, max: 50, menu: 'fit' },
     // How long the sleeve is. 100 is a long sleeve ending at the wrist. 20 is a typical short sleeve.

--- a/designs/onyx/src/raglansleeve.mjs
+++ b/designs/onyx/src/raglansleeve.mjs
@@ -312,8 +312,6 @@ export const raglanSleeve = {
   draft: draftRaglanSleeve,
   measurements: ['wrist', 'shoulderToWrist'],
   options: {
-    // How much larger to make the armhole as a proportion of the biceps measurement.
-    armholeTweakFactor: 1.1,
     bicepsPosition: 0.2,
     // How much ease to put around the wrist. For sleeves that don't reach the wrist, this value is interpolated with sleeveEase.
     wristEase: { pct: 0, min: -30, max: 50, menu: 'fit' },


### PR DESCRIPTION
Changes how ease around the armhole is calculated by having the armpit point move downwards for positive eases.

Current: Sleeve ease is applied entirely to the top of the shoulder.
New: Sleeve ease is applied equally to the top of the shoulder and to the armpit when sleeveEase is positive, but still applied only to the shoulder top for negative ease.

The reasoning is that, while you don't want to squeeze the armpit with negative ease, you do want extra room to be distributed evenly for roomier garments.

This should improve the quality of patterns generated with positive ease.