### PR TITLE
fix(markdown): Add more info to Extending Options part doc

### DIFF
--- a/markdown/dev/reference/api/part/config/options/en.md
+++ b/markdown/dev/reference/api/part/config/options/en.md
@@ -43,6 +43,9 @@ These are the types of options supported by the FreeSewing core library:
 6. [**millimeter** options][mm] are supported but not recommended (see warning below)
 7. [**percentage** options][pct] are for percentages (and can optionally be [**snapped percentage** options][snapped])
 
+These options can be [extended][extend] with additional, optional
+information to help with their use outside of the core.
+
 <Tip>
 
 In parametric design, percentage options are by far the most common.
@@ -69,3 +72,4 @@ percentage options][snapped] instead.
 [pct]: /reference/api/part/config/options/pct
 [snapped]: /reference/api/part/config/options/pct/snap
 [mm]: /reference/api/part/config/options/mm
+[extend]: /reference/api/part/config/options/extend

--- a/markdown/dev/reference/api/part/config/options/extend/en.md
+++ b/markdown/dev/reference/api/part/config/options/extend/en.md
@@ -2,58 +2,56 @@
 title: Extending options
 ---
 
-<Fixme>
+Additional, optional information can be added to options to extend
+their use outside of core functionality.
+This can be useful when using FreeSewing through a frontend UI.
+The extended information can be used by the frontend to affect
+how options are presented.
 
-Explain extending options here
 
-</Fixme>
+## Add menu structure
 
-
-## Suppress translation
-
-In the example above, you want the different `list` options to be translated.
-But sometimes, there is no need for that, like in this example from Breanna:
+Because FreeSewing designs hae been written with the expectation that
+they will be used primarily through the freesewing.org website,
+their options have been extended with menu information.
 
 ```js
 options: {
-  primaryBustDart: {
-    list: [
-      '06:00',
-      '07:00',
-      '08:00',
-      '09:00',
-      '10:00',
-      '11:00',
-      '11:30',
-      '12:00',
-      '12:30',
-      '13:00',
-      '13:30',
-      '14:00',
-      '15:00',
-      '16:00',
-      '17:00',
-    ],
-    dflt: '06:00',
-    doNotTranslate: true,
-  },
-  // More here
+  // Fit
+  waistEase: { pct: 2, min: 0, max: 10, menu: 'fit' },
+  seatEase: { pct: 5, min: 0, max: 15, menu: 'fit' },
+  // Style
+  waistHeight: { pct: 5, min: 0, max: 100, menu: 'style' },
+  lengthBonus: { pct: 0, min: -15, max: 10, menu: 'style' },
+  elasticatedCuff: { bool: true, menu: 'style' },
+  buttons = { count: 7, min: 4, max: 12, menu: 'style.closure' }
+  extraTopButton = { bool: true, menu: 'style.closure' }
 }
 ```
 
-As you can see above, you can set the `doNotTranslate` property to `true` and to indicate this.
+In the above example, the added `menu` attributes provide the
+the freesewing.org website UI with information about the options
+should appear in menus.
+The `waistEase` and `seatEase` options should appear in the `fit`
+menu while the other options go in the `style` menu.
+Additionally, the `buttons` and `extraTopButton` options should
+appear in a `closure` submenu under the `style` menu.
 
 <Note>
 
 ##### This is not a core feature
 
-To be clear, setting this here does not do anything in core. It's merely extra
-metadata you can add on the option to facilitate frontend integration.
+To be clear, setting this here does not do anything in core.
+It's merely extra metadata you can add on the option to facilitate
+frontend integration.
 
 </Note>
+
+
 ## Suppress translation
 
-In the example above, you want the different `list` options to be translated.
+When using `list` options, we usually we want the different options
+in the list to be translated.
 But sometimes, there is no need for that, like in this example from Breanna:
 
 ```js


### PR DESCRIPTION
I took a guess as to what the Extending Options documentation was supposed to cover.