### PR TITLE
fix(shared): Add set names to curated set buttons

### DIFF
--- a/sites/shared/components/curated-sets.mjs
+++ b/sites/shared/components/curated-sets.mjs
@@ -76,7 +76,20 @@ const SetLineup = ({ sets = [], href = false, onClick = false }) => (
       if (onClick) props.onClick = () => onClick(set)
       else if (typeof href === 'function') props.href = href(set.id)
 
-      if (onClick) return <button {...props} key={set.id}></button>
+      const { i18n } = useTranslation(ns)
+      const lang = i18n.language
+      if (onClick)
+        return (
+          <div>
+            <div>
+              <button {...props} key={set.id}></button>
+            </div>
+            <div className="text-xl absolute">
+              <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
+              <span>{set[`name${capitalize(lang)}`]}</span>
+            </div>
+          </div>
+        )
       else if (href) return <Link {...props} key={set.id}></Link>
       else return <div {...props} key={set.id}></div>
     })}

--- a/sites/shared/components/curated-sets.mjs
+++ b/sites/shared/components/curated-sets.mjs
@@ -50,51 +50,54 @@ import {
 
 export const ns = ['account', 'patterns', 'status', 'measurements', 'sets', inputNs]
 
-const SetLineup = ({ sets = [], href = false, onClick = false }) => (
-  <div
-    className={`w-full flex flex-row ${
-      sets.length > 1 ? 'justify-start px-8' : 'justify-center'
-    } overflow-x-scroll`}
-    style={{
-      backgroundImage: `url(/img/lineup-backdrop.svg)`,
-      width: 'auto',
-      backgroundSize: 'auto 100%',
-      backgroundRepeat: 'repeat-x',
-    }}
-  >
-    {sets.map((set) => {
-      const props = {
-        className: 'aspect-[1/3] w-auto h-96',
-        style: {
-          backgroundImage: `url(${cloudflareImageUrl({ id: `cset-${set.id}`, type: 'lineup' })})`,
-          width: 'auto',
-          backgroundSize: 'contain',
-          backgroundRepeat: 'no-repeat',
-          backgroundPosition: 'center',
-        },
-      }
-      if (onClick) props.onClick = () => onClick(set)
-      else if (typeof href === 'function') props.href = href(set.id)
+const SetLineup = ({ sets = [], href = false, onClick = false }) => {
+  const { i18n } = useTranslation(ns)
+  const lang = i18n.language
+  return (
+    <div
+      className={`w-full flex flex-row ${
+        sets.length > 1 ? 'justify-start px-8' : 'justify-center'
+      } overflow-x-scroll`}
+      style={{
+        backgroundImage: `url(/img/lineup-backdrop.svg)`,
+        width: 'auto',
+        backgroundSize: 'auto 100%',
+        backgroundRepeat: 'repeat-x',
+      }}
+    >
+      {sets.map((set) => {
+        const props = {
+          className: 'aspect-[1/3] w-auto h-96',
+          style: {
+            backgroundImage: `url(${cloudflareImageUrl({ id: `cset-${set.id}`, type: 'lineup' })})`,
+            width: 'auto',
+            backgroundSize: 'contain',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+          },
+        }
 
-      const { i18n } = useTranslation(ns)
-      const lang = i18n.language
-      if (onClick)
-        return (
-          <div>
+        if (onClick) props.onClick = () => onClick(set)
+        else if (typeof href === 'function') props.href = href(set.id)
+
+        if (onClick)
+          return (
             <div>
-              <button {...props} key={set.id}></button>
+              <div>
+                <button {...props} key={set.id}></button>
+              </div>
+              <div className="text-xl absolute">
+                <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
+                <span>{set[`name${capitalize(lang)}`]}</span>
+              </div>
             </div>
-            <div className="text-xl absolute">
-              <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-              <span>{set[`name${capitalize(lang)}`]}</span>
-            </div>
-          </div>
-        )
-      else if (href) return <Link {...props} key={set.id}></Link>
-      else return <div {...props} key={set.id}></div>
-    })}
-  </div>
-)
+          )
+        else if (href) return <Link {...props} key={set.id}></Link>
+        else return <div {...props} key={set.id}></div>
+      })}
+    </div>
+  )
+}
 
 const ShowCuratedSet = ({ cset }) => {
   const { control } = useAccount()


### PR DESCRIPTION
Closes #5898.

This was the best I could come up with. Someone better at CSS positioning might be able to do better.
- There is a `text-center` Tailwind class that makes the text alignment looks much better. However, that class doesn't work with `absolute` positioning.
- I had to use `absolute` positioning because otherwise the additional text would alter the vertical alignment of the image models, causing the heights of the models to be incorrect compared to the height marker background.
- So, I used `&nbsp;` characters to try to manually position the text, which is not a great thing to do.

![Screenshot 2024-02-16 at 5 55 29 PM](https://github.com/freesewing/freesewing/assets/109869956/4240c384-dddb-4f39-bbf9-c57b37659a57)