### PR TITLE
fix(markdown): Add yarn disambiguation to Linux tutorial

### DIFF
--- a/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
@@ -95,6 +95,21 @@ yarn kickstart
 
 Now you're ready to [start the development environment](/tutorials/getting-started-linux/dev-start).
 
+<Note>
+
+There is another `yarn` command that comes with some Linux distributions,
+installed as part of the `cmdtest` package and used for command line
+scenario testing.
+If you get an `ERROR: There are no scenarios; must have at least one.`
+message when trying to run the `yarn` command, it may be because the wrong
+`yarn` is being used.
+
+Possible workarounds for this include uninstalling the `cmdtest` package
+or making sure that npm `yarn` is installed and comes first in your `PATH`
+environment variable.
+
+</Note>
+
 ## Creating a new design
 
 If you would like to create a new design, run the following command:


### PR DESCRIPTION
I've been aware of this issue for a while but previously believed that it likely wouldn't affect anyone. However, it turned out that a FreeSewing customer did encounter this issue, and it caused problems for them, as reported on Discord:
> it was unclear to me, that "yarn" meant the npm package yarn, and not the command testing utility "yarn" in linux. 
> much confusion ensued.

https://discord.com/channels/698854858052075530/1190514590061179010/1190514590061179010
discord://discord.com/channels/698854858052075530/1190514590061179010/1190514590061179010