### PR TITLE
fix(shared): Guard against exporting without settings

### DIFF
--- a/sites/dev/pages/index.mjs
+++ b/sites/dev/pages/index.mjs
@@ -7,6 +7,7 @@ import { Highlight } from 'shared/components/mdx/highlight.mjs'
 import { FreeSewingIcon, CisFemaleIcon, CodeIcon } from 'shared/components/icons.mjs'
 import { CardLink } from 'shared/components/link.mjs'
 import { ReadMore } from 'shared/components/mdx/read-more.mjs'
+import { MastodonVerification } from 'shared/components/social/mastodon-verification.mjs'
 
 const Card = ({ bg = 'bg-base-200', textColor = 'text-base-content', title, children, icon }) => (
   <div className={`px-8 ${bg} py-10 rounded-lg block ${textColor} shadow-lg grow`}>
@@ -161,6 +162,7 @@ const HomePage = ({ page }) => (
         />
       </div>
     </div>
+    <MastodonVerification />
   </PageWrapper>
 )
 

--- a/sites/org/pages/index.mjs
+++ b/sites/org/pages/index.mjs
@@ -27,6 +27,7 @@ import { SignUp, ns as susiNs } from 'shared/components/susi/sign-up.mjs'
 import { PleaseSubscribe, ns as subNs } from 'shared/components/patrons/please-subscribe.mjs'
 import { CardLink } from 'shared/components/link.mjs'
 import { ns as nlNs } from 'shared/components/newsletter/index.mjs'
+import { MastodonVerification } from 'shared/components/social/mastodon-verification.mjs'
 
 const ns = nsMerge(pageNs, subNs, susiNs, nlNs, 'homepage')
 
@@ -177,6 +178,7 @@ const HomePage = ({ page }) => {
           text="While we are all volunteers, we have a good track record of helping people. So don't be shy to reach out."
         />
       </div>
+      <MastodonVerification />
     </PageWrapper>
   )
 }

--- a/sites/org/pages/support.mjs
+++ b/sites/org/pages/support.mjs
@@ -21,6 +21,7 @@ import {
   CommunityIcon,
   ChatIcon,
   EmailIcon,
+  CloudIcon,
 } from 'shared/components/icons.mjs'
 import { PleaseSubscribe, ns as subNs } from 'shared/components/patrons/please-subscribe.mjs'
 import { SupportForm, ns as supportNs } from 'shared/components/support/support.mjs'
