### PR TITLE
fix(github): Add noop jobs to workflows to prevent spurious notifications

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,12 @@
 name: Playwright Tests
+
+on: [push]
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo Noop.
+
 # While it's nice to test e2e tests, it's not all that useful to run them on alpha code
 #on:
 #  push:

--- a/.github/workflows/tests.new-design.yml
+++ b/.github/workflows/tests.new-design.yml
@@ -1,4 +1,12 @@
 name: Test new-design
+
+on: [push]
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo Noop.
+
   #on:
   #  push:
   #    branches:


### PR DESCRIPTION
Every time I sync my personal fork from freesewing/freesewing, GitHub sends me 2 workflow failure notifications:
```
.github/workflows/playwright.yml workflow run failed for develop branch
.github/workflows/tests.new-design.yml workflow run failed for develop branch
```

The failures and notifications occur because the content of the two workflows was commented out. Specifically, GitHub is expecting to see an `on:` section in the file:
```
[Error: .github#L1]
No event triggers defined in `on`
```

This fix adds noop jobs to the workflows as a temporary workaround. I imagine that eventually the workflows will be updated to work with v3. Or, perhaps they will be removed from the repository instead.

Edit: Added:

Or, perhaps this PR isn't necessary. I just found out that workflows can be disabled in GitHub via: https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow