### PR TITLE
fix(markdown): Roll back crowding accidental removals

### DIFF
--- a/markdown/org/docs/designs/lucy/cutting/en.md
+++ b/markdown/org/docs/designs/lucy/cutting/en.md
@@ -4,3 +4,15 @@ title: "Lucy tie-on pocket: Cutting Instructions"
 
 - Cut **2 pocket** parts
 - Cut pocket slit into **1 pocket** part
+
+#### Historical context 
+
+Tie-on pockets like Lucy were worn roughly from the mid-seventeenth (1650s) century until the end of the 19th century (1890s). They came in all shapes and sizes but Lucy is based on an 18th century example. 
+
+They were worn and used by all members of society and were mainly womens wear as men had a variety of pockets sewn into their clothing. 
+
+Pockets would be tied around the waist and could be accessed through a slit in skirts and petticoats. Where the pocket would be in between the layers was up to the individual. If it was hidden in between layers that would provide more security, but hinder accessibility. People who worked in trade often wore their pockets on the outside of their garments entirely, for easy access. 
+
+(Tie-on) Pockets were used alongside patch pockets, sewn in pockets, bags and other ways to carry your things. Sometimes they even had additional pockets hidden inside them! 
+
+If you want to learn more you can read: Burman, B. & Fennetaux A. (2020)  _The Pocket, A Hidden History of Women's Lives_ Yale University Press, London

--- a/markdown/org/docs/designs/lucy/fabric/en.md
+++ b/markdown/org/docs/designs/lucy/fabric/en.md
@@ -2,4 +2,21 @@
 title: "Lucy tie-on pocket: Fabric Options"
 ---
 
-Any fabric can be used to make Lucy, but if the fabric you are using is very light or sheer you may want to add a lining to both pocket pieces.
+Because pockets were worn by people in every layer of society historically what they were made out of varied intensely. Some were made out of sturdy and plain fabrics, marked with the owners initials. Others were made out of lavish silks or richly embroidered. 
+
+As such when it comes to fabric options the world is your oyster. 
+
+- Modern prints make fun modern pockets
+- Use a plain cotton or linen for a more historical option
+- Have a lot of scraps? Make a patchwork pocket! 
+- Pockets were often a first embroidery project, so go wild if you want to
+
+The one thing to keep in mind is how stable your fabric is. If it is not very stable or you think it won’t hold very much weight, you can add a lining. 
+
+Additionally, if you are handsewing your pocket it is worth picking a fabric that isn’t too thick or heavy. 
+
+Your binding doesn’t have to be the same colour as the main fabric either. You can use it to add a fun accent, or make your pocket fancier. Bias binding curves easier around any curves, but you can just as easily use strips of fabric as a more waste conscious option. 
+
+The ties can be made from self fabric, or you can use something like a twill tape instead.
+
+As always, whether you want to stick to historical practices or make something modern is entirely up to you!

--- a/markdown/org/docs/designs/lucy/instructions/en.md
+++ b/markdown/org/docs/designs/lucy/instructions/en.md
@@ -4,11 +4,11 @@ title: "Lucy tie-on pocket: Sewing Instructions"
 
 <Note>
 
-Lucy can be sewn by hand or by machine as you prefer.
+Lucy can be sewn by hand or by machine as you prefer. When sewing by hand, you can use a running stitch to sew the pocket pieces together and bind with a whipstitch. 
 
 </Note>
 
-## Step 1: Constructing the Pocket Bag
+## Step 1: Constructing the Pocket
 
 - Bind the pocket slit.
 - With _wrong sides together_ stitch the two pocket pieces together around the outside.
@@ -22,9 +22,9 @@ If you prefer you can _french seam_ the outer edges of the pocket bag together.
 
 ## Step 2: Binding the top edge and ties.
 
-There are two methods for binding the top edge. One is to create a loop and the other is to bind with the ties. Read through both methods carefully and decide which one you wish to use.
+There are two methods for binding the top edge. One leaves the side edges of the top binding open so the ties can be threaded through. The second uses the tape for the ties to bind the top edge. Read through both methods carefully and decide which one you wish to use.
 
-### Create a loop
+### Using binding
 
 - Cut a piece of binding the length of the top edge + seam allowance.
 - Fold under the short edges of the binging and stitch in place.

--- a/markdown/org/docs/designs/lucy/needs/en.md
+++ b/markdown/org/docs/designs/lucy/needs/en.md
@@ -2,8 +2,18 @@
 title: "Lucy tie-on pocket: What You Need"
 ---
 
+To make Lucy, you will need the following:
+
 - [Basic sewing supplies](/docs/sewing/basic-sewing-supplies)
 - About 0.5 meters (0.6 yards) of suitable fabric ([see Fabric options](/docs/designs/lucy/fabric))
 - About 0.5 meters (0.6 yards) of fabric if using a lining
 - About 2 meters (2.2 yards) of bias binding or strips of fabric if binding the edges
 - A length of tape that you can tie around your waist to make the ties with
+
+<Note>
+
+#### Piecing is Period!
+
+Pockets like these do not need to be made out of whole pieces of fabric, you can piece together scraps into a large enough piece to cut your pocket pattern out of. Neither do both sides need to be made out of the same fabric. 
+
+</Note>

--- a/markdown/org/docs/designs/lucy/options/edge/en.md
+++ b/markdown/org/docs/designs/lucy/options/edge/en.md
@@ -1,8 +1,8 @@
 ---
-title: undefined
+title: Edge
 ---
 
-undefined
+This option controls the width of the top edge of your pocket. 
 
 
 

--- a/markdown/org/docs/designs/lucy/options/length/en.md
+++ b/markdown/org/docs/designs/lucy/options/length/en.md
@@ -1,8 +1,8 @@
 ---
-title: undefined
+title: Length
 ---
 
-undefined
+The length option determines how long your pocket will be. 
 
 
 

--- a/markdown/org/docs/designs/lucy/options/width/en.md
+++ b/markdown/org/docs/designs/lucy/options/width/en.md
@@ -1,8 +1,8 @@
 ---
-title: undefined
+title: Width
 ---
 
-undefined
+This option determines the width of the pocket overall. 
 
 
 


### PR DESCRIPTION
These files seem to have been caught in the crossfire of fixing crowing issues with uppercased files. This reverts those changes.