### PR TITLE
feat: Support notes in title macro

### DIFF
--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -1,6 +1,18 @@
 Unreleased:
   Added:
 
+  Added:
+    plugin-annotations:
+      - The `title` macro now takes a `notes` and `classes.notes` as its config, allowing you to add notes
+      - The `classes.cutlist` config is removed from the title plugin, cutlist info is now included as notes
+    plugin-i18n:
+      - This plugin now supports translation of nested arrays of strings, giving you more flexibility to concatenate translated parts of strings
+    react-components:
+      - This Pattern component now supports translation of nested arrays of strings, giving you more flexibility to concatenate translated parts of strings
+
+    Removed:
+      - The `classes.cutlist` config is removed from the title plugin, cutlist info is now included as notes
+
 3.1.0:
   date: 2023-12-26
   Added:

--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -1,5 +1,4 @@
 Unreleased:
-  Added:
 
   Added:
     plugin-annotations:
@@ -10,7 +9,8 @@ Unreleased:
     react-components:
       - This Pattern component now supports translation of nested arrays of strings, giving you more flexibility to concatenate translated parts of strings
 
-    Removed:
+  Removed:
+    plugin-annotations:
       - The `classes.cutlist` config is removed from the title plugin, cutlist info is now included as notes
 
 3.1.0:

--- a/markdown/dev/howtos/code/adding-text/en.md
+++ b/markdown/dev/howtos/code/adding-text/en.md
@@ -9,31 +9,24 @@ provides the [Point.addText()](/reference/api/point/addtext) and
 [Path.addText()](/reference/api/path/addtext) methods to let you add text to
 points and paths.
 
-<Example caption="An example of adding text" tutorial>
-```design/src/part.mjs
-function draftPart = ({ 
-  Point,
-  points,
-  Path, 
-  paths,
-  part 
-}) {
+In addition, [the `title` macro](/reference/macros/title) not only lets you add a
+title to your part, it also allows you to add notes.
 
-  points.demo = new Point(70,10)
-  // highlight-start
-    .addText('Text on a point', 'center')
-  // highlight-end
+## Wrapping lines
 
-  paths.demo = new Path()
-    .move(new Point(0,0))
-    .line(new Point(100, 40))
-    .addClass('note dotted stroke-sm')
-  // highlight-start
-    .addText('Text on a path', 'center')
-  // highlight-end
+SVG does not provide any line-wrapping, so you will need to be mindful of that when you add longer text.
 
+To facilitate this, FreeSewing will enforce a line break when you use `\n` in your text.
 
-  return part
-}
-```
-</Example>
+## Translation
+
+Text that is added to a pattern typically requires translation. 
+You should break up your text in such a way that it remains possible to translate it.
+
+You can do that either via repeated calls to `addText()` or you can pass an array of strings, or even a nested array of strings, and FreeSewing will translate all individual pieces prior to contatenating them.
+
+<Note compact noP>
+
+Refer to [the `insertText` hook](/reference/hooks/inserttext#notes) for details.
+</Note>
+

--- a/markdown/dev/reference/macros/en.md
+++ b/markdown/dev/reference/macros/en.md
@@ -47,6 +47,24 @@ Now you can use these macros in your part:
 }
 ```
 
+## Removing macros and the role of the macro id
+
+Many macros accept an `id` parameter as part of their configuration.  This `id`
+is used to generate the names for paths, points, or snippets that are added to
+the part by the macro.  This way, macro-added content is deterministic, and can
+be removed again.
+
+Each macro typically has an `rm`-prefixed counterpart that removes the (changed
+done by) the macro.  For example, you can add a bartack with the `bartack`
+macro, and it can be removed with the `rmbartack` macro.  For this removal to
+work, and id must be set in the macro, and it must be passed when removing the
+macro.
+
+For macros that are typically used once per part (such as the `title` macro)
+you can rely on the default id.  For macros typically used multiple times (such
+as the various dimension macros) you should set an id that is unique within the
+part for each invocation.
+
 ## Macros we maintain
 
 Below is a list of macros from [the plugins we maintain](/reference/plugins).

--- a/markdown/dev/reference/macros/title/en.md
+++ b/markdown/dev/reference/macros/title/en.md
@@ -11,17 +11,26 @@ part of [core-plugins](/reference/plugins/core) (so it is available by default).
 
 ```js
 macro('title', {
-  String id = 'title',
-  String align,
-  Boolean append,
+  String align = 'left',
+  Boolean append = false,
   Point at,
-  Boolean cutlist
-  String nr,
-  String prefix,
-  Number rotation,
-  Number scale,
-  String title,
+  String brand = 'FreeSewing',
+  Boolean cutlist = true,
+  Number dy = 8,
   Boolean force = false,
+  String id = 'title',
+  Mixed notes = false,
+  String nr,
+  Number rotation = 0,
+  Number scale = 1,
+  String title = 'plugin-annotations:noName',
+  classes = {
+    String date: 'text-sm fill-current',
+    String name: 'fill-note',
+    String notes: 'text-md fill-current',
+    String nr: 'text-4xl fill-note font-bold',
+    String title: 'text-lg fill-current font-bold',
+  }
 })
 ```
 
@@ -34,7 +43,7 @@ macro('title', {
   // This is where name/version/etc. is supposed to be stored
   store.set('data.version', 3)
   store.set('data.name', 'Example')
-  store.set('data.for', 'Person')
+  store.set('data.for', 'Sorcha')
 
   macro('title', {
     nr: 9,
@@ -45,7 +54,7 @@ macro('title', {
   // Prevent clipping
   paths.diag = new Path()
     .move(new Point(-20,-50))
-    .move(new Point(80,35))
+    .move(new Point(120,35))
 
   return part
 }
@@ -56,19 +65,30 @@ macro('title', {
 
 | Property   | Default | Type                | Description |
 | ----------:| :-----: | ------------------- | ----------- |
-| `align'    | 'left'  | String              | Horizontal text alignment. Valid values: 'left', 'right', 'center' |
-| `append`   | `false` | Boolean             | Set this to `true` to append the `nr` to any text already set in Point `at`'s attributes, rather than overwrite it |
+| `align`    | `left`  | String              | Horizontal text alignment. One of `left`, `right`, or `center` |
+| `append`   | `false` | Boolean             | Set this to `true` to append the `nr`, rather than overwrite it |
 | `at`       |         | [Point](/reference/api/point) | The point at which to insert the title |
