### PR TITLE
fix(models, backend): In tests, use chai namespace import instead of default

### DIFF
--- a/packages/models/tests/models.test.mjs
+++ b/packages/models/tests/models.test.mjs
@@ -1,4 +1,4 @@
-import chai from 'chai'
+import * as chai from 'chai'
 import * as all from '../src/index.mjs'
 
 const expect = chai.expect

--- a/packages/models/tests/models.test.mjs
+++ b/packages/models/tests/models.test.mjs
@@ -1,7 +1,6 @@
-import * as chai from 'chai'
+import { expect } from 'chai'
 import * as all from '../src/index.mjs'
 
-const expect = chai.expect
 const { measurements, sizes } = all
 
 describe('Measurements', () => {

--- a/sites/backend/tests/shared.mjs
+++ b/sites/backend/tests/shared.mjs
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv'
 import axios from 'axios'
-import chai from 'chai'
+import * as chai from 'chai'
 import http from 'chai-http'
 import { verifyConfig } from '../src/config.mjs'
 import { randomString } from '../src/utils/crypto.mjs'


### PR DESCRIPTION
`yarn test` was encountering errors:
```sh
    ✖  @freesewing/models:test
$ npx mocha tests/*.test.mjs
       
       file:///.../packages/models/tests/models.test.mjs:1
       import chai from 'chai'
              ^^^^
       SyntaxError: The requested module 'chai' does not provide an export named 'default'
```
```sh
    ✖  backend.freesewing.org:test
$ npx mocha --require mocha-steps tests/index.mjs
       
       file:///.../freesewing/sites/backend/tests/shared.mjs:3
       import chai from 'chai'
              ^^^^
       SyntaxError: The requested module 'chai' does not provide an export named 'default'
```