### PR TITLE
fix(markdown): Typos in pattern design tutorial

### DIFF
--- a/markdown/dev/tutorials/pattern-design/part1/nodejs/en.md
+++ b/markdown/dev/tutorials/pattern-design/part1/nodejs/en.md
@@ -9,7 +9,7 @@ precise. You can switch this website theme from light to dark mode, and
 that would not work without JavaScript.
 
 As a **user** of FreeSewing, this is all you need. To develop with FreeSewing
-you are going to need to be able to run JavaScript *outside* the browswer using
+you are going to need to be able to run JavaScript *outside* the browser using
 a JavaScript *runtime*. Which just means a thing that can *run* JavaScript.
 
 We are going to be using [NodeJS](https://nodejs.org/) in this tutorial. It is

--- a/markdown/dev/tutorials/pattern-design/part1/sde/en.md
+++ b/markdown/dev/tutorials/pattern-design/part1/sde/en.md
@@ -41,7 +41,7 @@ It allows you to choose a design template to start from. The following templates
 For the following along this tutorial, you have two options:
 
 - Pick **Tutorial** if you prefer to read along, make small changes, and see how they affect the design.
-- Pick **From scratch** if you prefer to actively participate in recreating the design in this tutorial.
+- Pick **From scratch** if you prefer to actively participate by recreating the design in this tutorial.
 
 I recommend the latter. You will learn (and remember) a lot more if you are actively engaging.
 

--- a/markdown/dev/tutorials/pattern-design/part1/sde/en.md
+++ b/markdown/dev/tutorials/pattern-design/part1/sde/en.md
@@ -24,11 +24,11 @@ From left to right you can see:
 
 ## Design templates
 
-If you click he **Design** icon it will show this menu:
+If you click the **Design** icon it will show this menu:
 
 ![Design templates provided by the FreeSewing development environment](./templates.png)
 
-It allows you to choose a desing template to start from. The following templates are included:
+It allows you to choose a design template to start from. The following templates are included:
 
 - **From scratch**: Start with an (almost) empty design
 - **Tutorial**: Start with the end result of this very tutorial
@@ -41,7 +41,7 @@ It allows you to choose a desing template to start from. The following templates
 For the following along this tutorial, you have two options:
 
 - Pick **Tutorial** if you prefer to read along, make small changes, and see how they affect the design.
-- Pick **From scratch** if you prefer to actively participate be recreating the desing in this tutorial.
+- Pick **From scratch** if you prefer to actively participate in recreating the design in this tutorial.
 
-I recommend the latter. You will learn (and remember) a lot more if you are activele engaging.
+I recommend the latter. You will learn (and remember) a lot more if you are actively engaging.
 

--- a/markdown/dev/tutorials/pattern-design/part1/structure/en.md
+++ b/markdown/dev/tutorials/pattern-design/part1/structure/en.md
@@ -4,9 +4,9 @@ order: 40
 ---
 
 Inside the `freesewing` folder -- which might have a different name if that is
-the choice you made -- you will find a bunch of files and folders.  
+the choice you made -- you will find a bunch of files and folders.
 
-The one that matter is the `design` folder. In it, you will find the followin
+The one that matter is the `design` folder. In it, you will find the following
 subfolders:
 
 - `from-bella`

--- a/markdown/dev/tutorials/pattern-design/part2/adding-measurements/en.md
+++ b/markdown/dev/tutorials/pattern-design/part2/adding-measurements/en.md
@@ -21,7 +21,7 @@ So let's add it as a required measurement.
 In our `src/bib.mjs` file, we will add a `measurements` property to the `bib` object.
 This property will be an Array (a list) holding all required measurements for this part.
 
-I am usign [*the official name* of the measurement](/reference/measurements) here. For head
+I am using [*the official name* of the measurement](/reference/measurements) here. For head
 circumference, that name is `head`.
 
 ```src/bib.mjs

--- a/markdown/dev/tutorials/pattern-design/part2/adding-options/en.md
+++ b/markdown/dev/tutorials/pattern-design/part2/adding-options/en.md
@@ -49,7 +49,7 @@ Can you guess what it means?
 
 - We've added the `options` property to our `bib` object
 - On the `options` property, we have added `neckRatio` which holds the configuration for our option
-- It is a `pct` option -- whcih means it's a percentage
+- It is a `pct` option -- which means it's a percentage
 - Its default value is 90%
 - Its minimum value is 70%
 - Its maximum value is 90%

--- a/markdown/dev/tutorials/pattern-design/part2/conclusion/en.md
+++ b/markdown/dev/tutorials/pattern-design/part2/conclusion/en.md
@@ -12,7 +12,7 @@ including some more advanced things like rotating a bunch of them out of the
 way.
 
 You've also learned how to draw paths, which are the lines and curves that make up our pattern.
-And we've used macros which can help us with repetetive tasks.
+And we've used macros which can help us with repetitive tasks.
 
 What we've gotten so far is a perfectly suitable sewing pattern. You can print this, 
 and make a nice bib out of it.

--- a/markdown/dev/tutorials/pattern-design/part2/draft-method/en.md
+++ b/markdown/dev/tutorials/pattern-design/part2/draft-method/en.md
@@ -88,7 +88,7 @@ Here's a brief summary of the things we've added above:
 - `points`: A container object to hold the part's points
 - `paths`: A container object to hold the part's paths
 
-<Tip compact>Remember: Constructures start with a **C**apital letter</Tip>
+<Tip compact>Remember: Constructors start with a **C**apital letter</Tip>
 
 Long story short: These will make it possible for us to draw points and paths easily.
 

--- a/markdown/dev/tutorials/pattern-design/part3/annotations/en.md
+++ b/markdown/dev/tutorials/pattern-design/part3/annotations/en.md
@@ -263,7 +263,7 @@ The `title` and `scalebox` macros to be precise.
 Before we add the title, we will also set the cutlist via a method that was added to the
 store by one of the core plugins.
 
-As a matter of fact, all of these snippets, macros, and store methods are provided by plugings.
+As a matter of fact, all of these snippets, macros, and store methods are provided by plugins.
 For more details, [refer to the plugin guide](/guides/plugins).
 
 <Example previewFirst tutorial caption="This looks way better">

--- a/markdown/dev/tutorials/pattern-design/part3/complete/en.md
+++ b/markdown/dev/tutorials/pattern-design/part3/complete/en.md
@@ -7,7 +7,7 @@ Laser cutters is merely an example of a situation where your user wants not the
 complete detailed pattern with all annotations, but just the outlines.
 Essentially what we had at the end of part 2 of this tutorial.
 
-Since then, we've added a bunch of embellisments, and perhaps the user does 
+Since then, we've added a bunch of embellishments, and perhaps the user does 
 not want those.
 
 Well, good news: there is a setting for that too. That setting is `complete`, 

--- a/markdown/dev/tutorials/pattern-design/part3/flag/en.md
+++ b/markdown/dev/tutorials/pattern-design/part3/flag/en.md
@@ -336,5 +336,3 @@ function draftBib({
 }
 ```
 </Example>
-
-Now the first thing you should know is: **core does not care**. We are

--- a/markdown/dev/tutorials/pattern-design/part3/menu/en.md
+++ b/markdown/dev/tutorials/pattern-design/part3/menu/en.md
@@ -7,7 +7,7 @@ Strictly speaking, this tutorial is about learning to use FreeSewing's core
 library to do parametric design, and we made great strides in that regard.
 
 But FreeSewing is a lot more than its core library, and you might be wondering
-how your pattern options magically end up in the development environmnt under
+how your pattern options magically end up in the development environment under
 **Design options**:
 
 ![Design options menu](./options.png)
@@ -29,7 +29,7 @@ options: {
 It's just a silly example, but there's two important take-aways here:
 
 - You don't have to use options in your design. You can add options for things
-  that are not about the desing, but that you still want to capture the user's
+  that are not about the design, but that you still want to capture the user's
   input for (like shipping preferences in this case).
 - You can add extra properties to an option. Each option type has it's required
   properties. But you can add more and use them as you see fit.

--- a/markdown/dev/tutorials/pattern-design/part3/sa/en.md
+++ b/markdown/dev/tutorials/pattern-design/part3/sa/en.md
@@ -49,11 +49,11 @@ function draftBib({
 ```
 </Example>
 
-As you can see from the source, we can descructure an `sa` variable (short for
+As you can see from the source, we can destructure an `sa` variable (short for
 seam allowance) that will hold either:
 
 - `false` if the user does not want seam allowance
-- A value in `mm` indicating how much seam allwance the user wants
+- A value in `mm` indicating how much seam allowance the user wants
 
 To add seam allowance to our path, we just `offset` it by `sa` and add
 some classes to it to style it. But, crucially, only if the user wants

--- a/markdown/dev/tutorials/pattern-design/part3/tests/en.md
+++ b/markdown/dev/tutorials/pattern-design/part3/tests/en.md
@@ -58,7 +58,7 @@ option](test-option-lengthratio.png)
 
 ### neckRatio
 
-The `neckRatio` option will determine the size of the neck opening.  For a the
+The `neckRatio` option will determine the size of the neck opening.  For the
 same `head` measurement, varying this option should result in bibs with
 increasingly larger neck opening.
 


### PR DESCRIPTION
In `markdown/dev/tutorials/pattern-design/part3/flag/en.md` I deleted a line that seemed to be left over from editing. But, it may be that it was intended to be completed and included.