### PR TITLE
fix(core): Corectly load conditional plugins

### DIFF
--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -54,6 +54,7 @@ Unreleased:
     core:
       - Fix order in mergeOptions method so user settings take precendence over defaults
       - Fix upward snap for snapped percentage option when snap is a simple number
+      - The conditional loading of plugins had a bug causing them to never be loaded
     simon:
       - Replaced all instances of 'seperate' with 'separate' in option names
     plugintest:

--- a/packages/core/src/pattern/pattern-plugins.mjs
+++ b/packages/core/src/pattern/pattern-plugins.mjs
@@ -171,7 +171,7 @@ PatternPlugins.prototype.__macro = function (key, method) {
  * @param {object} plugin - An object with `plugin` and `condition` keys
  * @return {Pattern} this - The Pattern instance
  */
-PatternPlugins.prototype.__useIf = function (plugin, settings = [{}]) {
+PatternPlugins.prototype.__useIf = function (plugin, data, settings = [{}]) {
   let load = 0
   for (const set of settings) {
     if (plugin.condition(set)) load++
@@ -180,7 +180,7 @@ PatternPlugins.prototype.__useIf = function (plugin, settings = [{}]) {
     this.store.log.info(
       `Condition met: Loaded plugin \`${plugin.plugin.name}:${plugin.plugin.version}\``
     )
-    this.__loadPlugin(plugin.plugin, plugin.data)
+    this.__loadPlugin(plugin.plugin, data)
   } else {
     this.store.log.info(
       `Condition not met: Skipped loading plugin \`${plugin.plugin.name}:${plugin.plugin.version}\``

--- a/sites/shared/components/workbench/views/draft/header.mjs
+++ b/sites/shared/components/workbench/views/draft/header.mjs
@@ -138,7 +138,7 @@ export const DraftHeader = ({
     <div
       className={`hidden lg:flex sticky top-0 ${
         ui.kiosk ? 'z-50' : 'z-20'
-      }} transition-[top] duration-300 ease-in-out`}
+      }} transition-[top] duration-300 ease-in-out z-10`}
     >
       <div
         className={`hidden lg:flex flex-row flex-wrap gap-4 py-2 w-full bg-neutral text-neutral-content items-center justify-center`}


### PR DESCRIPTION
The parameters passed to the conditional load method were incorrect causing a conditional plugin to never get loaded.