### PR TITLE
fix(markdown): Add missing list property to Attributes and Defs docs

### DIFF
--- a/markdown/dev/reference/api/attributes/en.md
+++ b/markdown/dev/reference/api/attributes/en.md
@@ -12,6 +12,12 @@ Attributes new Attributes()
 
 The Attributes constructor takes no arguments.
 
+## Properties
+
+An Attributes object comes with the following property:
+
+- `list` : The of individual attributes.
+
 ## Methods
 An Attributes object exposes the following methods:
 

--- a/markdown/dev/reference/api/attributes/en.md
+++ b/markdown/dev/reference/api/attributes/en.md
@@ -16,7 +16,7 @@ The Attributes constructor takes no arguments.
 
 An Attributes object comes with the following property:
 
-- `list` : The of individual attributes.
+- `list` : Holds the internal object in which attributes are stored
 
 ## Methods
 An Attributes object exposes the following methods:

--- a/markdown/dev/reference/api/defs/en.md
+++ b/markdown/dev/reference/api/defs/en.md
@@ -14,7 +14,7 @@ they are documented here to facilitate development of plugins.
 
 A Defs object comes with the following property:
 
-- `list` : The entries of the `defs` element.
+- `list` : Holds the internal object in which entries of the `defs` element are stored
 
 ## Defs methods
 

--- a/markdown/dev/reference/api/defs/en.md
+++ b/markdown/dev/reference/api/defs/en.md
@@ -7,8 +7,14 @@ The `Defs` object in FreeSewing's core library represents an SVG document's
 It is not directly exposed, but it is available as the `defs` attribute
 of an [Svg object](/reference/api/svg/defs).
 
-While the methods exposed by this object are typically only used internally,
+While the properties and methods exposed by this object are typically only used internally,
 they are documented here to facilitate development of plugins.
+
+## Properties
+
+A Defs object comes with the following property:
+
+- `list` : The entries of the `defs` element.
 
 ## Defs methods
 


### PR DESCRIPTION
It was unclear to me whether the omission of the `list` property from the Attributes and Defs docs was intentional or not. Because `list` is an Enumerable property, I thought that perhaps the omission was accidental.

But, if the omission was intentional, please just close this PR.