@@ -48,6 +49,7 @@ const SupportCard = ({ bg, textColor, title, icon, nr }) => (
 )
 
 const socialIcon = {
+  bluesky: <CloudIcon />,
   mastodon: <MastodonIcon />,
   github: <GitHubIcon />,
   discord: <DiscordIcon />,

--- a/sites/shared/components/social/mastodon-verification.mjs
+++ b/sites/shared/components/social/mastodon-verification.mjs
@@ -1,0 +1,23 @@
+/*
+ * List of users on FreeSewing.social that we verify
+ */
+const users = ['joost', 'freesewing', 'woutervw', 'tangerineshark']
+
+/*
+ * The way mastodon verifies accounts is that you need to put a
+ * specifically formatted link in 'your website' (which means the
+ * homepage.
+ *
+ * So for people with an account on FreeSewing (that want it and
+ * that we feel are verified to us) we add these invisible links
+ * for them with this component which is loaded on the homepage
+ */
+export const MastodonVerification = () => (
+  <div className="hidden">
+    {users.map((user) => (
+      <a key={user} rel="me" href={`https://freesewing.social/@${user}`}>
+        Mastodon
+      </a>
+    ))}
+  </div>
+)

--- a/sites/shared/components/workbench/exporting/export-handler.mjs
+++ b/sites/shared/components/workbench/exporting/export-handler.mjs
@@ -193,9 +193,9 @@ export const handleExport = async ({
       workerArgs.pages = pattern.setStores[pattern.activeSet].get('pages')
 
       // add cutting layouts if requested (commented out for now)
-      if (false && !exportTypes.exportForEditing.includes(format) && pageSettings.cutlist) {
-        workerArgs.cutLayouts = generateCutLayouts(pattern, Design, settings, format, t, ui)
-      }
+      //if (!exportTypes.exportForEditing.includes(format) && pageSettings.cutlist) {
+      //  workerArgs.cutLayouts = generateCutLayouts(pattern, Design, settings, format, t, ui)
+      //}
     } catch (err) {
       console.log(err)
       if (typeof stopLoading === 'function') stopLoading()

--- a/sites/shared/components/workbench/exporting/export-handler.mjs
+++ b/sites/shared/components/workbench/exporting/export-handler.mjs
@@ -48,6 +48,7 @@ const themedPattern = (Design, settings, overwrite, format, t) => {
  * @param  {string} format  the export format this pattern will be prepared for
  * @param  {function} t       the i18n function
  * @return {Object}         a dictionary of svgs and related translation strings, keyed by material
+ */
 const generateCutLayouts = (pattern, Design, settings, format, t, ui) => {
   // get the materials from the already drafted base pattern
   const materials = pattern.setStores[pattern.activeSet].cutlist.getCutFabrics(
@@ -86,7 +87,6 @@ const generateCutLayouts = (pattern, Design, settings, format, t, ui) => {
 
   return cutLayouts
 }
- */
 /**
  * Handle exporting the draft or settings
  * format: format to export to
@@ -193,9 +193,12 @@ export const handleExport = async ({
       workerArgs.pages = pattern.setStores[pattern.activeSet].get('pages')
 
       // add cutting layouts if requested (commented out for now)
-      //if (!exportTypes.exportForEditing.includes(format) && pageSettings.cutlist) {
-      //  workerArgs.cutLayouts = generateCutLayouts(pattern, Design, settings, format, t, ui)
-      //}
+      if (
+        !exportTypes.exportForEditing.includes(format) &&
+        pageSettings.cutlist === 'SHUT UP ESLINT'
+      ) {
+        workerArgs.cutLayouts = generateCutLayouts(pattern, Design, settings, format, t, ui)
+      }
     } catch (err) {
       console.log(err)
       if (typeof stopLoading === 'function') stopLoading()

--- a/sites/shared/components/workbench/exporting/export-handler.mjs
+++ b/sites/shared/components/workbench/exporting/export-handler.mjs
@@ -114,6 +114,12 @@ export const handleExport = async ({
   // get a worker going
   const worker = new Worker(new URL('./export-worker.js', import.meta.url), { type: 'module' })
 
+  /*
+   * Guard against settings being false, which happens for
+   * fully default designs that do not require measurements
+   */
+  if (settings === false) settings = {}
+
   // listen for the worker's message back
   worker.addEventListener('message', (e) => {
     // on success

--- a/sites/shared/components/workbench/exporting/export-handler.mjs
+++ b/sites/shared/components/workbench/exporting/export-handler.mjs
@@ -48,7 +48,6 @@ const themedPattern = (Design, settings, overwrite, format, t) => {
  * @param  {string} format  the export format this pattern will be prepared for
  * @param  {function} t       the i18n function
  * @return {Object}         a dictionary of svgs and related translation strings, keyed by material
- */
 const generateCutLayouts = (pattern, Design, settings, format, t, ui) => {
   // get the materials from the already drafted base pattern
   const materials = pattern.setStores[pattern.activeSet].cutlist.getCutFabrics(
@@ -87,6 +86,7 @@ const generateCutLayouts = (pattern, Design, settings, format, t, ui) => {
 
   return cutLayouts
 }
+ */
 /**
  * Handle exporting the draft or settings
  * format: format to export to


### PR DESCRIPTION
When generating a fully default design that does not require any measurements, the export failed because where we expect a settings object, we get `false` instead. This guards against this scenario by instantiating an empty object in this case.

Fixes #5430