### PR TITLE
(Documentation) Fix error in the example for /reference/api/path/setclass

### DIFF
--- a/markdown/dev/reference/api/path/setclass/en.md
+++ b/markdown/dev/reference/api/path/setclass/en.md
@@ -38,5 +38,5 @@ as the two following calls yield the same result:
 
 ```js
 path.attr('class', 'fabric', true)
-path.addClass('fabric')
+path.setClass('fabric')
 ```


### PR DESCRIPTION
In the example for setClass, addClass is used. This fix changes it to setClass.