### PR TITLE
fix(core): Add missing anchor property to Stack() constructor

### DIFF
--- a/packages/core/src/stack.mjs
+++ b/packages/core/src/stack.mjs
@@ -15,6 +15,7 @@ export function Stack(name = null) {
   this.bottomRight = false
   this.width = false
   this.height = false
+  this.anchor = new Point(0, 0)
 
   return this
 }


### PR DESCRIPTION
I noticed that the `anchor` property gets added only when/after `Stack.home()` was called.

(No docs updates are needed. The `anchor` property is already listed in the `Stack` Core API doc.)