### PR TITLE
fix(shared): Flags should not display null notes

### DIFF
--- a/sites/shared/components/workbench/views/flags.mjs
+++ b/sites/shared/components/workbench/views/flags.mjs
@@ -63,7 +63,7 @@ export const Flag = ({ data, t, handleUpdate }) => {
   return (
     <div className="flex flex-col gap-2 items-start">
       <div className="first:mt-0 grow md flag">
-        <Mdx md={desc + notes} />
+        <Mdx md={notes ? desc + notes : desc} />
       </div>
       {button ? <div className="mt-2 w-full flex flex-row justify-end">{button}</div> : null}
     </div>


### PR DESCRIPTION
Before:
![Screenshot 2024-01-25 at 4 23 21 PM](https://github.com/freesewing/freesewing/assets/109869956/511bf2f6-201e-4282-b10f-0eccf614fd39)

After:
![Screenshot 2024-01-25 at 4 23 15 PM](https://github.com/freesewing/freesewing/assets/109869956/33c1756b-9ad3-4f53-a6fa-036976bdf868)
