### PR TITLE
fix(markdown): In Windows tutorial, change link from .node-version to .nvmrc

### DIFF
--- a/markdown/dev/tutorials/getting-started-windows/en.md
+++ b/markdown/dev/tutorials/getting-started-windows/en.md
@@ -61,7 +61,7 @@ using `nvm install v18.17.0`. For the purposes of debugging it can be useful to
 have the same version of Node.js installed as the main project uses, which you can
 then activate using `nvm use <version>`. You can determine what version the
 FreeSewing project uses by checking
-[freesewing/freesewing/.node-version](https://github.com/freesewing/freesewing/blob/develop/.node-version).
+[freesewing/freesewing/.nvmrc](https://github.com/freesewing/freesewing/blob/develop/.nvmrc).
 
 <Warning> At the time this guide was written the latest version of Node.js/npm has
 a bug in the dependency resolution process which causes the freesewing project


### PR DESCRIPTION
Corrected a 404 link. The previous `.node-version` file was removed some time ago.

_(I'm still thinking about a long-term fix and messaging for the acceptable/recommended Node.js versions issue. It would be easier to maintain if we had this documented in just one place, instead of in every tutorial.)_