### PR TITLE
chore(markdown): Add Svg.render() documentation

### DIFF
--- a/markdown/dev/reference/api/svg/asrenderprops/en.md
+++ b/markdown/dev/reference/api/svg/asrenderprops/en.md
@@ -15,7 +15,7 @@ Object svg.asRenderProps()
 
 ## Returned object properties
 
-This returns JavaScript object has the following properties:
+The returned JavaScript object has the following properties:
 
 | Name | Description |
 | ----:| ----------- |

--- a/markdown/dev/reference/api/svg/render/en.md
+++ b/markdown/dev/reference/api/svg/render/en.md
@@ -11,19 +11,11 @@ The `Svg.render()` method will render a drafted
 string svg.render()
 ```
 
-## Svg.render() example
+<Warning>
 
-```
-import { Aaron } from "@freesewing/aaron"
+This method is mostly internal and should not be used directly.
+Instead, it is intended that the
+[Pattern.render()](reference/api/pattern/render)
+method be used to render patterns as SVG.
 
-// Load some public test measurements from the FreeSewing backend
-const measurements = (
-  await (
-    await fetch("https://backend3.freesewing.org/curated-sets/1.json")
-  ).json()
-).measurements
-
-const pattern = new Aaron({ measurements })
-
-const svg = new Svg(pattern).render()
-```
+</Warning>

--- a/markdown/dev/reference/api/svg/render/en.md
+++ b/markdown/dev/reference/api/svg/render/en.md
@@ -2,4 +2,28 @@
 title: Svg.render()
 ---
 
-FIXME: Write docs
+The `Svg.render()` method will render a drafted
+[Pattern](/reference/core/pattern) as SVG.
+
+## Signature
+
+```js
+string svg.render()
+```
+
+## Svg.render() example
+
+```
+import { Aaron } from "@freesewing/aaron"
+
+// Load some public test measurements from the FreeSewing backend
+const measurements = (
+  await (
+    await fetch("https://backend3.freesewing.org/curated-sets/1.json")
+  ).json()
+).measurements
+
+const pattern = new Aaron({ measurements })
+
+const svg = new Svg(pattern).render()
+```


### PR DESCRIPTION
Also a small grammar fix in `Svg.asRenderProps()`.

(This fixes half of Issue #3193. The other half will be addressed in a separate PR.)

Edit: Added:

The other half of #3193 was subsequently merged via #5900. As a result, this PR now closes #3193.