### PR TITLE
fix(carlita,hugo,jaeger): Add Fixme tags to incomplete documentation

### DIFF
--- a/markdown/org/docs/designs/carlita/instructions/en.md
+++ b/markdown/org/docs/designs/carlita/instructions/en.md
@@ -54,13 +54,13 @@ Don't forget the seam allowance for these pieces when cutting if you are making 
 
 #### Maker's notes
 
-<Warning>
+<Fixme>
 
 We don't have fully worked out instructions for Carlita yet.
 Below are some notes from [@AnnekeCaramin](/users/AnnekeCaramin) who
 [made Carlita](http://www.annekecaramin.com/2018/02/this-is-one-of-those-origin-superhero.html).
 
-</Warning>
+</Fixme>
 
 - Find and mark roll line on lapel,
 - Draft back stay & cut from heavy muslin or hair canvas if you want to be absolutely bulletproof

--- a/markdown/org/docs/designs/hugo/instructions/en.md
+++ b/markdown/org/docs/designs/hugo/instructions/en.md
@@ -2,7 +2,7 @@
 title: "Hugo hoodie: Sewing Instructions"
 ---
 
-<Note>
+<Fixme>
 
 ###### Documentation under construction
 
@@ -11,7 +11,7 @@ Scroll down, it's embedded in this page.
 
 Now the bad news: The written instructions for Hugo are not complete yet.
 
-</Note>
+</Fixme>
 
 ## Video
 

--- a/markdown/org/docs/designs/jaeger/instructions/en.md
+++ b/markdown/org/docs/designs/jaeger/instructions/en.md
@@ -2,13 +2,13 @@
 title: "Jaeger jacket: Sewing Instructions"
 ---
 
-<Note>
+<Fixme>
 
 ###### Jaeger documentation is under construction
 
 This documentation is not yet finished.
 
-</Note>
+</Fixme>
 
 ## Construction
 


### PR DESCRIPTION
Making sure that incomplete documentation is marked with `<Fixme>` tags (rather than `<Note>` or `<Warning>`) to make it easier to find and to help prevent it from from being overlooked.