### PR TITLE
fix(brian): Take biceps ease into account for armhole depth

### DIFF
--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -26,6 +26,8 @@ Unreleased:
       - Calling `Path.join` with a second parameter to indicate that the resulting paths most be closed is now deprecated and will be removed in FreeSewing v4.
 
   Fixed:
+    brian:
+      - Take biceps ease into account when calculating armhole depth
     carlton:
       - Fixed a stray seam allowance path on the collar
     charlie:

--- a/designs/brian/src/base.mjs
+++ b/designs/brian/src/base.mjs
@@ -109,7 +109,8 @@ export const base = {
       // The new way uses the waistToArmpit measurement
       points.cbArmhole = new Point(
         0,
-        points.cbWaist.y - measurements.waistToArmpit * (1 - options.armholeDepth)
+        points.cbWaist.y -
+          measurements.waistToArmpit * (1 - options.armholeDepth - options.bicepsEase / 2)
       )
     }
 


### PR DESCRIPTION
Originally, #5999 was filed to report issues with the sleeve on Jaeger not responding to biceps ease as expected. Increasing the biceps ease would actually make the sleeve more narrow.

Turns out, this is a side-effect of the way the armhole depth is calculated in v3. We used to take the biceps measurement (and ease) for that, but now we rely on the waist to armpit measurements.

In brain, we used this new measurements along with the armholeDepthFactor option to locate the bottom of the armhole. This means that when we change the biceps ease, nothing will change in the briam armhole, which means the total sleevecap length target remains unchanges.
However, in Jaeger, increased biceps ease causes a taller sleevecap, and since the total target sleevecap length (inherited from Brian) remains unchanged, the pattern accomodates by making the sleeve more narrow so that the taller sleevecap has the same sleevecap length. This is what results in the counterintuitive behavior where increasing the biceps ease makes the sleevecap more narrow.

This resolves that by taking the biceps ease into account when calculating the bottom of the armhole in Brian. As a result, changing the biceps ease will impact the armhole on Brian, which will in turn influence the target sleevecap length that Bent drafts a 2-part sleeve for, and now things work as aspected.

Given that Brian is such a foundational block, making changes to it is a high-stakes game, but I feel this is a bug, so we need to fix it.

Fixes #5999