### PR TITLE
Box - Update to v3 standards

### DIFF
--- a/config/templates/design/src/box.mjs
+++ b/config/templates/design/src/box.mjs
@@ -1,17 +1,4 @@
-function draftBox({
-  options,
-  Point,
-  Path,
-  points,
-  paths,
-  Snippet,
-  snippets,
-  complete,
-  sa,
-  paperless,
-  macro,
-  part,
-}) {
+function draftBox({ options, Point, Path, points, paths, Snippet, snippets, sa, macro, part }) {
   const w = 500 * options.size
   points.topLeft = new Point(0, 0)
   points.topRight = new Point(w, 0)
@@ -27,33 +14,27 @@ function draftBox({
     .close()
     .attr('class', 'fabric')
 
-  // Complete?
-  if (complete) {
-    points.logo = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)
-    snippets.logo = new Snippet('logo', points.logo)
-    points.text = points.logo
-      .shift(-90, w / 8)
-      .attr('data-text', 'hello')
-      .attr('data-text-class', 'center')
+  points.logo = points.topLeft.shiftFractionTowards(points.bottomRight, 0.5)
+  snippets.logo = new Snippet('logo', points.logo)
+  points.text = points.logo
+    .shift(-90, w / 8)
+    .attr('data-text', 'hello')
+    .attr('data-text-class', 'center')
 
-    if (sa) {
-      paths.sa = paths.seam.offset(sa).attr('class', 'fabric sa')
-    }
+  if (sa) {
+    paths.sa = paths.seam.offset(sa).attr('class', 'fabric sa')
   }
 
-  // Paperless?
-  if (paperless) {
-    macro('hd', {
-      from: points.bottomLeft,
-      to: points.bottomRight,
-      y: points.bottomLeft.y + sa + 15,
-    })
-    macro('vd', {
-      from: points.bottomRight,
-      to: points.topRight,
-      x: points.topRight.x + sa + 15,
-    })
-  }
+  macro('hd', {
+    from: points.bottomLeft,
+    to: points.bottomRight,
+    y: points.bottomLeft.y + sa + 15,
+  })
+  macro('vd', {
+    from: points.bottomRight,
+    to: points.topRight,
+    x: points.topRight.x + sa + 15,
+  })
 
   return part
 }

--- a/config/templates/design/src/box.mjs
+++ b/config/templates/design/src/box.mjs
@@ -22,7 +22,7 @@ function draftBox({ options, Point, Path, points, paths, Snippet, snippets, sa, 
     .attr('data-text-class', 'center')
 
   if (sa) {
-    paths.sa = paths.seam.offset(sa).attr('class', 'fabric sa')
+    paths.sa = paths.seam.offset(sa).addClass('fabric sa')
   }
 
   macro('hd', {

--- a/config/templates/design/src/box.mjs
+++ b/config/templates/design/src/box.mjs
@@ -26,11 +26,13 @@ function draftBox({ options, Point, Path, points, paths, Snippet, snippets, sa, 
   }
 
   macro('hd', {
+    id: 'hWidth',
     from: points.bottomLeft,
     to: points.bottomRight,
     y: points.bottomLeft.y + sa + 15,
   })
   macro('vd', {
+    id: 'vHeight',
     from: points.bottomRight,
     to: points.topRight,
     x: points.topRight.x + sa + 15,


### PR DESCRIPTION
I've updated the basic box added to new designs to meet v3 standards. In particular:

- Complete check is removed (done implicitly now for the title and logo.
- Paperless check is removed (done implicitly now for dimensions).
- .attr('class', 'fabric sa') is now .addClass('fabric sa') (it's easier to read).