### PR TITLE
fix(yaml, markdown): Fix typos

### DIFF
--- a/markdown/dev/guides/faq/is-copying-ok/en.md
+++ b/markdown/dev/guides/faq/is-copying-ok/en.md
@@ -30,7 +30,7 @@ that's an indie designer who might be depending on the sales of their pattern
 to put food on the table or some big pattern company that you feel should be
 taken down a notch: It doesn't matter. Not cool. Don't do this.
 
-## Do you accept contributrion that are a copy of an existing garment?
+## Do you accept contributions that are a copy of an existing garment?
 
 Yes. 
 

--- a/markdown/dev/guides/markdown/jargon/en.md
+++ b/markdown/dev/guides/markdown/jargon/en.md
@@ -26,7 +26,7 @@ We are migrating from _cjs_ to _esm_ modules
 To add a new jargon term, you need to add it to the jargon file for the
 website you'd like to add it to:
 
-| Website | Jargon file | Github link |
+| Website | Jargon file | GitHub link |
 | ------- | ----------- | ----------- |
 | freesewing.dev | `sites/dev/jargon.mjs` | [jargon.mjs](https://github.com/freesewing/freesewing/blob/develop/sites/dev/jargon.mjs) |
 | freesewing.org | `sites/org/jargon.mjs` | [jargon.mjs](https://github.com/freesewing/freesewing/blob/develop/sites/org/jargon.mjs) |

--- a/markdown/dev/guides/translation/en.md
+++ b/markdown/dev/guides/translation/en.md
@@ -20,7 +20,7 @@ FreeSewing is currently available in the following languages:
 | `es` | **Spanish**    | https://es.freesewing.org/ |
 | `fr` | **French**     | https://fr.freesewing.org/ |
 | `nl` | **Dutch**      | https://nl.freesewing.org/ |
-| `uk` | **Ukranian**   | https://uk.freesewing.org/ |
+| `uk` | **Ukrainian**   | https://uk.freesewing.org/ |
 
 <Note compact>
 English is the translation source language and the working language of the FreeSewing project
@@ -48,7 +48,7 @@ Discord](https://discord.freesewing.org) for any questions that may remain.
 
 ## Adding a new language
 
-We would love to make FreeSewing available in more langauges. If you are
+We would love to make FreeSewing available in more languages. If you are
 interested in starting a new translation effort, that is great.
 
 We ask that you familiarize yourself with this translation guide to understand
@@ -124,7 +124,7 @@ The top-priority translations in Crowdin are everything under the `packages`
 and `sites` folder. Do this first.
 </Tip>
 
-### High priority: Translation of Documenation
+### High priority: Translation of Documentation
 This includes all the documentation on FreeSewing.org.
 
 This is a significant amount of text that makes up more than 90% of the top &
@@ -164,10 +164,10 @@ translate smaller snippets,
 
 Once translated, there is a proofreading step that will be handled by one of
 our proofreaders. This is often a formality, but it's an extra step to allow
-qulity assurance and avoid any mistakes from slipping in. Much like the code
+quality assurance and avoid any mistakes from slipping in. Much like the code
 review process when you submit a pull request on GitHub.
 
-Once your translation is approved, Crowdin will automatically submut a pull
+Once your translation is approved, Crowdin will automatically submit a pull
 request on GitHub to update the translation files in our repository. And the
 next time our website or software packages get build, they will include the new
 translations.
@@ -179,7 +179,7 @@ we also have to be realistic that the growing body of documentation and other
 FreeSewing content can be a daunting task to take on for translators, especially
 when you want to start a new language.
 
-Furtunately, machine translation has gotten rather good so we can get some help.
+Fortunately, machine translation has gotten rather good so we can get some help.
 Our Crowdin project is integrated with a [DeepL](https://www.deepl.com) 
 subscription, and this can be a great help to translators.
 

--- a/markdown/dev/howtos/code/adding-text/en.md
+++ b/markdown/dev/howtos/code/adding-text/en.md
@@ -23,7 +23,7 @@ To facilitate this, FreeSewing will enforce a line break when you use `\n` in yo
 Text that is added to a pattern typically requires translation. 
 You should break up your text in such a way that it remains possible to translate it.
 
-You can do that either via repeated calls to `addText()` or you can pass an array of strings, or even a nested array of strings, and FreeSewing will translate all individual pieces prior to contatenating them.
+You can do that either via repeated calls to `addText()` or you can pass an array of strings, or even a nested array of strings, and FreeSewing will translate all individual pieces prior to concatenating them.
 
 <Note compact noP>
 

--- a/markdown/dev/howtos/design/trace/en.md
+++ b/markdown/dev/howtos/design/trace/en.md
@@ -125,7 +125,7 @@ What we want is for our original pattern to be shown as the background of our de
 To do so, we needed to take a couple of steps:
 
 - Turn it into SVG: Because FreeSewing patterns are SVG
-- Turn it into a JavaSCript file: Because you can't `import` an SVG like that
+- Turn it into a JavaScript file: Because you can't `import` an SVG like that
 - Give it an `id`: So we can use that to reference it when adding the snippet
 - `import` the SVG into our part
 - Create a plugin to add it as a snippet

--- a/markdown/dev/howtos/ways-to-contribute/en.md
+++ b/markdown/dev/howtos/ways-to-contribute/en.md
@@ -40,7 +40,7 @@ us](https://discord.freesewing.org/).
 
 ##### Who wants a job in the tech sector?
 
-For many in our community, contributring to FreeSewing marked their
+For many in our community, contributing to FreeSewing marked their
 first steps into the world of open source software development.
 
 I (joost) am happy to provide guidance or mentorship to anyone who

--- a/markdown/dev/i18n/en.md
+++ b/markdown/dev/i18n/en.md
@@ -12,7 +12,7 @@ FreeSewing currently is available in the following languages:
 - French
 - Spanish
 - German
-- Ukranian
+- Ukrainian
 
 ## Translation guide
 

--- a/markdown/dev/reference/api/attributes/asrenderprops/en.md
+++ b/markdown/dev/reference/api/attributes/asrenderprops/en.md
@@ -3,7 +3,7 @@ title: Attributes.asRenderProps()
 ---
 
 The `Attributes.asRenderProps()` method will return the data stored in the
-attributes as a serializable Javascript object. This method is typically
+attributes as a serializable JavaScript object. This method is typically
 note invoked directly but rather called under the hood as a result of
 calling [`Pattern.getRenderProps()`](/reference/core/pattern/getrenderprops).
 
@@ -15,7 +15,7 @@ Object attributes.asRenderProps()
 
 ## Returned object properties
 
-This returns Javascript object has the following properties:
+This returns JavaScript object has the following properties:
 
 | Name | Description |
 | ----:| ----------- |

--- a/markdown/dev/reference/api/part/asrenderprops/en.md
+++ b/markdown/dev/reference/api/part/asrenderprops/en.md
@@ -4,7 +4,7 @@ title: Part.asRenderProps()
 
 
 The `Part.asRenderProps()` method will return the data stored in the
-part as a serializable Javascript object. This method is typically
+part as a serializable JavaScript object. This method is typically
 not invoked directly but rather called under the hood as a result of
 calling [`Pattern.getRenderProps()`](/reference/core/pattern/getrenderprops).
 
@@ -16,7 +16,7 @@ Object part.asRenderProps()
 
 ## Returned object properties
 
-This returns Javascript object has the following properties:
+This returns JavaScript object has the following properties:
 
 | Name | Description |
 | ----:| ----------- |

--- a/markdown/dev/reference/api/part/config/hide/en.md
+++ b/markdown/dev/reference/api/part/config/hide/en.md
@@ -60,7 +60,7 @@ const part = {
 
 ### hide.inherited
 
-To hide parts that you have not explicitly included in this part that may be pulled in by the explictly included `from` and `after` parts, set `hide.inherited` to a truthy value.
+To hide parts that you have not explicitly included in this part that may be pulled in by the explicitly included `from` and `after` parts, set `hide.inherited` to a truthy value.
 
 <Note>This setting will hide any part included as `from` or `after` by your explicitly included `from` part or its dependency chain. It will also hide any part included as `from` by your explicitly included `after` part or its dependency chain. It will not hide the `after` parts of `after` parts</Note>
 

--- a/markdown/dev/reference/api/part/draft/en.md
+++ b/markdown/dev/reference/api/part/draft/en.md
@@ -37,7 +37,7 @@ access the following properties:
 | `log`             | See [the logging documentation](/reference/api/store/log) |
 | `macro`           | See [the macros documentation](/reference/macros/) |
 | `store`           | See [the store documentation](/reference/api/store) |
-| `units`           | A version of [`utils.units()`](/reference/api/utils/units) that is preconfigured with the user's chosenunits |
+| `units`           | A version of [`utils.units()`](/reference/api/utils/units) that is preconfigured with the user's chosen units |
 | `utils`           | See [the utils documentation](/reference/api/utils) |
 | `Bezier`          | The [bezier-js](https://pomax.github.io/bezierjs/) library's `Bezier` named export |
 || **_Return value_**   |

--- a/markdown/dev/reference/api/path/asrenderprops/en.md
+++ b/markdown/dev/reference/api/path/asrenderprops/en.md
@@ -3,7 +3,7 @@ title: Path.asRenderProps()
 ---
 
 The `Path.asRenderProps()` method will return the data stored in the
-path as a serializable Javascript object. This method is typically
+path as a serializable JavaScript object. This method is typically
 not invoked directly but rather called under the hood as a result of
 calling [`Pattern.getRenderProps()`](/reference/core/pattern/getrenderprops).
 
@@ -15,7 +15,7 @@ Object path.asRenderProps()
 
 ## Returned object properties
 
-This returns Javascript object has the following properties:
+This returns JavaScript object has the following properties:
 
 | Name | Description |
 | ----:| ----------- |

--- a/markdown/dev/reference/api/point/asrenderprops/en.md
+++ b/markdown/dev/reference/api/point/asrenderprops/en.md
@@ -3,7 +3,7 @@ title: Point.asRenderProps()
 ---
 
 The `Point.asRenderProps()` method will return the data stored in the
-point as a serializable Javascript object. This method is typically
+point as a serializable JavaScript object. This method is typically
 not invoked directly but rather called under the hood as a result of
 calling [`Pattern.getRenderProps()`](/reference/core/pattern/getrenderprops).
 
@@ -15,7 +15,7 @@ Object point.asRenderProps()
 
 ## Returned object properties
 
-This returns Javascript object has the following properties:
+This returns JavaScript object has the following properties:
 
 | Name | Description |
 | ----:| ----------- |

--- a/markdown/dev/reference/api/snippet/asrenderprops/en.md
+++ b/markdown/dev/reference/api/snippet/asrenderprops/en.md
@@ -3,7 +3,7 @@ title: Snippet.asRenderProps()
 ---
 
 The `Snippet.asRenderProps()` method will return the data stored in the
-snippet as a serializable Javascript object. This method is typically
+snippet as a serializable JavaScript object. This method is typically
 not invoked directly but rather called under the hood as a result of
 calling [`Pattern.getRenderProps()`](/reference/core/pattern/getrenderprops).
 
@@ -15,7 +15,7 @@ Object snippet.asRenderProps()
 
 ## Returned object properties
 
-This returns Javascript object has the following properties:
+This returns JavaScript object has the following properties:
 
 | Name | Description |
 | ----:| ----------- |

--- a/markdown/dev/reference/api/store/en.md
+++ b/markdown/dev/reference/api/store/en.md
@@ -3,7 +3,7 @@ title: Store
 ---
 
 A **Store** object holds a simple key/value store with methods for storing and
-retrieving data. It is shared across the pattern, and is a the recommended way
+retrieving data. It is shared across the pattern, and is the recommended way
 to pass data between your parts.
 
 The store can also be extended with additional methods by plugins. Refer to

--- a/markdown/dev/reference/api/svg/asrenderprops/en.md
+++ b/markdown/dev/reference/api/svg/asrenderprops/en.md
@@ -3,7 +3,7 @@ title: Svg.asRenderProps()
 ---
 
 The `Svg.asRenderProps()` method will return the data stored in the
-svg as a serializable Javascript object. This method is typically
+svg as a serializable JavaScript object. This method is typically
 not invoked directly but rather called under the hood as a result of
 calling [`Pattern.getRenderProps()`](/reference/core/pattern/getrenderprops).
 
@@ -15,7 +15,7 @@ Object svg.asRenderProps()
 
 ## Returned object properties
 
-This returns Javascript object has the following properties:
+This returns JavaScript object has the following properties:
 
 | Name | Description |
 | ----:| ----------- |

--- a/markdown/dev/reference/api/utils/applytransformtopoint/en.md
+++ b/markdown/dev/reference/api/utils/applytransformtopoint/en.md
@@ -12,7 +12,7 @@ Point utils.applyTransformToPoint(string transform, Point A)
 
 ## Parameters
 
-1st parameter is a SVG transform string. Eg: `scale(sfx, sfy)` where `sfx` and `sfy` are the scaling factors along the x-axis and y-axis respectively.
+1st parameter is a SVG transform string. E.g.: `scale(sfx, sfy)` where `sfx` and `sfy` are the scaling factors along the x-axis and y-axis respectively.
 
 2nd parameter is the original point that is to be transformed. It is a [Point](/reference/api/point) object.
 

--- a/markdown/dev/reference/api/utils/generatestacktransform/en.md
+++ b/markdown/dev/reference/api/utils/generatestacktransform/en.md
@@ -19,13 +19,13 @@ Array generateStackTransform(
 
 ## Parameters
 
-The first and second paramter set the value of the *translate transform* along the X and Y axis in millimeter.
+The first and second parameters set the value of the *translate transform* along the X and Y axis in millimeter.
 In other words, it moves the stack.
 
 The third parameter sets the *rotate transform* in degrees.
 In other words, it rotates the stack.
 
-The fourth and fifth parameter flip the part along the X or Y axis respectively.
+The fourth and fifth parameters flip the part along the X or Y axis respectively.
 
 <Note compact>
 This is a low-level method to facilitate intervening in the pattern layout late in the draft process.

--- a/markdown/dev/reference/api/utils/linesintersect/en.md
+++ b/markdown/dev/reference/api/utils/linesintersect/en.md
@@ -2,7 +2,7 @@
 title: utils.linesIntersect()
 ---
 
-The `utils.linesInersect()` function finds the intersection between two line
+The `utils.linesIntersect()` function finds the intersection between two line
 segments. Returns a [Point](../point) object for the intersection, or `false`
 if the lines don't intersect.
 

--- a/markdown/dev/reference/api/utils/mergei18n/en.md
+++ b/markdown/dev/reference/api/utils/mergei18n/en.md
@@ -49,7 +49,7 @@ The configuration object takes 3 top-level properties:
 - `p`: Specifies configuration for how to merge the part name translations (under `p` in the translation files)
 - `o`: Specifies configuration for how to merge the option translations (under `p` in the translation files)
 
-For **each of the `s`, `p`, and `o` keys** you can specificy the followig properties:
+For **each of the `s`, `p`, and `o` keys** you can specify the following properties:
 
 - `drop`: An Array with the keys of entries to not merge (drop). Keys that are not in this array will be merged.
 - `keep`: An Array with the keys of entries to merge (keep). Keys that are not in this array will not be merged.

--- a/markdown/dev/reference/backend/people/en.md
+++ b/markdown/dev/reference/backend/people/en.md
@@ -18,7 +18,7 @@ for.
 
 ### The `measies` property holds measurements
 
-These measurments should be structured as an object that can be used for the
+These measurements should be structured as an object that can be used for the
 `measurements` key in the [pattern settings
 object](/reference/settings/measurements).
 

--- a/markdown/dev/reference/macros/rmbanner/en.md
+++ b/markdown/dev/reference/macros/rmbanner/en.md
@@ -13,4 +13,3 @@ part of [core-plugins](/reference/plugins/core) (so it is available by default).
 ```js
 macro('rmBanner', id = 'banner')
 ```
-  

--- a/markdown/dev/reference/macros/rmbartack/en.md
+++ b/markdown/dev/reference/macros/rmbartack/en.md
@@ -13,4 +13,3 @@ part of [core-plugins](/reference/plugins/core) (so it is available by default).
 ```js
 macro('rmBartack', id = 'bartack')
 ```
-  

--- a/markdown/dev/reference/sites/sanity/en.md
+++ b/markdown/dev/reference/sites/sanity/en.md
@@ -17,7 +17,7 @@ The Sanity content scheme is stored in `sites/sanity/schema` in our monorepo.
 We use two datasets:
 
 - `site-data` holds blog and showcase posts in all languages, as well as
-  newsletter editions. This dataset is publicly avaialble.
+  newsletter editions. This dataset is publicly available.
 - `user-data` holds images uploaded by users, such as for their account image,
   or measurements set image. This dataset is not publicly available.
 
@@ -35,7 +35,7 @@ so if you want to become an editor, you can ask joost to grant you access.
 
 ### Local development
 
-After setting up the monorepo with `yarn kickstart` in the root folder, change your working directoy to `sites/sanity` and run `yarn dev`:
+After setting up the monorepo with `yarn kickstart` in the root folder, change your working directory to `sites/sanity` and run `yarn dev`:
 
 ```sh
 git clone git@github.com:freesewing/freesewing.git

--- a/markdown/dev/reference/store-methods/cutlist.setcutonfold/en.md
+++ b/markdown/dev/reference/store-methods/cutlist.setcutonfold/en.md
@@ -1,7 +1,7 @@
 ---
 title: cutlist.setCutOnFold()
 ---
-The `cutlist.setCutOnFold()` method will take two points to determin the cut on fold line.
+The `cutlist.setCutOnFold()` method will take two points to determine the cut on fold line.
 
 This method is called internally by [the `cutonfold` macro](/reference/macros/cutonfold) to store information for cutting layout tools.
 In other words, you typically have no reason to call this method manually.

--- a/markdown/dev/reference/store-methods/cutlist.setgrain/en.md
+++ b/markdown/dev/reference/store-methods/cutlist.setgrain/en.md
@@ -2,7 +2,7 @@
 title: cutlist.setGrain()
 ---
 
-The `store.cutlist.setGrain()` method will take an angle to determin the grainline.
+The `store.cutlist.setGrain()` method will take an angle to determine the grainline.
 
 This method is called internally by [the `grainline` macro](/reference/macros/grainline).
 to store information for cutting layout tools.

--- a/markdown/dev/reference/store-methods/en.md
+++ b/markdown/dev/reference/store-methods/en.md
@@ -6,7 +6,7 @@ Store methods are typically provided by plugins and attached to
 the store to make them available during the drafting process.
 
 Some of FreeSewing's core library functionality is implemented 
-as store methods to allow plugins to override this functinoality.
+as store methods to allow plugins to override this functionality.
 Examples include log handling and pattern layout algorithm.
 
 All store methods below are either provided by plugins we maintain,

--- a/markdown/dev/reference/store-methods/flag.preset/en.md
+++ b/markdown/dev/reference/store-methods/flag.preset/en.md
@@ -17,7 +17,7 @@ is on or off respectively.
 undefined Store.flag.preset(string preset)
 ```
 
-Since these methods are not part of FreeSewing's core API, what you pass to this method does depend on your own implemntation.
+Since these methods are not part of FreeSewing's core API, what you pass to this method does depend on your own implementation.
 The example above is from our implementation, which uses the following properties:
 
 ## Configuration

--- a/markdown/dev/tutorials/pattern-design/part2/avoiding-overlap/en.md
+++ b/markdown/dev/tutorials/pattern-design/part2/avoiding-overlap/en.md
@@ -13,7 +13,7 @@ to rotate.
 
 However, there is a catch. 
 
-## Macros and auto-gerenated IDs
+## Macros and auto-generated IDs
 We have used the `round` macro to help us round the corners
 of our strap, and it added a bunch of auto-generated points to our pattern. We need to
 rotate these points too, but what are their names?

--- a/markdown/org/docs/about/faq/newsletter/why-subscribe-multiple-clicks/en.md
+++ b/markdown/org/docs/about/faq/newsletter/why-subscribe-multiple-clicks/en.md
@@ -30,7 +30,7 @@ That's where it would be over. Except for one technical detail that's also impor
 <Warning compact>This is more technical and harder to understand</Warning>
 
 Another reason is that while we could make it so that clicking the link in your 
-email would immeadiatly subcribe you, it would be in violation of internet standards.
+email would immediately subscribe you, it would be in violation of internet standards.
 Specifically, the __HTTP__ protocol's __GET method__ definition which states that:
 
 

--- a/markdown/org/docs/about/faq/newsletter/why-unsubscribe-multiple-clicks/en.md
+++ b/markdown/org/docs/about/faq/newsletter/why-unsubscribe-multiple-clicks/en.md
@@ -3,7 +3,7 @@ title: Why do I have to click again to confirm I want to unsubscribe from the ne
 ---
 
 While we could make it so that clicking the link in your 
-email would immeadiatly unsubcribe you, it would be in violation of internet standards.
+email would immediately unsubscribe you, it would be in violation of internet standards.
 Specifically, the __HTTP__ protocol's __GET method__ definition which states that:
 
 

--- a/markdown/org/docs/about/guide/en.md
+++ b/markdown/org/docs/about/guide/en.md
@@ -47,7 +47,7 @@ FreeSewing.org is our most visible asset, and for many people their first encoun
 
 ## Patterns vs Designs
 
-If you came to this site looking for _sewing patterns_ and did not immeadiatly find a place to download them, that's because all of FreeSewing's sewing patterns are **made to measure**.
+If you came to this site looking for _sewing patterns_ and did not immediately find a place to download them, that's because all of FreeSewing's sewing patterns are **made to measure**.
 
 We don’t scale or grade patterns.
 Instead, FreeSewing drafts a design into a pattern made to your measurements.
@@ -103,6 +103,6 @@ FreeSewing also provides **curated measurements sets**. These are measurements s
 
 ## Where to turn to for help
 
-If you get stuck, consule [the support page](/support/) for various support options.
+If you get stuck, consult [the support page](/support/) for various support options.
 
 

--- a/markdown/org/docs/about/site/account/username/en.md
+++ b/markdown/org/docs/about/site/account/username/en.md
@@ -6,6 +6,6 @@ Your username is special name that uniquely identifies you.
 
 You can choose your own username, so anything goes.
 
-To avoid consusion, usernames must be unique when lowercased.
+To avoid confusion, usernames must be unique when lowercased.
 In other words, the username `Joost` will not be available if a user `joost` exists.
 

--- a/markdown/org/docs/about/site/apikeys/expiry/en.md
+++ b/markdown/org/docs/about/site/apikeys/expiry/en.md
@@ -7,6 +7,6 @@ Every API key has an **expiry date** after which the key will stop working.
 By default, API keys expire after 1 month, but we support up to two years.
 
 <Note>
-When your key is about to exire, you must replace it with a new one. 
+When your key is about to expire, you must replace it with a new one. 
 You cannot extend the expiry date of a key once set.
 </Note>

--- a/markdown/org/docs/about/site/bookmarks/location/en.md
+++ b/markdown/org/docs/about/site/bookmarks/location/en.md
@@ -2,7 +2,7 @@
 title: Location
 ---
 
-Every bookmark has a **loation** attribute that is mandatory. It holds the URL of the bookmark.
+Every bookmark has a **location** attribute that is mandatory. It holds the URL of the bookmark.
 
 A bookmark without a location or URL is useless, as this holds the location the bookmark should point to.
 

--- a/markdown/org/docs/about/site/csets/en.md
+++ b/markdown/org/docs/about/site/csets/en.md
@@ -32,7 +32,7 @@ pick the one that best represents their own body.
 We rely on our community to submit measurements sets for curation. 
 If you have a public measurements set on the site, you can suggest it for curation.
 
-To be part of our curated measurments sets collection, you should provide the following:
+To be part of our curated measurements sets collection, you should provide the following:
 
 - **All measurements** of the person. We do not accept incomplete sets as that would mean some designs would not work with them.
 - **The height** of the person. This helps users select a measurements set closest to their own body.

--- a/markdown/org/docs/about/site/draft/core-settings/locale/en.md
+++ b/markdown/org/docs/about/site/draft/core-settings/locale/en.md
@@ -12,5 +12,5 @@ FreeSewing currently supports the following languages:
 - German
 - Dutch
 
-You can picks any of these and your pattern will be translated in this language.
+You can pick any of these and your pattern will be translated in this language.
 

--- a/markdown/org/docs/about/site/draft/core-settings/scale/en.md
+++ b/markdown/org/docs/about/site/draft/core-settings/scale/en.md
@@ -7,5 +7,5 @@ Things like logos, line widths, font sizes, and so on.
 
 This setting was added at the requests of people who like to use our patterns to make doll clothes.
 When generating such a small pattern, the arrowheads, titles, and so on tend to obscure much of the pattern.
-This setting allows you to scale them down or -- if you so wich -- scale them up.
+This setting allows you to scale them down or -- if you so wish -- scale them up.
 

--- a/markdown/org/docs/about/site/en.md
+++ b/markdown/org/docs/about/site/en.md
@@ -13,7 +13,7 @@ Most people will be most interested in [How to generate bespoke sewing patterns]
 It can be frustrating for visitors who come here expecting a website where they can download sewing patterns that they can't seem to find the sewing patterns to download. Almost like hiding the *download button* is some elaborate scheme to waste their time.
 
 I don't really know how to fix this because I cannot control people's expectations.
-FreeSewing.org is _very_ different from the a website with some links to PDF sewing patterns.
+FreeSewing.org is _very_ different from a website with some links to PDF sewing patterns.
 So if that's what you're expecting, we almost have to de-train you before we can talk about what this site offers.
 
 So I'm not going to do that. I'm going to assume you are reading with an open mind.
@@ -55,7 +55,7 @@ I'd like to highlight a couple of them that are worth your attention:
 ### User Experience
 
 The [User Experience setting](/account/control/) allows you to gradually reveal more complexity.
-If you are a little overwhelmed with everything FreeSewing.org has to offer, setting this to a lower value will gardually hide more features for the sake of simplicity. But setting a higher value here will show more features and functionality.
+If you are a little overwhelmed with everything FreeSewing.org has to offer, setting this to a lower value will gradually hide more features for the sake of simplicity. But setting a higher value here will show more features and functionality.
 
 Dial this setting down if you want a simpler experience. Turn it up if you want more power, or some things that you know exists are not shown on your screen.
 

--- a/markdown/org/docs/about/site/patterns/public/en.md
+++ b/markdown/org/docs/about/site/patterns/public/en.md
@@ -5,4 +5,4 @@ title: Public
 This settings controls whether your pattern will accessible by the **public** or not.
 
 By default, patterns are private and only you can access your own patterns.
-If you'd like to share your pattern with others -- perhaps because they showed an interest or you are loooking for input -- you should first make it public.
+If you'd like to share your pattern with others -- perhaps because they showed an interest or you are looking for input -- you should first make it public.

--- a/markdown/org/docs/about/site/sets/public/en.md
+++ b/markdown/org/docs/about/site/sets/public/en.md
@@ -2,11 +2,11 @@
 title: Public
 ---
 
-Every measurements set has a **public** attribute that controls whether or not the measurments set is public.
+Every measurements set has a **public** attribute that controls whether or not the measurements set is public.
 
 By default, measurements sets are private and you are the only one who can use them.
 
-But, you can choose to make your measurments set public which allows other
+But, you can choose to make your measurements set public which allows other
 users to utilize the measurements in this set to generate or test their own
 patterns.
 

--- a/markdown/org/docs/about/site/sets/units/en.md
+++ b/markdown/org/docs/about/site/sets/units/en.md
@@ -6,8 +6,8 @@ Every measurements set has a **units** attribute that controls what units will
 be used to display measurements in the set.
 
 While each FreeSewing user has a **units** setting in their account that
-controls their overal preference between imperial or metric units, it is common
-to also have measurements sets for differnet people, and those different people
+controls their overall preference between imperial or metric units, it is common
+to also have measurements sets for different people, and those different people
 might have other preferences.
 
 That is why we allow you to set the units on each measurements set.

--- a/markdown/org/docs/measurements/bustfront/en.md
+++ b/markdown/org/docs/measurements/bustfront/en.md
@@ -4,6 +4,6 @@ title: Bust front
 
 The **bust front** is the front part of your chest circumference.
 
-To measure your bust front, run the tape measure horizontally accross the fullest part of your chest,
+To measure your bust front, run the tape measure horizontally across the fullest part of your chest,
 starting at the side (seam) on one side, across your breasts to the side (seam) on the other side.
 <MeasieImage />

--- a/markdown/org/docs/measurements/shoulderslope/en.md
+++ b/markdown/org/docs/measurements/shoulderslope/en.md
@@ -6,7 +6,7 @@ The **shoulder slope** measurement is an indicator for the amount with which you
 
 To measure your shoulder slope, you need to determine the angle at which your shoulder line slopes downward.
 
-A good way to measure your shoulder slope is to take a
+A good way to measure your shoulder slope is to take
 a selfie and rotate it until your shoulder line is horizontal.
 
 The number of degrees you had to rotate is your shoulder slope.

--- a/markdown/org/docs/measurements/waisttoarmpit/en.md
+++ b/markdown/org/docs/measurements/waisttoarmpit/en.md
@@ -4,7 +4,7 @@ title: Waist to armpit
 
 The **waist to armpit** is the measurement from your waist up towards your armpit, measured on the side of your body.
 
-Since _armpit_ is a bit ambigious, we recommend finding the height that would be about the tightest possible sleeve that could still work.
+Since _armpit_ is a bit ambiguous, we recommend finding the height that would be about the tightest possible sleeve that could still work.
 The height of the subcapular/posterior lymph nodes is typically a good spot.
 
 Or, if you're not certain where the lymph nodes under your arm are, you can follow this approach:
@@ -13,7 +13,7 @@ Or, if you're not certain where the lymph nodes under your arm are, you can foll
 - Raise your dominant arm (the right if you are right-handed, or the left if you are left-handed) about 30 degrees sideways, away from your body.
 - Now reach to the side of your body with the other hand, placing the palm of your hand against the side, and your thumb on your chest pointing upwards.
 - Slide your hand upwards as far as you can without having to push anything out of the way.
-- Your index finger will now sit in the armput, which is a bit too high. But your middlefinger is a good spot to mark as the start of your armpit.
+- Your index finger will now sit in the armpit, which is a bit too high. But your middle finger is a good spot to mark as the start of your armpit.
 
 
 <MeasieImage />

--- a/markdown/org/docs/sewing/double-welt-pockets/en.md
+++ b/markdown/org/docs/sewing/double-welt-pockets/en.md
@@ -119,7 +119,7 @@ Mark the welt pocket as follows:
 - Align the center opening of the pocket with a horizontal line. Let it extend to help you align the welts later
 - Mark two horizontal lines parallel to the center line, at an offset equal to the welt height (0.5cm in our example)
 
-The part of the horizontal lines parallel to the center line that fall in between the verticle lines is where we'll sew our welts in place. This is illustrated by the red lines.
+The part of the horizontal lines parallel to the center line that fall in between the vertical lines is where we'll sew our welts in place. This is illustrated by the red lines.
 
 ### Step 3: Fold and press the welts
 

--- a/markdown/org/docs/sewing/edgestitching/en.md
+++ b/markdown/org/docs/sewing/edgestitching/en.md
@@ -2,7 +2,7 @@
 title: Edgestitching
 ---
 
-Edgestitching is a speficic type of _topstitching_.
+Edgestitching is a specific type of _topstitching_.
 It is specific because of its location.
 To edgestitch means to topstitch right next to a seam,
 typically about 3mm or 1/8 inch next to it.

--- a/sites/org/components/footer/en.yaml
+++ b/sites/org/components/footer/en.yaml
@@ -1,7 +1,7 @@
 cc: Content on FreeSewing.org is available under a Creative Commons license
-mit: The FreeSewing source code is available on Github under the MIT license
+mit: The FreeSewing source code is available on GitHub under the MIT license
 sponsors: FreeSewing is sponsored by these awesome companies
 algolia: Search powered by Algolia
 crowdin: Translation powered by Crowdin
-bugsnag: Error handling by Bugsnag
+bugsnag: Error handling by BugSnag
 vercel: Builds & Hosting by Vercel

--- a/sites/org/pages/translation/en.yaml
+++ b/sites/org/pages/translation/en.yaml
@@ -8,7 +8,7 @@ translatedOnly: Translated but not (yet) approved by a proofreader
 notTranslated: Not (yet) translated
 defaultLanguage: This is our source language and the working language of the FreeSewing project
 addLanguage1: Looking to add a language?
-addLanguage2: We would love to make FreeSewing available in more langauges.
+addLanguage2: We would love to make FreeSewing available in more languages.
 addLanguage3: If you are interested in starting a new translation effort, please reach out.
 globalRanking: Global ranking
 groupByLanguage: Group by language

--- a/sites/shared/components/account/en.yaml
+++ b/sites/shared/components/account/en.yaml
@@ -116,11 +116,11 @@ controlTitle: Which user experience do you prefer?
 # img
 imgTitle: How about a picture?
 imgDragAndDropImageHere: Drag and drop an image here
-imgPasteUrlHere: Paste an image location (url) here
+imgPasteUrlHere: Paste an image location (URL) here
 imgSelectImage: Select an image
 
 # newsletter
-newsletterTitle: Would you like to reveice the FreeSewing newsletter?
+newsletterTitle: Would you like to receive the FreeSewing newsletter?
 newsletterYes: Yes, I would like to receive the newsletter
 newsletterYesd: Once every 3 months you'll receive an email from us with honest wholesome content. No tracking, no ads, no nonsense.
 newsletterNod: You can always change your mind later. But until you do, we will not send you any newsletters.
@@ -220,7 +220,7 @@ public: Public
 publicSet: Public measurements set
 privateSet: Private measurements set
 publicSetDesc: Others are allowed to use these measurements to generate or test patterns
-privateSetDesc: These measurments cannot be used by other users or visitors
+privateSetDesc: These measurements cannot be used by other users or visitors
 permalink: Permalink
 editThing: Edit {thing}
 saveThing: Save {thing}
@@ -229,8 +229,8 @@ noFilter: Do not filter
 filterByDesignDocs: If you have a specific design in mind, you can <b>filter by design</b> to only list those measurements that are required for this design.
 setLacksMeasiesForDesign: This set lacks measurements required for this pattern
 setHasMeasiesForDesign: This set has all measurements required for this pattern
-someSetsLacking: Some of these sets lack the measurments required to generate this pattern
-theseSetsReady: These sets have all required measurments to generate this pattern
+someSetsLacking: Some of these sets lack the measurements required to generate this pattern
+theseSetsReady: These sets have all required measurements to generate this pattern
 chooseSet: Please choose a set of measurements
 patternForWhichSet: Which set of measurements should we generate a pattern for?
 bookmarkedSets: Measurements sets you've bookmarked
@@ -240,7 +240,7 @@ curateCuratedSets: Curate our selection of curated measurements sets
 useThisSet: Use this set of measurements
 ownSets: Your own measurements sets
 noOwnSets: You do not have any of your own measurements sets (yet)
-pleaseMtm: Because our patterns are bespokee, we strongly suggest you take accurate measurements.
+pleaseMtm: Because our patterns are bespoke, we strongly suggest you take accurate measurements.
 noOwnSetsMsg: You can store your measurements as a measurements set, after which you can generate as many patterns as you want for them.
 measurements: Measurements
 chooseASet: Choose a measurements set
@@ -278,7 +278,7 @@ imgNew: Generate a social media image
 imgNewInfo: Use our generator to create an image you can share on social media, supports wide (classic), square (Instagram), or tall (stories/TikTok) formats.
 
 csetNew: Suggest a new curated measurements set
-csetNewInfo: We curate a collection of vetted measurments sets that we use to test patterns. You can suggest a measurements set here.
+csetNewInfo: We curate a collection of vetted measurements sets that we use to test patterns. You can suggest a measurements set here.
 
 opackNew: Suggest a new options pack
 opackNewInfo: We curate a collection of vetted option packs for each of our designs. You can suggest your options here.

--- a/sites/shared/components/susi/en.yaml
+++ b/sites/shared/components/susi/en.yaml
@@ -8,7 +8,7 @@ checkYourInbox: Go check your inbox for an email from
 clickSigninLink: Click the sign-in link in that email to sign in to your FreeSewing account.
 clickSignupLink: Click your personal signup link in that email to create your FreeSewing account.
 consentLacking: We lack consent to process your data
-consentLackingMsg: Getting your consent is part of sign up process. Look for the email you received when you signed up for instracutions. You can sign up again with the same email address to receive the email again.
+consentLackingMsg: Getting your consent is part of sign up process. Look for the email you received when you signed up for instructions. You can sign up again with the same email address to receive the email again.
 contact: Contact support
 contactingGithub: Contacting GitHub
 contactingGoogle: Contacting Google

--- a/sites/shared/components/workbench/menus/core-settings/en.yaml
+++ b/sites/shared/components/workbench/menus/core-settings/en.yaml
@@ -36,7 +36,7 @@ no: No
 completeYes.t: Generate a complete pattern
 completeYes.d: This will generate a complete pattern with all notations, lines, markings. Use this if you are not certain what to choose.
 completeNo.t: Generate a pattern outline
-completeNo.d: Only generate the outline of the pattern parts. Use this if you are looking to use a lasercutter or have other specific needs.
+completeNo.d: Only generate the outline of the pattern parts. Use this if you are looking to use a laser cutter or have other specific needs.
 expandYes.t: Expand all pattern parts
 expandYes.d: This will generate a pattern where all pattern parts are drawn to their full size, even if they are simple rectangles.
 expandNo.t: Keep patterns parts compact where possible
@@ -52,7 +52,7 @@ metric.d: Use this if you use the metric system, and centimeters and millimeters
 imperial.t: Use imperial units
 imperial.d: Use this if inches and fractions or inches are more familiar to you then centimeters. This is often the preferred choice for people based in the UK & US.
 saNo.t: Do not include seam allowance
-saNo.d: This generates a pattern which does not include any seam allowance. The size of the seam allowance does not matter as no seam allowancce will be included.
+saNo.d: This generates a pattern which does not include any seam allowance. The size of the seam allowance does not matter as no seam allowance will be included.
 saYes.t: Include seam allowance
 saYes.d: This generates a pattern that will include seam allowance. The size of the seam allowance is set individually.
 clearSettingsNotMeasurements: Clear settings, but keep measurements

--- a/sites/shared/components/workbench/menus/ui-settings/en.yaml
+++ b/sites/shared/components/workbench/menus/ui-settings/en.yaml
@@ -4,7 +4,7 @@ renderer.t: Render Engine
 renderer.d: Controls how the pattern is rendered (drawn) on the screen
 renderWithReact.t: Render with FreeSewing's React components
 renderWithReact.d: Render as SVG through our React components. Allows interactivity and is optimized for screen. Use this if you are not sure what to pick.
-renderWithCore.t: Render with Freesewing's Core library
+renderWithCore.t: Render with FreeSewing's Core library
 renderWithCore.d: Render directly to SVG from Core. Allows no interactivity and is optimized for print. Use this if you want to know what it will look like when exported.
 control.t: User Experience
 control.d: Which user experience do you prefer? Please note that this is an account setting, so it will impact the entire website.

--- a/sites/shared/i18n/docs/en.yaml
+++ b/sites/shared/i18n/docs/en.yaml
@@ -3,7 +3,7 @@ docs: Documentation
 controltip.t: Power versus Simplicity
 controltip.d1: The <b>Power versus Simplicity</b> setting of your FreeSewing account will impact how you experience the FreeSewing website.
 controltip.d2: By default, some of the more advanced features of this site are hidden to make it more easy for new users to find their way.
-controltip.d3: If you want to sacrify some of that simplicy to gain more power, you can update your Power versus Simplicity setting accordingly.
+controltip.d3: If you want to sacrifice some of that simplicity to gain more power, you can update your Power versus Simplicity setting accordingly.
 helpWithDocs: Help us improve our documentation
 authors: Authors
 maintainers: Maintainers

--- a/sites/shared/i18n/homepage/en.yaml
+++ b/sites/shared/i18n/homepage/en.yaml
@@ -4,7 +4,7 @@ howDoesItWork: How does it work?
 whatIsFreeSewing: What is FreeSewing?
 whatIsFreeSewingNot: What is FreeSewing not?
 what1: FreeSewing is open source software to generate bespoke sewing patterns, loved by home sewers and fashion entrepreneurs alike.
-what2: FreeSewing.org makes this software available to you as an online tool with unmatched custimization and flexibility. We have over 50 designs, and regularly add new ones. You can pick any design and generate a pattern to your exact measurements.
+what2: FreeSewing.org makes this software available to you as an online tool with unmatched customization and flexibility. We have over 50 designs, and regularly add new ones. You can pick any design and generate a pattern to your exact measurements.
 what3: Industry sizing is a bunch of lies. Join the slow fashion revolution and enjoy clothes that fit you.
 whatNot1: FreeSewing is not a company. We do not sell anything. We do not have staff or employees. We do not have an office. We do not get paid.
 whatNot2: Our website does not contain any advertising. We do not track you or sell your personal data. We do not violate your privacy.

--- a/sites/shared/i18n/sections/en.yaml
+++ b/sites/shared/i18n/sections/en.yaml
@@ -5,11 +5,11 @@ showcaseAbout: Examples and inspiration from the FreeSewing community using our 
 docs: Documentation
 docsAbout: In-depth documentation for all our designs, our website, and much more
 account: Your Account
-accountAbout: Manage your account settings and preferences, and your presonal data
+accountAbout: Manage your account settings and preferences, and your personal data
 designs: Designs
 designsAbout: Our library of designs that you can turn into made-to-measure patterns with a few clicks
 community: Community
-communityAbout: More information about the peope behind FreeSewing and where to fine like-minded makers
+communityAbout: More information about the people behind FreeSewing and where to fine like-minded makers
 apiAbout: Documentation for our core API library and our backend REST API.
 designAbout: Everything you need to know to start designing parametric sewing patterns.
 contributeAbout: Looking to contribute to FreeSewing? Right this way.

--- a/sites/shared/i18n/status/en.yaml
+++ b/sites/shared/i18n/status/en.yaml
@@ -6,7 +6,7 @@ copiedToClipboard: Copied to clipboard
 dataLoaded: Loaded data from the FreeSewing backend
 generatingPdf: Generating your PDF, one moment please
 nailedIt: Nailed it!
-pdfFailed: An unexpected error occured while generating your PDF
+pdfFailed: An unexpected error occurred while generating your PDF
 pdfReady: PDF generated
 processingUpdate: Processing update
 settingsSaved: Settings saved

--- a/sites/shared/i18n/support/en.yaml
+++ b/sites/shared/i18n/support/en.yaml
@@ -29,7 +29,7 @@ howCanYouSupportFreeSewing: How can you support FreeSewing?
 issueAssigned: Issue assigned
 issueClosed: Issue closed
 issueReferenced: Issue referenced
-issueReopened: Issue Re-Openened
+issueReopened: Issue Re-Opened
 maintainerSupport: Maintainer Support
 maintainerSupport1: If you are <b>a FreeSewing patron</b>, you can go straight to the top and contact Joost directly.
 maintainerSupport2: While Joost will treat requests from patrons with priority, he does also needs sleep. So keep that in mind, especially when you are in a different time zone.


### PR DESCRIPTION
I ran a spellcheck on almost all YAML and documentation files and fixed all the typos and errors that were exposed.

(I'll be running the spellcheck on design documentation and filing a separate PR for them.)