### PR TITLE
chore(core): Remove options distance debug logging

### DIFF
--- a/packages/core/src/pattern/pattern-config.mjs
+++ b/packages/core/src/pattern/pattern-config.mjs
@@ -98,14 +98,17 @@ PatternConfig.prototype.addPart = function (part) {
 
 /** Log the final report on part inheritance order */
 PatternConfig.prototype.logPartDistances = function () {
-  const priorities = []
-  for (const partName in this.parts) {
+  const priorities = {}
+  for (const partName of Object.keys(this.parts)) {
     const p = this.__mutated.partDistance[partName]
-    if (p in priorities) priorities[p] += ', ' + partName
-    else priorities[p] = partName
+    if (typeof priorities[p] === 'undefined') priorities[p] = new Set()
+    priorities[p].add(partName)
   }
-  for (let p = 1; p < priorities.length; p++)
-    this.store.log.debug(`⚪️  Options priority __${p}__ :\`${priorities[p]}\``)
+  for (const p of Object.keys(priorities))
+    this.store.log.debug(
+      `⚪️  Options priority __${p}__ : ` +
+        `${[...priorities[p]].map((p) => '`' + p + '`').join(', ')}`
+    )
 }
 
 /**


### PR DESCRIPTION
In the 2022-11-12 Contributor Call, we agreed to remove the options distance debug logging code once v3 was released. This PR performs that chore and closes #3062.

Options distance information is still logged, but instead of individual messages for each part, things are now logged as a concise summary.

After:
![Screenshot 2024-01-20 at 7 45 42 PM](https://github.com/freesewing/freesewing/assets/109869956/b879b1e2-6fe5-4c2d-961e-591c9a2ccc0d)

Before:
![Screenshot 2024-01-20 at 7 45 29 PM](https://github.com/freesewing/freesewing/assets/109869956/0a2531bf-5381-4a49-9b54-97fce891e228)
