### PR TITLE
fix(core): Remove Svg.body property

### DIFF
--- a/markdown/dev/reference/api/svg/body/en.md
+++ b/markdown/dev/reference/api/svg/body/en.md
@@ -1,5 +1,0 @@
----
-title: Svg.body
----
-
-FIXME: write docs

--- a/packages/core/src/svg.mjs
+++ b/packages/core/src/svg.mjs
@@ -30,7 +30,6 @@ export function Svg(pattern) {
   this.attributes.add('xmlns:freesewing', 'http://freesewing.org/namespaces/freesewing')
   this.attributes.add('freesewing', version)
   this.layout = {}
-  this.body = ''
   this.style = ''
   this.defs = new Defs()
 }
@@ -48,7 +47,6 @@ Svg.prototype.asRenderProps = function () {
   return {
     attributes: this.attributes.asRenderProps(),
     layout: this.layout,
-    body: this.body,
     style: this.style,
     defs: this.defs.asRenderProps(),
   }

--- a/packages/core/tests/pattern-draft.test.mjs
+++ b/packages/core/tests/pattern-draft.test.mjs
@@ -212,7 +212,6 @@ describe('Pattern', () => {
     const pattern = new Test()
     pattern.draft()
     const rp = pattern.getRenderProps()
-    expect(rp.svg.body).to.equal('')
     expect(rp.width).to.equal(4)
     expect(rp.height).to.equal(4)
     expect(rp.parts.front.height).to.equal(4)

--- a/packages/core/tests/svg.test.mjs
+++ b/packages/core/tests/svg.test.mjs
@@ -43,7 +43,6 @@ describe('Svg', () => {
     const svg = new Svg()
     expect(svg.attributes instanceof Attributes).to.equal(true)
     expect(svg.freeId).to.equal(0)
-    expect(svg.body).to.equal('')
     expect(svg.style).to.equal('')
     expect(svg.defs).to.be.an.instanceof(Defs)
     expect(svg.prefix).to.equal('<?xml version="1.0" encoding="UTF-8" standalone="no"?>')


### PR DESCRIPTION
When working on #3193 to try to document the `Svg.body` property, I discovered that it actually doesn't do anything. So, I am filing this PR to remove it entirely.

It may be that removing `Svg.body` is something we do not want to do. Perhaps instead we want to implement it to do something. If that is the case, I do not know what the intentions are for what `Svg.body` is supposed to do or how it is supposed to be used.