### PR TITLE
fix(shared): Correct MeasieImage width and source URL

### DIFF
--- a/sites/shared/components/measurements/image.mjs
+++ b/sites/shared/components/measurements/image.mjs
@@ -34,8 +34,8 @@ export const MeasieImage = (props) => {
         <img
           className="shadow aspect-[4/3]"
           height={sarahImages[m].height}
-          width={sarahImages[m].height}
-          src={sarahImages[m].height}
+          width={sarahImages[m].width}
+          src={sarahImages[m].src}
           alt={t('measurements:' + m)}
           style={{ ...style, backgroundImage: `url(/img/sarah-${pose}.jpg)` }}
         />
@@ -44,8 +44,8 @@ export const MeasieImage = (props) => {
         <img
           className="shadow"
           height={timImages[m].height}
-          width={timImages[m].height}
-          src={timImages[m].height}
+          width={timImages[m].width}
+          src={timImages[m].src}
           alt={t('measurements:' + m)}
           style={{ ...style, backgroundImage: `url(/img/tim-${pose}.jpg)` }}
         />


### PR DESCRIPTION
The issue was introduced in 3bca940.
It was reported on Discord:
https://discord.com/channels/698854858052075530/1206763279989608479/1206763279989608479
discord://discord.com/channels/698854858052075530/1206763279989608479/1206763279989608479

![Screenshot 2024-02-12 at 5 34 16 PM](https://github.com/freesewing/freesewing/assets/109869956/c728774c-4926-4caa-8d7f-52533564a7bb)
![Screenshot 2024-02-12 at 5 34 29 PM](https://github.com/freesewing/freesewing/assets/109869956/3d245052-fa30-4d78-9d8b-02fe50ef0cb1)
