### PR TITLE
Added documentation of two new methods in the utils section of API.

### DIFF
--- a/markdown/dev/reference/api/utils/applytransformtopoint/en.md
+++ b/markdown/dev/reference/api/utils/applytransformtopoint/en.md
@@ -2,7 +2,7 @@
 title: utils.applyTransformToPoint()
 ---
 
-The `utils.applyTransformToPoint()` function applies a specified transformation to the point's coordinates. Returns the transformed point as a [Point](https://freesewing.dev/reference/api/point) object.
+The `utils.applyTransformToPoint()` function applies a specified transformation to the point's coordinates. Returns the transformed point as a [Point](/reference/api/point) object.
 
 ## Signature
 
@@ -14,5 +14,5 @@ Point utils.applyTransformToPoint(string transform, Point A)
 
 1st parameter is a SVG transform string. Eg: `scale(sfx, sfy)` where `sfx` and `sfy` are the scaling factors along the x-axis and y-axis respectively.
 
-2nd parameter is the original point that is to be transformed. It is a [Point](https://freesewing.dev/reference/api/point) object.
+2nd parameter is the original point that is to be transformed. It is a [Point](/reference/api/point) object.
 

--- a/markdown/dev/reference/api/utils/applytransformtopoint/en.md
+++ b/markdown/dev/reference/api/utils/applytransformtopoint/en.md
@@ -1,0 +1,18 @@
+---
+title: utils.applyTransformToPoint()
+---
+
+The `utils.applyTransformToPoint()` function applies a specified transformation to the point's coordinates. Returns the transformed point as a [Point](https://freesewing.dev/reference/api/point) object.
+
+## Signature
+
+```js
+Point utils.applyTransformToPoint(string transform, Point A)
+```
+
+## Parameters
+
+1st parameter is a SVG transform string. Eg: `scale(sfx, sfy)` where `sfx` and `sfy` are the scaling factors along the x-axis and y-axis respectively.
+
+2nd parameter is the original point that is to be transformed. It is a [Point](https://freesewing.dev/reference/api/point) object.
+

--- a/markdown/dev/reference/api/utils/combinetransforms/en.md
+++ b/markdown/dev/reference/api/utils/combinetransforms/en.md
@@ -1,0 +1,16 @@
+---
+title: utils.combineTransform()
+---
+
+The `utils.combineTransform()` function merges an array of SVG transformations into a single composite matrix transformation. Returns a single combined matrix transform string.
+
+## Signature
+
+```js
+string utils.combineTransforms(string[] transforms)
+```
+
+## Parameters
+
+The function only takes a single parameter i.e array of transform strings. Eg: `["scale(sfx, sfy)", rotate(angle), translate(tx, ty)]`
+


### PR DESCRIPTION
Closes  #4078

Documented two new methods `utils.applyTransformToPoint()` and `utils.combineTransforms` in the Utils section of API references doc.