### PR TITLE
Fix dead links from /docs/site to /docs/about/site

### DIFF
--- a/markdown/org/docs/about/site/account/en.md
+++ b/markdown/org/docs/about/site/account/en.md
@@ -7,9 +7,9 @@ Your FreeSewing account is where we store your data. Your account itself can hol
 <ReadMore recurse />
 
 In addition, any 
-[bookmarks](/docs/site/about/site/bookmarks/), 
-[measurements sets](/docs/site/about/site/sets/), 
-[patterns](/docs/site/about/site/patterns/), and
-[API keys](/docs/site/about/site/apikeys/) are strictly speaking also part
+[bookmarks](/docs/about/site/bookmarks/), 
+[measurements sets](/docs/about/site/sets/), 
+[patterns](/docs/about/site/patterns/), and
+[API keys](/docs/about/site/apikeys/) are strictly speaking also part
 of your _account data_ but they are stored as individual records, rather than
 as fields in your account.

--- a/markdown/org/docs/about/site/account/password/en.md
+++ b/markdown/org/docs/about/site/account/password/en.md
@@ -5,5 +5,5 @@ title: Password
 Your password guards your account so that only you can access it.
 
 We do not enforce a password policy, but recommend you
-enable [Two-Factor Authentication](/docs/site/account/mfa).
+enable [Two-Factor Authentication](/account/mfa/).
 

--- a/markdown/org/docs/about/site/draft/core-settings/en.md
+++ b/markdown/org/docs/about/site/draft/core-settings/en.md
@@ -6,7 +6,7 @@ The **Core Settings** menu allows you to tweak various aspects of the
 FreeSewing Core library, which -- under the hood -- generates your pattern for
 you.
 
-In contrast to [Design Options](/docs/site/draft/design-options/) which are
+In contrast to **Design options** which are
 specific for a given design, these Core Settings are the same for every design.
 So you will find this menu always provides the same settings, regardless of
 what design you are generating a pattern for.

--- a/markdown/org/docs/about/site/draft/core-settings/sabool/en.md
+++ b/markdown/org/docs/about/site/draft/core-settings/sabool/en.md
@@ -13,11 +13,11 @@ allowance, you should enable it by changing this option to **Yes**.
 FreeSewing's core library only takes a single setting to handle seam allowance: `sa`.
 However, for convenience, we've split this up into two different settings on the website:
 
-- **[Include Seam Allowance](/docs/site/draft/core-settings/sabool)**: Controls whether or not to include seam allowance
-- **[Seam Allowance Size](/docs/site/draft/core-settings/samm)**: Controls how big to make the seam allowance, if it is included
+- **[Include Seam Allowance](/docs/about/site/draft/core-settings/sabool)**: Controls whether or not to include seam allowance
+- **[Seam Allowance Size](/docs/about/site/draft/core-settings/samm)**: Controls how big to make the seam allowance, if it is included
 
 The latter will only be shown if you've enabled the former.
 
 </Note>
 
-[core-settings]: /docs/site/draft/core-settings/
+[core-settings]: /docs/about/site/draft/core-settings/

--- a/markdown/org/docs/about/site/draft/core-settings/samm/en.md
+++ b/markdown/org/docs/about/site/draft/core-settings/samm/en.md
@@ -12,11 +12,11 @@ of this size.
 FreeSewing's core library only takes a single setting to handle seam allowance: `sa`.
 However, for convenience, we've split this up into two different settings on the website:
 
-- **[Include Seam Allowance](/docs/site/draft/core-settings/sabool)**: Controls whether or not to include seam allowance
-- **[Seam Allowance Size](/docs/site/draft/core-settings/samm)**: Controls how big to make the seam allowance, if it is included
+- **[Include Seam Allowance](/docs/about/site/draft/core-settings/sabool)**: Controls whether or not to include seam allowance
+- **[Seam Allowance Size](/docs/about/site/draft/core-settings/samm)**: Controls how big to make the seam allowance, if it is included
 
 The latter will only be shown if you've enabled the former.
 
 </Note>
 
-[core-settings]: /docs/site/draft/core-settings/
+[core-settings]: /docs/about/site/draft/core-settings/

--- a/sites/org/next.config.mjs
+++ b/sites/org/next.config.mjs
@@ -18,7 +18,7 @@ config.rewrites = async () => {
     },
     {
       source: '/sets',
-      destination: '/docs/site/sets',
+      destination: '/docs/about/site/sets',
     },
   ]
 }


### PR DESCRIPTION
Fix dead links to the docs. Some pages no longer exist so were replaced with another appropriate link, of with no link. Closes #5589 .