### PR TITLE
fix(shared): Adjust <DesignInfo> to accommodate designs with no design options

### DIFF
--- a/sites/shared/components/designs/info.mjs
+++ b/sites/shared/components/designs/info.mjs
@@ -111,9 +111,11 @@ export const DesignInfo = ({ design, docs = false, workbench = false, modal = fa
         <li>
           <DocsLink site="org" slug={`docs/designs/${design}/fabric`} />
         </li>
-        <li>
-          <DocsLink site="org" slug={`docs/designs/${design}/options`} />
-        </li>
+        {Object.keys(config.options).length > 0 ? (
+          <li>
+            <DocsLink site="org" slug={`docs/designs/${design}/options`} />
+          </li>
+        ) : null}
         <li>
           <DocsLink site="org" slug={`docs/designs/${design}/notes`} />
         </li>
@@ -352,8 +354,12 @@ export const DesignInfo = ({ design, docs = false, workbench = false, modal = fa
             </>
           ) : null}
 
-          <h6 className="mt-4">{t('account:designOptions')}</h6>
-          <SimpleOptionsList options={config.options} t={t} design={design} />
+          {Object.keys(config.options).length > 0 ? (
+            <>
+              <h6 className="mt-4">{t('account:designOptions')}</h6>
+              <SimpleOptionsList options={config.options} t={t} design={design} />
+            </>
+          ) : null}
 
           <h6 className="mt-4">{t('account:parts')}</h6>
           <ul className="list list-disc list-inside pl-2">
@@ -361,6 +367,7 @@ export const DesignInfo = ({ design, docs = false, workbench = false, modal = fa
               <li key={part}>{part}</li>
             ))}
           </ul>
+
           {Object.keys(config.plugins).length > 0 ? (
             <>
               <h6 className="mt-4">{t('account:plugins')}</h6>


### PR DESCRIPTION
This issue was exposed while testing `<DesignInfo>` for Gozer. (Gozer's docs are missing the tag, and I am filing a PR to add it.)

Gozer is the only design with no options. All other existing designs have at least one option, which is why we haven't seen the issue before.

(The added blank line 370 is for visual whitespace to separate the parts and plugins sections, to make the code easier to read.)

![Screenshot 2024-02-01 at 12 34 27 AM](https://github.com/freesewing/freesewing/assets/109869956/1a4b4719-6885-4c27-b15b-4f56fbda729c)
![Screenshot 2024-02-01 at 12 35 23 AM](https://github.com/freesewing/freesewing/assets/109869956/14a3be88-bfab-4aaf-a7dd-2dda60479adb)
![Screenshot 2024-02-01 at 12 31 45 AM](https://github.com/freesewing/freesewing/assets/109869956/4a3db8e0-46d1-4261-ac12-94391f33dc3a)
![Screenshot 2024-02-01 at 12 32 13 AM](https://github.com/freesewing/freesewing/assets/109869956/fc1413ff-753d-41b9-bb2b-f3698ef49340)
