### PR TITLE
fix(backend): Allow Oauth login without consent. Fixes #5433"

### DIFF
--- a/sites/backend/src/models/user.mjs
+++ b/sites/backend/src/models/user.mjs
@@ -1518,7 +1518,7 @@ UserModel.prototype.guardedMfaUpdate = async function ({ body, user, ip }) {
       this.clear.mfaSecret,
       this.clear.data.mfaScratchCodes
     )
-    let result, mfaScratchCodes
+    let result
     if (Array.isArray(check)) [result] = check
     else result = check
     if (result) {
@@ -1556,7 +1556,7 @@ UserModel.prototype.guardedMfaUpdate = async function ({ body, user, ip }) {
      * Verify secret and token
      */
     const check = await this.mfa.verify(body.token, this.clear.mfaSecret, false)
-    let result, mfaScratchCodes
+    let result
     if (Array.isArray(check)) [result] = check
     else result = check
     if (body.secret === this.clear.mfaSecret && result) {

--- a/sites/backend/src/models/user.mjs
+++ b/sites/backend/src/models/user.mjs
@@ -121,7 +121,7 @@ UserModel.prototype.oauthSignIn = async function ({ body }) {
     /*
      * Final check for account status and other things before returning
      */
-    const [ok, err, status] = this.isOk()
+    const [ok, err, status] = this.isOk(401, 'signInFailed', true)
     if (ok === true) return this.signInOk()
     else return this.setResponse(status, err)
   }
@@ -1819,7 +1819,7 @@ UserModel.prototype.isOk = function (
   if (
     this.exists &&
     this.record &&
-    this.record.status > 0 &&
+    (allowWithoutConsent || this.record.status > 0) &&
     (allowWithoutConsent || this.record.consent > 0) &&
     this.record.role &&
     this.record.role !== 'blocked'
@@ -1828,7 +1828,7 @@ UserModel.prototype.isOk = function (
 
   if (!this.exists) return [false, 'noSuchUser', 404]
   if (this.record.consent < 1 && !allowWithoutConsent) return [false, 'consentLacking', 451]
-  if (this.record.status < 1) return [false, 'statusLacking', 403]
+  if (this.record.status < 1 && !allowWithoutConsent) return [false, 'statusLacking', 403]
   if (this.record.role === 'blocked') return [false, 'accountBlocked', 403]
 
   return [false, failMsg, failStatus]


### PR DESCRIPTION
We need to allow login without consent, because people need to be logged in to give consent.
This is typically handled at the sign-in page, but when people navigate away, or for some other reason need to bootstrap an account without consent, this is required.

The same happens when logging in with username/password or magic link, but there we already accommodate for this use case.
However, for Oauth, this was overlooked, so this commit adds it.

To be complete: This allows login while both consent is lacking, and status is not active because that's the state the account is in at that point. 