### PR TITLE
chore(markdown): Add docs for new Pattern* classes

### DIFF
--- a/markdown/dev/reference/api/patternconfig/en.md
+++ b/markdown/dev/reference/api/patternconfig/en.md
@@ -1,0 +1,15 @@
+---
+title: PatternConfig
+---
+
+The `PatternConfig` object in FreeSewing's core library...
+
+<Fixme>
+
+Documentation needs to be written.
+
+</Fixme>
+
+## Methods
+
+<ReadMore />

--- a/markdown/dev/reference/api/patterndrafter/en.md
+++ b/markdown/dev/reference/api/patterndrafter/en.md
@@ -1,0 +1,15 @@
+---
+title: PatternDrafter
+---
+
+The `PatternDrafter` object in FreeSewing's core library...
+
+<Fixme>
+
+Documentation needs to be written.
+
+</Fixme>
+
+## Methods
+
+<ReadMore />

--- a/markdown/dev/reference/api/patterndraftqueue/en.md
+++ b/markdown/dev/reference/api/patterndraftqueue/en.md
@@ -1,0 +1,15 @@
+---
+title: PatternDraftQueue
+---
+
+The `PatternDraftQueue` object in FreeSewing's core library...
+
+<Fixme>
+
+Documentation needs to be written.
+
+</Fixme>
+
+## Methods
+
+<ReadMore />

--- a/markdown/dev/reference/api/patternplugins/en.md
+++ b/markdown/dev/reference/api/patternplugins/en.md
@@ -1,0 +1,15 @@
+---
+title: PatternPlugins
+---
+
+The `PatternPlugins` object in FreeSewing's core library...
+
+<Fixme>
+
+Documentation needs to be written.
+
+</Fixme>
+
+## Methods
+
+<ReadMore />

--- a/markdown/dev/reference/api/patternrenderer/en.md
+++ b/markdown/dev/reference/api/patternrenderer/en.md
@@ -1,0 +1,15 @@
+---
+title: PatternRenderer
+---
+
+The `PatternRenderer` object in FreeSewing's core library...
+
+<Fixme>
+
+Documentation needs to be written.
+
+</Fixme>
+
+## Methods
+
+<ReadMore />

--- a/markdown/dev/reference/api/patternsampler/en.md
+++ b/markdown/dev/reference/api/patternsampler/en.md
@@ -1,0 +1,15 @@
+---
+title: PatternSampler
+---
+
+The `PatternSampler` object in FreeSewing's core library...
+
+<Fixme>
+
+Documentation needs to be written.
+
+</Fixme>
+
+## Methods
+
+<ReadMore />


### PR DESCRIPTION
I'm filing this PR to inquire whether these new Pattern* classes should be documented? I get the impression that perhaps they were instead intended to be non-public (as far as documentation is concerned), and perhaps only `Pattern` is intended to be public?

(This PR currently consists of doc stubs with `<Fixme>` tags, but if we want a more substantial PR before the merge, I can switch it to Draft status, work on it further, and then resubmit it.)