### PR TITLE
fix(shared): Add optional measurements to pattern Edit Measurements by Hand

### DIFF
--- a/sites/shared/components/workbench/views/measies/editor.mjs
+++ b/sites/shared/components/workbench/views/measies/editor.mjs
@@ -4,10 +4,10 @@ import { MeasieInput, ns as inputNs } from 'shared/components/inputs.mjs'
 import { useTranslation } from 'next-i18next'
 import { DynamicMdx } from 'shared/components/mdx/dynamic.mjs'
 
-export const ns = nsMerge('workbench', inputNs)
+export const ns = nsMerge('workbench', 'account', inputNs)
 
 export const MeasiesEditor = ({ Design, settings, update }) => {
-  const { i18n } = useTranslation(ns)
+  const { t, i18n } = useTranslation(ns)
 
   const onUpdate = (m, newVal) => {
     update.settings(['measurements', m], newVal)
@@ -15,19 +15,48 @@ export const MeasiesEditor = ({ Design, settings, update }) => {
 
   return (
     <div className="max-w-2xl mx-auto">
-      {Design.patternConfig.measurements.map((m) => (
-        <MeasieInput
-          key={m}
-          m={m}
-          imperial={settings.units === 'umperial' ? true : false}
-          original={settings.measurements?.[m]}
-          update={(m, newVal) => onUpdate(m, newVal)}
-          id={`edit-${m}`}
-          docs={
-            <DynamicMdx language={i18n.language} slug={`docs/measurements/${m.toLowerCase()}`} />
-          }
-        />
-      ))}
+      <h5>{t('account:requiredMeasurements')}</h5>
+      {Object.keys(Design.patternConfig.measurements).length === 0 ? (
+        <p>(None)</p>
+      ) : (
+        <div>
+          {Design.patternConfig.measurements.map((m) => (
+            <MeasieInput
+              key={m}
+              m={m}
+              imperial={settings.units === 'imperial' ? true : false}
+              original={settings.measurements?.[m]}
+              update={(m, newVal) => onUpdate(m, newVal)}
+              id={`edit-${m}`}
+              docs={
+                <DynamicMdx
+                  language={i18n.language}
+                  slug={`docs/measurements/${m.toLowerCase()}`}
+                />
+              }
+            />
+          ))}
+          <br />
+        </div>
+      )}
+      <h5>{t('account:optionalMeasurements')}</h5>
+      {Object.keys(Design.patternConfig.optionalMeasurements).length === 0 ? (
+        <p>(None)</p>
+      ) : (
+        Design.patternConfig.optionalMeasurements.map((m) => (
+          <MeasieInput
+            key={m}
+            m={m}
+            imperial={settings.units === 'umperial' ? true : false}
+            original={settings.measurements?.[m]}
+            update={(m, newVal) => onUpdate(m, newVal)}
+            id={`edit-${m}`}
+            docs={
+              <DynamicMdx language={i18n.language} slug={`docs/measurements/${m.toLowerCase()}`} />
+            }
+          />
+        ))
+      )}
     </div>
   )
 }


### PR DESCRIPTION
(There is an analogous situation with Account -> Create a new measurements set -> Edit Measurement Sets -> Filter by Design where optional measurement fields aren't seen. For example, if you select Brian you don't get the opportunity to enter the optional `highBust` measurement. That other situation is not addressed by this PR.)

How things look with the PR, with a variety of designs:
![Screenshot 2024-02-16 at 5 28 21 PM](https://github.com/freesewing/freesewing/assets/109869956/3e80f22d-93e6-48b7-b20e-e32cefc79e18)
![Screenshot 2024-02-16 at 5 26 46 PM](https://github.com/freesewing/freesewing/assets/109869956/644ad404-ba95-4e9a-b5c6-35cf46e395e3)
![Screenshot 2024-02-16 at 5 26 14 PM](https://github.com/freesewing/freesewing/assets/109869956/a807f01e-ecb9-4378-9df4-33b705e8d0b7)
![Screenshot 2024-02-16 at 5 28 43 PM](https://github.com/freesewing/freesewing/assets/109869956/50250bbb-681b-4073-8097-09083bae17c3)
