### PR TITLE
Typo fix in plugin-annotations en.json (mirorred -> mirrored)

### DIFF
--- a/plugins/plugin-annotations/i18n/en.json
+++ b/plugins/plugin-annotations/i18n/en.json
@@ -13,7 +13,7 @@
   "fusible": "fusible interfacing",
   "interfacing": "interfacing",
   "lining": "lining",
-  "mirrored": "mirorred",
+  "mirrored": "mirrored",
   "noName": "No name",
   "noVersion": "No version",
   "onBias": "on the bias",


### PR DESCRIPTION
Just a simple typo fix for the cut instructions plugin.