### PR TITLE
Updated Tristan design name and showcases

### DIFF
--- a/designs/tristan/i18n/en.json
+++ b/designs/tristan/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "t": "Tristan",
+  "t": "Tristan top",
   "d": "Tristan is a fitted tank top with prince(ss) seams.",
   "p": { 
     "backInside": "Back inside",

--- a/markdown/org/showcase/a-lined-tristan-top-with-front-lacing/en.md
+++ b/markdown/org/showcase/a-lined-tristan-top-with-front-lacing/en.md
@@ -3,7 +3,7 @@ title: "A lined Tristan top with front lacing"
 caption: "A top made out of fabric scraps. The main fabric was likely upholstery fabric."
 date: 20240116
 intro: "This Tristan top is lined and had bias binding applied to the neck hole, armholes, and hem."
-designs: ["noble"]
+designs: ["tristan"]
 maker: Natalia
 ---
 

--- a/markdown/org/showcase/a-noble-top-for-the-renaissance-festival/en.md
+++ b/markdown/org/showcase/a-noble-top-for-the-renaissance-festival/en.md
@@ -3,13 +3,13 @@ title: "A Noble top for the Renaissance Festival"
 caption: "This top is made from scrap cotton fabrics"
 date: 20231016
 intro: "This top is based on the Noble block."
-designs: ["noble"]
+designs: ["tristan"]
 maker: Natalia
 ---
 
-This top was made based on the Noble block. The wearer reports that their body is asymmetric, which you can see in the back view. They were very happy with this simple variation of Noble.
+This top was made based on the Noble block, and later spun off into its own design, Tristan. The wearer reports that their body is asymmetric, which you can see in the back view. They were very happy with this simple variation of Noble.
 
-![A view of the front](https://imagedelivery.net/ouSuR9yY1bHt-fuAokSA5Q/showcase-a-noble-top-for-the-renaissance-festival-1/public "The image caption/title goes here")
+![A view of the front](https://imagedelivery.net/ouSuR9yY1bHt-fuAokSA5Q/showcase-a-noble-top-for-the-renaissance-festival-1/public "A view of the front")
 
-![The back view](https://imagedelivery.net/ouSuR9yY1bHt-fuAokSA5Q/showcase-a-noble-top-for-the-renaissance-festival-2/public "The image caption/title goes here")
+![The back view](https://imagedelivery.net/ouSuR9yY1bHt-fuAokSA5Q/showcase-a-noble-top-for-the-renaissance-festival-2/public "The back view")
 


### PR DESCRIPTION
Moved two showcases from Noble to Tristan.

Updated name from "Tristan" to "Tristan top" on Designs page.