### PR TITLE
feat(shared): Allow missing measurement sets to be selected for new patterns

### DIFF
--- a/sites/shared/components/account/sets.mjs
+++ b/sites/shared/components/account/sets.mjs
@@ -817,7 +817,14 @@ export const MsetButton = (props) => <MsetCard {...props} href={false} />
 export const MsetLink = (props) => <MsetCard {...props} onClick={false} useA={false} />
 export const MsetA = (props) => <MsetCard {...props} onClick={false} useA={true} />
 
-export const UserSetPicker = ({ design, t, href, clickHandler, size = 'lg' }) => {
+export const UserSetPicker = ({
+  design,
+  t,
+  href,
+  clickHandler,
+  missingClickHandler,
+  size = 'lg',
+}) => {
   // Hooks
   const backend = useBackend()
   const { control } = useAccount()
@@ -899,9 +906,10 @@ export const UserSetPicker = ({ design, t, href, clickHandler, size = 'lg' }) =>
           </Popout>
           <div className="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-2">
             {lackingSets.map((set) => (
-              <MsetLink
+              <MsetButton
                 {...{ set, control, design }}
-                onClick={clickHandler}
+                onClick={missingClickHandler}
+                href={href}
                 requiredMeasies={measurements[design]}
                 key={set.id}
                 size={size}

--- a/sites/shared/components/workbench/views/measies/index.mjs
+++ b/sites/shared/components/workbench/views/measies/index.mjs
@@ -33,6 +33,14 @@ export const MeasiesView = ({ design, Design, settings, update, missingMeasureme
     setView('draft')
   }
 
+  const loadMissingMeasurements = (set) => {
+    update.settings([
+      [['measurements'], designMeasurements(Design, set.measies)],
+      [['units'], set.imperial ? 'imperial' : 'metric'],
+    ])
+    setView('measies')
+  }
+
   return (
     <div className="max-w-7xl mt-8 mx-auto px-4">
       <h2>{t('account:measurements')}</h2>
@@ -68,6 +76,7 @@ export const MeasiesView = ({ design, Design, settings, update, missingMeasureme
               key={2}
               design={design}
               clickHandler={loadMeasurements}
+              missingClickHandler={loadMissingMeasurements}
               t={t}
               size="md"
             />,


### PR DESCRIPTION
Resolves #5915.

Clicking on a measurement set with missing measurements directs to the measies view. There functionality already exists to tell the user which measurements are missing. Users can then Edit Measurements by Hand to provide the missing measurements.

![Screenshot 2024-02-12 at 7 44 42 PM](https://github.com/freesewing/freesewing/assets/109869956/7ebe84c7-1404-4629-8384-371521657ea8)