### PR TITLE
fix(gozer): In docs, add <DesignInfo> and change <Fixme> to <Warning>

### DIFF
--- a/markdown/org/docs/designs/gozer/en.md
+++ b/markdown/org/docs/designs/gozer/en.md
@@ -11,3 +11,5 @@ where the pattern was. So I posted it. And he published it.
 
 Wouter
 
+<br />
+<DesignInfo design='gozer' docs />

--- a/markdown/org/docs/designs/gozer/notes/en.md
+++ b/markdown/org/docs/designs/gozer/notes/en.md
@@ -2,5 +2,5 @@
 title: "Gozer the ghost: Designer Notes"
 ---
 
-<Fixme>The designer, nor FreeSewing, are liable for anything that follows the use of this pattern. You've been warned.</Fixme>
+<Warning>The designer, nor FreeSewing, are liable for anything that follows the use of this pattern. You've been warned.</Warning>
 


### PR DESCRIPTION
I added a `<DesignInfo>` to Gozer's main doc page. Otherwise, there is no specification info about the design and no links to the instructions, etc., except in the navigation menu.

The `<br />` is to add vertical whitespace. Otherwise the `#FreeSewingGozer` starts immediately after the `Wouter`, making them run together. It didn't look right.

I intentionally chose to use `<br />` rather than a trailing `\` or two space characters to add the vertical whitespace because I think it makes the Markdown file easier to read and edit. Otherwise, it could look as if a blank line with two space characters had been added to the file by mistake.

(The empty element in the `Documentation` list is because Gozer has no design options. I've addressed this `<DesignInfo>` custom tag issue in PR #5944.)

Finally, I changed the `<Fixme>` to a `<Warning>`. "Warning" seems more accurate, and I want to reserve "Fixme" for actual fixme situations (so we can make actual fixmes easier to find by searcing for "fixme").

Screenshots for the added `<DesignInfo>` change:
![Screenshot 2024-02-01 at 12 39 59 AM](https://github.com/freesewing/freesewing/assets/109869956/e8453144-050a-4a30-b183-75c9e9929e17)
![Screenshot 2024-02-01 at 12 37 06 AM](https://github.com/freesewing/freesewing/assets/109869956/d78f6906-fc62-40cc-b84a-1545368d3744)
