### PR TITLE
feat(shared): Add pattern information to PDF cover sheet

### DIFF
--- a/sites/shared/components/workbench/exporting/export-handler.mjs
+++ b/sites/shared/components/workbench/exporting/export-handler.mjs
@@ -13,6 +13,8 @@ import {
   printSettingsPath,
 } from 'shared/components/workbench/views/print/config.mjs'
 import get from 'lodash.get'
+import mustache from 'mustache'
+import he from 'he'
 
 export const ns = ['cut', 'plugin', 'common']
 export const exportTypes = {
@@ -187,6 +189,18 @@ export const handleExport = async ({
       pattern.draft()
       workerArgs.svg = pattern.render()
 
+      // Save pattern forName, notes, warnings info for coversheet
+      const store = pattern.setStores[pattern.activeSet]
+      workerArgs.strings.forName = store.get('data.for', 'ephemeral')
+      const notes = store?.plugins?.['plugin-annotations']?.flags?.note
+        ? store?.plugins?.['plugin-annotations']?.flags?.note
+        : []
+      const warns = store?.plugins?.['plugin-annotations']?.flags?.warn
+        ? store?.plugins?.['plugin-annotations']?.flags?.warn
+        : []
+      workerArgs.strings.notes = flagsToString(notes, mustache, t)
+      workerArgs.strings.warns = flagsToString(warns, mustache, t)
+
       if (format === 'pdf') pageSettings.size = [pattern.width, pattern.height]
 
       // add the svg and pages data to the worker args
@@ -208,4 +222,24 @@ export const handleExport = async ({
 
   // post a message to the worker with all needed data
   worker.postMessage(workerArgs)
+}
+
+/**
+ * Convert pattern flags to a formatted string for printing
+ */
+const flagsToString = (flags, mustache, t) => {
+  let first = true
+  let string = ''
+  for (const flag of Object.values(flags)) {
+    let title = flag.replace ? mustache.render(t(flag.title), flag.replace) : t(flag.title)
+    title = he.decode(title)
+    let desc = flag.replace ? mustache.render(t(flag.desc), flag.replace) : t(flag.desc)
+    desc = desc.replaceAll('\n\n', '\n')
+    desc = desc.replaceAll('\n', ' ')
+    desc = he.decode(desc)
+    if (!first) string += '\n'
+    first = false
+    string += '- ' + title + ': ' + desc
+  }
+  return string
 }

--- a/sites/shared/components/workbench/exporting/export-worker.js
+++ b/sites/shared/components/workbench/exporting/export-worker.js
@@ -51,6 +51,9 @@ const exportYaml = (settings) => exportBlob(yaml.dump(settings), 'application/x-
 const exportSvg = (svg) => exportBlob(svg, 'image/svg+xml')
 
 const exportPdf = async (data) => {
+  // Save yaml for coversheet
+  data.strings.yaml = yaml.dump(data.settings)
+
   const maker = data.format === 'pdf' ? new SinglePdfMaker(data) : new PdfMaker(data)
   await maker.makePdf()
   postSuccess(await maker.toBlob())

--- a/sites/shared/components/workbench/exporting/pdf-maker.mjs
+++ b/sites/shared/components/workbench/exporting/pdf-maker.mjs
@@ -252,7 +252,6 @@ export class PdfMaker {
     this.pdf.fontSize(fontSize)
     this.pdf.text(text, 50, this.lineLevel)
 
-    const lines = text.split(/\r\n|\r|\n/).length
     this.lineLevel += this.pdf.heightOfString(text) + marginBottom
 
     return this

--- a/sites/shared/components/workbench/exporting/pdf-maker.mjs
+++ b/sites/shared/components/workbench/exporting/pdf-maker.mjs
@@ -118,12 +118,44 @@ export class PdfMaker {
 
   /** generate the title for the cover page */
   async generateCoverPageTitle() {
-    this.addText('FreeSewing', 28)
-      .addText(this.strings.tagline, 12, 20)
-      .addText(this.strings.design, 48, -8)
+    // FreeSewing tag
+    this.addText('FreeSewing', 20).addText(this.strings.tagline, 10, 4)
 
-    await SVGtoPDF(this.pdf, logoSvg, this.pdf.page.width - lineStart - 100, lineStart, {
-      width: 100,
+    // Design name
+    this.addText(this.strings.design, 32)
+
+    // Measurement Set
+    this.addText('Measurement Set: ' + this.strings.forName, 10)
+
+    // Date
+    const currentDateTime = new Date().toLocaleString('en', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      timeZoneName: 'short',
+    })
+    this.addText('PDF Generated: ' + currentDateTime, 10)
+
+    // Settings YAML
+    const savedLineLevel = this.lineLevel + 2
+    const savedWidth = this.pdf.widthOfString('Settings: ') + 50
+    this.addText('Settings: ', 10)
+    this.pdf.fontSize(6)
+    this.pdf.text('(Measurement values are in mm.)', savedWidth, savedLineLevel)
+    this.addText(this.strings.yaml, 8)
+
+    // Notes and Warnings
+    if (this.strings.notes) {
+      this.addText('Notes:', 10).addText(this.strings.notes, 8)
+    }
+    if (this.strings.warns) {
+      this.addText('Warnings:', 10).addText(this.strings.warns, 8)
+    }
+
+    await SVGtoPDF(this.pdf, logoSvg, this.pdf.page.width - lineStart - 50, lineStart, {
+      width: 50,
       height: this.lineLevel - lineStart,
       preserveAspectRatio: 'xMaxYMin meet',
     })
@@ -220,7 +252,9 @@ export class PdfMaker {
     this.pdf.fontSize(fontSize)
     this.pdf.text(text, 50, this.lineLevel)
 
-    this.lineLevel += fontSize + marginBottom
+    const lines = text.split(/\r\n|\r|\n/).length
+    this.lineLevel += this.pdf.heightOfString(text) + marginBottom
+
     return this
   }
 }


### PR DESCRIPTION
Resolves #5332.

This PR adds information to the PDF coversheet.

![Screenshot 2024-02-13 at 8 10 25 AM](https://github.com/freesewing/freesewing/assets/109869956/c788cf29-3a9e-4fcf-a3d0-fb03fd31d1ee)