### PR TITLE
fix(shared): Blog navigation menu in reverse chronological order

### DIFF
--- a/sites/shared/prebuild/markdown.mjs
+++ b/sites/shared/prebuild/markdown.mjs
@@ -167,7 +167,8 @@ const loadBlog = async () => {
   for (const lang of Object.keys(titles)) {
     posts[lang] = {}
     for (const post of ordered) {
-      posts[lang][post.s] = { t: post.t }
+      const sortkey = 9999999999 - post.o
+      posts[lang][post.s] = { t: post.t, o: sortkey }
       if (lang === 'en') meta[post.s] = { a: post.a, d: post.o }
     }
   }


### PR DESCRIPTION
Fixes #5730.

![Screenshot 2024-02-13 at 5 57 01 AM](https://github.com/freesewing/freesewing/assets/109869956/721e1a50-6863-4361-b247-cec67b8955b9)
