### PR TITLE
chore(markdown): Add 2023 pledge amount to revenue history

### DIFF
--- a/markdown/org/docs/about/pledge/en.md
+++ b/markdown/org/docs/about/pledge/en.md
@@ -21,7 +21,8 @@ You can read about [their motivations for doing so on this page](/docs/about/ple
 | `€10.736,82` | 2020 |
 | `€10.070,77` | 2021 |
 | `€9.325,54`  | 2022 | 
-| `€38.814,94` | **Euro donated to [MSF](https://msf.org/)** |
+| `€10.222,07` | 2023 |
+| `€49.030,01` | **Euro donated to [MSF](https://msf.org/)** |
 
 <Tip>
 


### PR DESCRIPTION
The 2023 €10.222,07 figure came from the 2024Q1 newsletter: https://github.com/freesewing/freesewing/blob/develop/markdown/org/newsletter/2024q1/en.md

(Not that it matters now, but I believe that the previous €38.814,94 total was slightly incorrect, off by €7. I calculated the actual figure to have been €38.807,94.)