-| `cutlist`  | `true`  | Boolean             | Whether to include cutting instructions |
-| `id`       | `title` | `string` | The ID of this macro instance |
+| `brand`    | `FreeSewing`  | String | Brand name will prefix the design name |
+| `classes.date`  | `text-sm fill-current`  | String | CSS classes for the date |
+| `classes.name`  | `fill-note`  | String | CSS classes for the name |
+| `classes.notes`  | `text-md fill-current`  | String | CSS classes for the notes |
+| `classes.nr`  | `text-4xl fill-note font-bold`  | String | CSS classes for the nr |
+| `classes.title`  | `text-lg fill-current font-bold`  | String | CSS classes for the title |
+| `cutlist`  | `true`  | Boolean             | Set this to `true` to prepend notes with the cutting instructions |
+| `dy`       | `8`     | Number              | SVG-equivalent of line height, controls the vertical spacing between text lines |
+| `force`    | `false` | `boolean`           | Set this to `true` to display the macro output even when `complete` is `false` |
+| `id`       | `title` | `string` | The ID of this macro instance. See [Removing macros and the role of the macro id](/reference/macros#removing-macros-and-the-role-of-the-macro-id) |
+| `notes`    | | String | Any notes to go under the title |
 | `nr`       |         | String              | The number of the pattern part |
-| `title`    |         | String              | The name of the pattern part. If title is not set or is an empty string, this won't be rendered, and the version will go beneath the nr.|
+| `rotation` | `0`     | Number              | Rotation in degrees |
+| `scale`    | 1       | Number              | An optional scaling factor to make the title bigger/smaller |
+| `title`    | `plugin-annotations:noName` | String | The name of the pattern part |
 | `prefix`   |         | String              | A prefix to add to the created points. This allow for more than 1 title per part, as long as you give them a different prefix.|
-| `rotation` | 0       | Number | An optional rotation in degrees |
-| `scale`    | 1       | Number | An optional scaling factor |
-| `force`      | `false`    | `boolean`  | Set this to `true` to display the macro output even when `complete` is `false` |
+
 
 ## Notes
 
-This macro takes the `complete` setting into account and won't output anything when both complete and `force` are `false`.
+- This macro takes the `complete` setting into account and won't output anything when both complete and `force` are `false`.
+- This macro will check the value of `store.version` and `store.name` for the design version and name. These are auto-set by core.
+- This macro will check the value of `store.for` for info of who this pattern was generated for. This is something to be done at run-time by your frontend.
 

--- a/markdown/dev/reference/macros/title/en.md
+++ b/markdown/dev/reference/macros/title/en.md
@@ -46,15 +46,25 @@ macro('title', {
   store.set('data.for', 'Sorcha')
 
   macro('title', {
-    nr: 9,
-    title: 'The title',
-    at: new Point(0,0)
+    nr: 8,
+    title: 'The Title',
+    at: new Point(0,0),
+    brand: 'Bazooka Crew',
+    notes: [
+      "You can use any brand you want",
+      "\n",
+      "but if you plan to contribute your",
+      "\n",
+      "design, you should use the default",
+      "\n",
+      "(btw: These are the notes)"
+    ]
   })
 
   // Prevent clipping
   paths.diag = new Path()
     .move(new Point(-20,-50))
-    .move(new Point(120,35))
+    .move(new Point(120,55))
 
   return part
 }

--- a/packages/react-components/src/pattern/utils.mjs
+++ b/packages/react-components/src/pattern/utils.mjs
@@ -71,7 +71,8 @@ export const getId = ({
 export const translateStrings = (t, list) => {
   let translated = ''
   for (const string of list) {
-    if (string) translated += t(string.toString()).replace(/&quot;/g, '"') + ' '
+    if (Array.isArray(string)) translated += translateStrings(t, string)
+    else if (string) translated += t(string.toString()).replace(/&quot;/g, '"') + ' '
   }
 
   return translated

--- a/plugins/plugin-annotations/src/title.mjs
+++ b/plugins/plugin-annotations/src/title.mjs
@@ -1,3 +1,6 @@
+const capitalize = (string) =>
+  typeof string === 'string' ? string.charAt(0).toUpperCase() + string.slice(1) : ''
+
 /*
  * Defaults for the title macro
  */
@@ -12,10 +15,10 @@ const macroDefaults = {
   rotation: 0,
   scale: 1,
   title: 'plugin-annotations:noName',
+  notes: false,
   classes: {
-    cutlist: 'text-md fill-current',
+    notes: 'text-md fill-current',
     date: 'text-sm fill-current',
-    for: 'fill-current font-bold',
     name: 'fill-note',
     nr: 'text-4xl fill-note font-bold',
     title: 'text-lg fill-current font-bold',
@@ -74,9 +77,8 @@ const title = function (config, { Point, points, scale, locale, store, part, log
 
   /*
    * Get the list of IDs
-   * Initialize the verticle cadence
    */
-  const ids = store.generateMacroIds(['cutlist', 'date', 'for', 'name', 'nr', 'title'], mc.id)
+  const ids = store.generateMacroIds(['nr', 'date', 'title', 'name', 'notes'], mc.id)
 
   let shift = mc.dy
 
@@ -94,24 +96,63 @@ const title = function (config, { Point, points, scale, locale, store, part, log
   } else delete ids.nr
 
   /*
+   * Title: date
+   */
+  points[ids.date] = mc.at
+    .shift(-90, shift / 2)
+    .addText(
+      new Date().toLocaleString(locale || 'en', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      }),
+      `${mc.classes.date} ${mc.align}`
+    )
+    .attr('data-text-transform', transform)
+    .attr('data-render-always', 1) // Render even when outside the part bounding box
+  shift += mc.dy
+
+  /*
    * Title: title
    */
   if (mc.title) {
     points[ids.title] = mc.at
       .clone()
       .shift(-90, shift)
-      .attr('data-text', mc.title, mc.append ? false : true)
-      .attr('data-text-class', `${mc.classes.title} ${mc.align}`)
       .attr('data-text-transform', transform)
       .attr('data-render-always', 1) // Render even when outside the part bounding box
+    if (mc.append) points[ids.title].addText(mc.title, `${mc.classes.title} ${mc.align}`)
+    else points[ids.title].setText(mc.title, `${mc.classes.title} ${mc.align}`)
     shift += mc.dy
     store.set(['partTitles', part.name], mc.title)
   } else delete ids.title
 
   /*
-   * Title: cutlist
+   * Title: name
    */
+  points[ids.name] = mc.at
+    .clone()
+    .shift(-90, shift)
+    .addText(
+      `FreeSewing ${capitalize(
+        (store.data?.name || 'plugin-annotations:noName').replace('@freesewing/', '')
+      )} v${store.data?.version || 'plugin-annotations:noVersion'} ( `,
+
+      `${mc.classes.name} ${mc.align}`
+    )
+    .addText(store.data?.for ? store.data.for : 'ephemeral')
+    .addText(' )')
+    .attr('data-text-transform', transform)
+    .attr('data-render-always', 1) // Render even when outside the part bounding box
+  shift += mc.dy
+
+  /*
+   * Title: notes
+   */
+  const notes = []
   if (mc.cutlist) {
+    points[ids.notes] = mc.at.clone().shift(-90, shift)
     /*
      * Get cutlist instructions from the store, only proceed if the list is available
      */
@@ -123,92 +164,37 @@ const title = function (config, { Point, points, scale, locale, store, part, log
       for (const [material, instructions] of Object.entries(partCutlist.materials)) {
         instructions.forEach(({ cut, identical, onBias, onFold }, c) => {
           /*
-           * Create point
+           * Concat line
            */
-          const id = `${ids.cutlist}_${material}_${c}`
-          ids[`cutlist_${material}_${c}`] = id
-          points[id] = mc.at
-            .clone()
-            .shift(-90, shift)
-            .attr('data-text', 'plugin-annotations:cut')
-            .attr('data-text-class', `${mc.classes.cutlist} ${mc.align}`)
-            .attr('data-text-transform', transform)
-            .attr('data-render-always', 1) // Render even when outside the part bounding box
-            .addText(cut)
-          shift += mc.dy
-
-          /*
-           * Add instructions if parts are mirrored
-           */
-          if (!identical && cut > 1) points[id].addText('plugin-annotations:mirrored')
-
-          /*
-           * Add instructions if parts are cut on fold
-           */
+          notes.push('plugin-annotations:cut')
+          notes.push(cut)
+          if (!identical && cut > 1) notes.push('plugin-annotations:mirrored')
           if (onFold)
-            points[id].addText(
-              onBias ? 'plugin-annotations:onFoldAndBias' : 'plugin-annotations:onFold'
-            )
+            notes.push(onBias ? 'plugin-annotations:onFoldAndBias' : 'plugin-annotations:onFold')
+          else if (onBias) notes.push('plugin-annotations:onBias')
+          notes.push('plugin-annotations:from', 'plugin-annotations:' + material)
           /*
-           * Add instructions if parts on on bias
-           */ else if (onBias) points[id].addText('plugin-annotations:onBias')
-
-          /*
-           * Add 'from' (material) text
+           * Force a line break between materials
            */
-          points[id].addText('plugin-annotations:from').addText('plugin-annotations:' + material)
+          notes.push('\n')
         })
       }
     }
-  } else delete ids.cutlist
-
-  /*
-   * Title: Design name
-   */
-  points[ids.name] = mc.at
-    .clone()
-    .shift(-90, shift)
-    .attr(
-      'data-text',
-      `${(store.data?.name || 'plugin-annotations:noName').replace('@freesewing/', '')} v${
-        store.data?.version || 'plugin-annotations:noVersion'
-      }`
-    )
-    .attr('data-text-class', `${mc.classes.name} ${mc.align}`)
-    .attr('data-text-transform', transform)
-    .attr('data-render-always', 1) // Render even when outside the part bounding box
-  shift += mc.dy
-
-  /*
-   * Title: For (measurements set)
-   */
-  if (store.data.for) {
-    points[ids.for] = mc.at
-      .shift(-90, shift)
-      .attr('data-text', `(${store.data.for})`)
-      .attr('data-text-class', `${mc.classes.for} ${mc.align}`)
+  }
+  if (mc.notes) {
+    if (Array.isArray(notes)) notes.push(...mc.notes)
+    else notes.push(mc.notes)
+  }
+  if (notes.length > 0) {
+    /*
+     * Add all text on a single point
+     */
+    points[ids.notes]
+      .addText(notes, `${mc.classes.notes} ${mc.align}`)
       .attr('data-text-transform', transform)
       .attr('data-render-always', 1) // Render even when outside the part bounding box
-    shift += mc.dy
-  } else delete ids.for
-
-  /*
-   * Title: Date
-   */
-  points[ids.date] = mc.at
-    .shift(-90, shift)
-    .attr(
-      'data-text',
-      new Date().toLocaleString(locale || 'en', {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-      })
-    )
-    .attr('data-text-class', `${mc.classes.date} ${mc.align}`)
-    .attr('data-text-transform', transform)
-    .attr('data-render-always', 1) // Render even when outside the part bounding box
+      .attr('data-text-lineheight', mc.dy)
+  } else delete ids.cutlist
 
   /*
    * Store all IDs in the store so we can remove this macro with rmtitle

--- a/plugins/plugin-annotations/src/title.mjs
+++ b/plugins/plugin-annotations/src/title.mjs
@@ -182,7 +182,7 @@ const title = function (config, { Point, points, scale, locale, store, part, log
     }
   }
   if (mc.notes) {
-    if (Array.isArray(notes)) notes.push(...mc.notes)
+    if (Array.isArray(mc.notes)) notes.push(...mc.notes)
     else notes.push(mc.notes)
   }
   if (notes.length > 0) {

--- a/plugins/plugin-annotations/src/title.mjs
+++ b/plugins/plugin-annotations/src/title.mjs
@@ -16,6 +16,7 @@ const macroDefaults = {
   scale: 1,
   title: 'plugin-annotations:noName',
   notes: false,
+  brand: 'FreeSewing',
   classes: {
     notes: 'text-md fill-current',
     date: 'text-sm fill-current',
@@ -135,14 +136,14 @@ const title = function (config, { Point, points, scale, locale, store, part, log
     .clone()
     .shift(-90, shift)
     .addText(
-      `FreeSewing ${capitalize(
+      `${mc.brand} ${capitalize(
         (store.data?.name || 'plugin-annotations:noName').replace('@freesewing/', '')
-      )} v${store.data?.version || 'plugin-annotations:noVersion'} ( `,
+      )} v${store.data?.version || 'plugin-annotations:noVersion'} (`,
 
       `${mc.classes.name} ${mc.align}`
     )
     .addText(store.data?.for ? store.data.for : 'ephemeral')
-    .addText(' )')
+    .addText(')')
     .attr('data-text-transform', transform)
     .attr('data-render-always', 1) // Render even when outside the part bounding box
   shift += mc.dy
@@ -162,7 +163,7 @@ const title = function (config, { Point, points, scale, locale, store, part, log
        * Iterate over materials
        */
       for (const [material, instructions] of Object.entries(partCutlist.materials)) {
-        instructions.forEach(({ cut, identical, onBias, onFold }, c) => {
+        instructions.forEach(({ cut, identical, onBias, onFold }) => {
           /*
            * Concat line
            */

--- a/plugins/plugin-annotations/tests/title.test.mjs
+++ b/plugins/plugin-annotations/tests/title.test.mjs
@@ -39,12 +39,12 @@ describe('Title Plugin Tests', () => {
     expect(p.attributes.get('data-text')).to.equal('unitTest')
     expect(p.attributes.get('data-text-class')).to.equal('text-lg fill-current font-bold left')
     expect(p.attributes.get('data-text-x')).to.equal('-12')
-    expect(p.attributes.get('data-text-y')).to.equal('-26')
+    expect(p.attributes.get('data-text-y')).to.equal('-18')
     p = pattern.parts[0].test.points.__macro_title_title_name
-    expect(p.attributes.get('data-text')).to.equal('testPattern v99')
+    expect(p.attributes.get('data-text')).to.equal('FreeSewing TestPattern v99 ( ephemeral )')
     expect(p.attributes.get('data-text-class')).to.equal('fill-note left')
     expect(p.attributes.get('data-text-x')).to.equal('-12')
-    expect(p.attributes.get('data-text-y')).to.equal('-18')
+    expect(p.attributes.get('data-text-y')).to.equal('-10')
     p = pattern.parts[0].test.points.__macro_title_title_date
     expect(p.attributes.get('data-text')).to.include(', 202')
   })
@@ -117,12 +117,12 @@ describe('Title Plugin Tests', () => {
     expect(p.attributes.get('data-text')).to.equal('unitTest')
     expect(p.attributes.get('data-text-class')).to.equal('text-lg fill-current font-bold left')
     expect(p.attributes.get('data-text-x')).to.equal('-12')
-    expect(p.attributes.get('data-text-y')).to.equal('-26')
+    expect(p.attributes.get('data-text-y')).to.equal('-18')
     p = pattern.parts[0].test.points.__macro_title_foo_name
-    expect(p.attributes.get('data-text')).to.equal('testPattern v99')
+    expect(p.attributes.get('data-text')).to.equal('FreeSewing TestPattern v99 ( ephemeral )')
     expect(p.attributes.get('data-text-class')).to.equal('fill-note left')
     expect(p.attributes.get('data-text-x')).to.equal('-12')
-    expect(p.attributes.get('data-text-y')).to.equal('-18')
+    expect(p.attributes.get('data-text-y')).to.equal('-10')
   })
 
   it('Should run the title macro with custom alignment', () => {
@@ -208,5 +208,64 @@ describe('Title Plugin Tests', () => {
       'text-lg fill-current font-bold left'
     )
     expect(p.__macro_title_title_name.attributes.get('data-text-class')).to.equal('fill-note left')
+  })
+
+  it('Should run the title macro with notes', () => {
+    const notes = 'These are the notes\nHere are some more notes'
+    const part = {
+      name: 'test',
+      draft: ({ points, Point, macro, part }) => {
+        points.anchor = new Point(-12, -34)
+        macro('title', {
+          at: points.anchor,
+          nr: 3,
+          title: 'unitTest',
+          notes,
+        })
+
+        return part
+      },
+      plugins: [annotationsPlugin],
+    }
+    // Note that we're not loading core plugins but the local plugin
+    const Pattern = new Design({
+      data: { name: 'testPattern', version: 99 },
+      parts: [part],
+      noCorePlugins: true,
+    })
+    const pattern = new Pattern()
+    pattern.draft().render()
+    let p = pattern.parts[0].test.points.__macro_title_title_notes
+    expect(p.attributes.get('data-text')).to.equal(notes)
+  })
+
+  it('Should run the title macro with a custom brand', () => {
+    const brand = 'Bazooka Patterns'
+    const part = {
+      name: 'test',
+      draft: ({ points, Point, macro, part }) => {
+        points.anchor = new Point(-12, -34)
+        macro('title', {
+          at: points.anchor,
+          nr: 3,
+          title: 'unitTest',
+          brand,
+          id: 'foo',
+        })
+
+        return part
+      },
+      plugins: [annotationsPlugin],
+    }
+    // Note that we're not loading core plugins but the local plugin
+    const Pattern = new Design({
+      data: { name: 'testPattern', version: 99 },
+      parts: [part],
+      noCorePlugins: true,
+    })
+    const pattern = new Pattern()
+    pattern.draft().render()
+    let p = pattern.parts[0].test.points.__macro_title_foo_name
+    expect(p.attributes.get('data-text')).to.equal(`${brand} TestPattern v99 ( ephemeral )`)
   })
 })

--- a/plugins/plugin-i18n/src/index.mjs
+++ b/plugins/plugin-i18n/src/index.mjs
@@ -1,25 +1,34 @@
 import { name, version } from '../data.mjs'
 
+const translate = (locale, text, t, pattern) => {
+  let translated = ''
+  /*
+   * Call oneself recursively if text is an array
+   */
+  if (Array.isArray(text))
+    return text.map((string) => translate(locale, string, t, pattern)).join(' ')
+
+  if (t instanceof Function) return t(text, locale)
+  else if (typeof t[locale] === 'object') return t[locale][text] || text
+  else {
+    const msg =
+      "No translation method or object was passed to the i18n plugin. This plugin won't do anything without that"
+    if (pattern?.store?.log?.warn) {
+      if (!pattern.store.get(['plugins', 'plugin-i18n', 'missingMethodWarning'])) {
+        pattern.store.set(['plugins', 'plugin-i18n', 'missingMethodWarning'], true)
+        pattern.store.log.warn(msg)
+      }
+    } else console.log(msg)
+
+    return text
+  }
+}
+
 export const plugin = {
   name,
   version,
   hooks: {
-    insertText: (locale, text, t, pattern) => {
-      if (t instanceof Function) return t(text, locale)
-      else if (typeof t[locale] === 'object') return t[locale][text] || text
-      else {
-        const msg =
-          "No translation method or object was passed to the i18n plugin. This plugin won't do anything without that"
-        if (pattern?.store?.log?.warn) {
-          if (!pattern.store.get(['plugins', 'plugin-i18n', 'missingMethodWarning'])) {
-            pattern.store.set(['plugins', 'plugin-i18n', 'missingMethodWarning'], true)
-            pattern.store.log.warn(msg)
-          }
-        } else console.log(msg)
-
-        return text
-      }
-    },
+    insertText: (locale, text, t, pattern) => translate(locale, text, t, pattern),
   },
 }
 

--- a/plugins/plugin-i18n/src/index.mjs
+++ b/plugins/plugin-i18n/src/index.mjs
@@ -1,7 +1,6 @@
 import { name, version } from '../data.mjs'
 
 const translate = (locale, text, t, pattern) => {
-  let translated = ''
   /*
    * Call oneself recursively if text is an array
    */

--- a/sites/shared/components/tabs.mjs
+++ b/sites/shared/components/tabs.mjs
@@ -32,28 +32,25 @@ export const Tabs = ({ tabs = '', active = 0, children, withModal = false }) => 
           }`
 
           return withModal && activeTab === tabId ? (
-            <div className={`flex flex-row justify-between w-1/${tablist.length}`}>
-              <button key={tabId} className={btnClasses} onClick={() => setActiveTab(tabId)}>
-                {title}
-              </button>
-              <button
-                className={`${btnClasses} px-0`}
-                onClick={() =>
-                  setModal(
-                    <ModalWrapper
-                      flex="col"
-                      justify="top lg:justify-center"
-                      slideFrom="right"
-                      fullWidth
-                    >
-                      {childrenWithTabSetter}
-                    </ModalWrapper>
-                  )
-                }
-              >
-                <KioskIcon className="w-6 h-6 hover:text-secondary" />
-              </button>
-            </div>
+            <button
+              key={tabId}
+              className={btnClasses}
+              onClick={() =>
+                setModal(
+                  <ModalWrapper
+                    flex="col"
+                    justify="top lg:justify-center"
+                    slideFrom="right"
+                    fullWidth
+                  >
+                    {childrenWithTabSetter}
+                  </ModalWrapper>
+                )
+              }
+            >
+              <span className="pr-2">{title}</span>
+              <KioskIcon className="w-6 h-6 hover:text-secondary" />
+            </button>
           ) : (
             <button key={tabId} className={btnClasses} onClick={() => setActiveTab(tabId)}>
               {title}

--- a/sites/shared/styles/globals.css
+++ b/sites/shared/styles/globals.css
@@ -73,10 +73,10 @@
     @apply pl-2 lg:pl-4 list-decimal list-inside text-base-content;
   }
   .mdx code {
-    @apply bg-neutral-content px-2 rounded text-neutral font-mono font-bold;
+    @apply bg-base-300 px-1.5 text-base-content font-mono font-medium bg-opacity-10 py-0.5 border-base-content rounded border;
   }
   .mdx pre code {
-    @apply bg-inherit;
+    @apply bg-inherit border-0;
   }
   .mdx a.heading-autolink {
     color: currentColor;


### PR DESCRIPTION
This started out as a fix for #5753 after I felt the approach in #5760 was not the best way to handle this.

The problem lies in the way the cutlist data is added to the pattern by the title plugin. The whole cutlist thing was added by a less experienced contributor, and they were a little too focussed on what they were trying to accomplish, rather than keeping an eye on the big picture.

In this case, a bunch of points get added to the part to anchor all of the text for the cutlist. This causes problems when inheriting parts because points are added per material, and now we don't know what materials were used and how to remove these points.

I appreciate @woutervdub effort to resolve this in #5760 but as I mentioned above, I don't love the approach.
Rather than finding a clever way to remove these points, I am of the opinion that they should never have been added in the first place.

Specifically, all we are doing is adding one or more lines of text. The idea that you need multiple points for this is an incorrect assumption, and therein lies the root of this problem.

So, this refactor adds support to the title macro for 'notes'. These notes will be added below the title. The cutlist info is now just prepended to the notes. So it stops being something 'special' (which it never should have been) and instead just behaves like other text that is placed on the part by the title macro.

The only flanking measure required to make this happen was to add support for nested arrays in handling text.
This way, you can pass a nested array to concatenate strings in such a way that each part will still be individually translated.

And as all text in FreeSewing, to force a linebreak, you just use "\n" as The Dark Lord intended.