### PR TITLE
Add disabled pattern delete button when no patterns selected

### DIFF
--- a/sites/shared/components/account/patterns.mjs
+++ b/sites/shared/components/account/patterns.mjs
@@ -585,7 +585,11 @@ export const Patterns = () => {
         <button className="btn btn-error" onClick={removeSelectedPatterns}>
           <TrashIcon /> {selCount} {t('patterns')}
         </button>
-      ) : null}
+      ) : (
+        <button className="btn" onClick={null}>
+          <TrashIcon /> {selCount} {t('patterns')}
+        </button>
+      )}
       <TableWrapper>
         <table className="table table-auto">
           <thead className="border border-base-300 border-b-2 border-t-0 border-x-0">

--- a/sites/shared/components/account/patterns.mjs
+++ b/sites/shared/components/account/patterns.mjs
@@ -581,15 +581,9 @@ export const Patterns = () => {
           {t('patternNew')}
         </Link>
       </p>
-      {selCount ? (
-        <button className="btn btn-error" onClick={removeSelectedPatterns}>
-          <TrashIcon /> {selCount} {t('patterns')}
-        </button>
-      ) : (
-        <button className="btn" onClick={null}>
-          <TrashIcon /> {selCount} {t('patterns')}
-        </button>
-      )}
+      <button className="btn btn-error" onClick={removeSelectedPatterns} disabled={selCount < 1}>
+        <TrashIcon /> {selCount} {t('patterns')}
+      </button>
       <TableWrapper>
         <table className="table table-auto">
           <thead className="border border-base-300 border-b-2 border-t-0 border-x-0">


### PR DESCRIPTION
Adds a grey/disabled delete button to `account/patterns` when no patterns are selected. Motivated by multiple users (me included) at least initially glossing over the fact that this is how pattern deletion is done.