### PR TITLE
fix(shared, plugins): Provide measurement set name to patterns

### DIFF
--- a/plugins/plugin-annotations/src/title.mjs
+++ b/plugins/plugin-annotations/src/title.mjs
@@ -142,7 +142,7 @@ const title = function (config, { Point, points, scale, locale, store, part, log
 
       `${mc.classes.name} ${mc.align}`
     )
-    .addText(store.data?.for ? store.data.for : 'ephemeral')
+    .addText(store.data?.setName ? store.data.setName : 'ephemeral')
     .addText(')')
     .attr('data-text-transform', transform)
     .attr('data-render-always', 1) // Render even when outside the part bounding box

--- a/sites/shared/components/workbench/exporting/export-handler.mjs
+++ b/sites/shared/components/workbench/exporting/export-handler.mjs
@@ -15,6 +15,7 @@ import {
 import get from 'lodash.get'
 import mustache from 'mustache'
 import he from 'he'
+import yaml from 'js-yaml'
 
 export const ns = ['cut', 'plugin', 'common']
 export const exportTypes = {
@@ -185,13 +186,26 @@ export const handleExport = async ({
         }
       }
 
+      // Initialize the pattern stores
+      pattern.getConfig()
+
+      // Save the measurement set name to pattern stores
+      if (settings?.metadata?.setName) {
+        pattern.store.set('data.setName', settings.metadata.setName)
+        for (const store of pattern.setStores) store.set('data.setName', settings.metadata.setName)
+      }
+
       // draft and render the pattern
       pattern.draft()
       workerArgs.svg = pattern.render()
 
-      // Save pattern forName, notes, warnings info for coversheet
+      // Get coversheet info: setName, settings YAML, version, notes, warnings
       const store = pattern.setStores[pattern.activeSet]
-      workerArgs.strings.forName = store.get('data.for', 'ephemeral')
+      workerArgs.strings.setName = settings?.metadata?.setName
+        ? settings.metadata.setName
+        : 'ephemeral'
+      workerArgs.strings.yaml = yaml.dump(settings)
+      workerArgs.strings.version = store?.data?.version ? store.data.version : ''
       const notes = store?.plugins?.['plugin-annotations']?.flags?.note
         ? store?.plugins?.['plugin-annotations']?.flags?.note
         : []

--- a/sites/shared/components/workbench/exporting/export-worker.js
+++ b/sites/shared/components/workbench/exporting/export-worker.js
@@ -51,9 +51,6 @@ const exportYaml = (settings) => exportBlob(yaml.dump(settings), 'application/x-
 const exportSvg = (svg) => exportBlob(svg, 'image/svg+xml')
 
 const exportPdf = async (data) => {
-  // Save yaml for coversheet
-  data.strings.yaml = yaml.dump(data.settings)
-
   const maker = data.format === 'pdf' ? new SinglePdfMaker(data) : new PdfMaker(data)
   await maker.makePdf()
   postSuccess(await maker.toBlob())

--- a/sites/shared/components/workbench/exporting/pdf-maker.mjs
+++ b/sites/shared/components/workbench/exporting/pdf-maker.mjs
@@ -125,7 +125,6 @@ export class PdfMaker {
     this.addText(this.strings.design, 32)
     let savedLineLevel = this.lineLevel - 27
     let savedWidth = this.pdf.widthOfString(this.strings.design) + 50
-    let nameString = this.strings.design
     const versionSetString = ' v' + this.strings.version + ' ( ' + this.strings.setName + ' )'
     this.pdf.fontSize(18)
     this.pdf.text(versionSetString, savedWidth, savedLineLevel)

--- a/sites/shared/components/workbench/exporting/pdf-maker.mjs
+++ b/sites/shared/components/workbench/exporting/pdf-maker.mjs
@@ -121,14 +121,18 @@ export class PdfMaker {
     // FreeSewing tag
     this.addText('FreeSewing', 20).addText(this.strings.tagline, 10, 4)
 
-    // Design name
+    // Design name, version, and Measurement Set
     this.addText(this.strings.design, 32)
+    let savedLineLevel = this.lineLevel - 27
+    let savedWidth = this.pdf.widthOfString(this.strings.design) + 50
+    let nameString = this.strings.design
+    const versionSetString = ' v' + this.strings.version + ' ( ' + this.strings.setName + ' )'
+    this.pdf.fontSize(18)
+    this.pdf.text(versionSetString, savedWidth, savedLineLevel)
 
-    // Measurement Set
-    this.addText('Measurement Set: ' + this.strings.forName, 10)
-
-    // Date
+    // Date and timestamp
     const currentDateTime = new Date().toLocaleString('en', {
+      weekday: 'long',
       year: 'numeric',
       month: 'short',
       day: 'numeric',
@@ -136,12 +140,12 @@ export class PdfMaker {
       minute: 'numeric',
       timeZoneName: 'short',
     })
-    this.addText('PDF Generated: ' + currentDateTime, 10)
+    this.addText(currentDateTime, 10)
 
     // Settings YAML
-    const savedLineLevel = this.lineLevel + 2
-    const savedWidth = this.pdf.widthOfString('Settings: ') + 50
     this.addText('Settings: ', 10)
+    savedLineLevel = this.lineLevel - 9
+    savedWidth = this.pdf.widthOfString('Settings: ') + 50
     this.pdf.fontSize(6)
     this.pdf.text('(Measurement values are in mm.)', savedWidth, savedLineLevel)
     this.addText(this.strings.yaml, 8)

--- a/sites/shared/components/workbench/new.mjs
+++ b/sites/shared/components/workbench/new.mjs
@@ -215,6 +215,13 @@ export const Workbench = ({ design, Design, saveAs = false, preload = false }) =
       if (typeof pattern.getConfig !== 'function') return null
 
       const patternConfig = pattern.getConfig()
+
+      // Save the measurement set name to pattern stores
+      if (settings?.metadata?.setName) {
+        pattern.store.set('data.setName', settings.metadata.setName)
+        for (const store of pattern.setStores) store.set('data.setName', settings.metadata.setName)
+      }
+
       if (ui.renderer === 'svg') {
         // Add theme to svg renderer
         pattern.use(pluginI18n, (key) => t(key))

--- a/sites/shared/components/workbench/views/measies/index.mjs
+++ b/sites/shared/components/workbench/views/measies/index.mjs
@@ -3,7 +3,7 @@
 import { Fragment } from 'react'
 import { nsMerge } from 'shared/utils.mjs'
 import { ns as authNs } from 'shared/components/wrappers/auth/index.mjs'
-import { designMeasurements, horFlexClasses } from 'shared/utils.mjs'
+import { designMeasurements, horFlexClasses, capitalize } from 'shared/utils.mjs'
 // Hooks
 import { useTranslation } from 'next-i18next'
 // Components
@@ -24,12 +24,21 @@ const iconClasses = { className: 'w-8 h-8 md:w-10 md:h-10 lg:w-12 lg:h-12 shrink
 
 export const MeasiesView = ({ design, Design, settings, update, missingMeasurements, setView }) => {
   const { t } = useTranslation(['workbench'])
+  const { i18n } = useTranslation(ns)
+  const lang = i18n.language
 
   const loadMeasurements = (set) => {
     update.settings([
       [['measurements'], designMeasurements(Design, set.measies)],
       [['units'], set.imperial ? 'imperial' : 'metric'],
     ])
+    // Save the measurement set name to pattern settings
+    if (set[`name${capitalize(lang)}`])
+      // Curated measurement set
+      update.settings([[['metadata'], { setName: set[`name${capitalize(lang)}`] }]])
+    else if (set?.name)
+      // User measurement set
+      update.settings([[['metadata'], { setName: set.name }]])
     setView('draft')
   }
 


### PR DESCRIPTION
Closes #6051.

This PR:
- Passes measurement set name to the pattern, so the `title` macro can display it.
- Also adds the measurement set name to the PDF cover sheet.
- Makes some changes to the PDF cover sheet, how things are formatted/presented.

Please note that this PR introduces a new `settings.metadata.setName` setting which is not a part of Core. I felt that I had to do this to be able to provide the set name to the export handler. Otherwise the `title` macro would display "ephemeral" on PDFs. (If there is a different way to do this without introducing the non-official, non-Core setting, this PR can be rewokred to do so.)

![Screenshot 2024-02-16 at 5 40 55 PM](https://github.com/freesewing/freesewing/assets/109869956/079c0a2c-b38d-4922-a75b-1a8b28a124fa)
![Screenshot 2024-02-16 at 5 41 33 PM](https://github.com/freesewing/freesewing/assets/109869956/3e2c5114-5ee8-4704-b70a-f6e8f937481c)
![Screenshot 2024-02-16 at 5 43 19 PM](https://github.com/freesewing/freesewing/assets/109869956/fb2ecdba-ac99-49a1-aa0f-fec417460942)
