### PR TITLE
feat: Changes to handle per-set bust plugin conditionality

### DIFF
--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -1,5 +1,7 @@
 Unreleased:
   Changed:
+    brian:
+      - Always load plugin-bust due to its changes in how it handle conditionality.
     plugin-bust:
       - This plugin now uses the `preSetDraft` rather than `preDraft` lifecycle hook
       - Conditionality has been moved to the `preSetDraft` lifecycle hook, rather than exposing a `withCondition` named export

--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -1,3 +1,18 @@
+Unreleased:
+  Changed:
+    plugin-bust:
+      - This plugin now uses the `preSetDraft` rather than `preDraft` lifecycle hook
+      - Conditionality has been moved to the `preSetDraft` lifecycle hook, rather than exposing a `withCondition` named export
+      - The plugin will now always be loaded, but will check for each drafted set whether it should make any changes.
+
+  Deprecated:
+    plugin-bust:
+      - The `withCondition` named  export is deprecated and will always return true.
+
+  Fixed:
+    hugo:
+      - Add missing dimension id attributes
+
 3.2.0:
   date: 2024-02-11
 

--- a/designs/brian/src/base.mjs
+++ b/designs/brian/src/base.mjs
@@ -1,4 +1,4 @@
-import { withCondition as bustPlugin } from '@freesewing/plugin-bust'
+import { bustPlugin } from '@freesewing/plugin-bust'
 
 export const base = {
   name: 'brian.base',

--- a/markdown/dev/reference/hooks/predraft/en.md
+++ b/markdown/dev/reference/hooks/predraft/en.md
@@ -20,4 +20,7 @@ pattern.on('preDraft', pattern => {
 
 ## Notes
 
-The `preDraft` hook is rarely used, but it's there if you need it.
+The `preDraft` hook fires once for all the sets in the pattern.
+While typically, there is only one set, there might be more. 
+In that case, the [`preSetDraft` lifecycle hook](/reference/hooks/presetdraft) is
+the per-set equivalent of this hook.

--- a/markdown/dev/reference/hooks/presetdraft/en.md
+++ b/markdown/dev/reference/hooks/presetdraft/en.md
@@ -21,4 +21,15 @@ pattern.on('preSetDraft', pattern => {
 
 ## Notes
 
-The `preSetDraft` hook is rarely used, but it's there if you need it.
+The `preSetDraft` fires once for each set in the pattern.
+
+The pattern tracks the active set on the `activeSet` property. 
+So if you are using this hook and would like to get access to teh active set, you can do so like this:
+
+```js
+pattern.on('preSetDraft', ({ settings, activeSet }) => {
+  const set = settings[Number(activeSet)]
+
+  // Now set holds the active set of settings
+}
+```

--- a/plugins/plugin-bust/src/index.mjs
+++ b/plugins/plugin-bust/src/index.mjs
@@ -4,13 +4,12 @@ export const plugin = {
   name,
   version,
   hooks: {
-    preDraft: function ({ settings }) {
-      for (const i in settings) {
-        if (settings[i].measurements) {
-          if (typeof settings[i].measurements.bust === 'undefined') {
-            settings[i].measurements.bust = settings[i].measurements.chest
-            settings[i].measurements.chest = settings[i].measurements.highBust
-          }
+    preSetDraft: function ({ settings, activeSet }) {
+      const set = settings[Number(activeSet)]
+      if (set.measurements && set.options?.draftForHighBust && set.measurements?.highBust) {
+        if (typeof set.measurements.bust === 'undefined') {
+          set.measurements.bust = set.measurements.chest
+          set.measurements.chest = set.measurements.highBust
         }
       }
     },
@@ -24,6 +23,11 @@ export const pluginBust = plugin
 // Helper method to conditionally load this plugin
 export const withCondition = {
   plugin,
-  condition: (settings = false) =>
-    settings?.options?.draftForHighBust && settings?.measurements?.highBust ? true : false,
+  condition: (settings = false) => {
+    console.log(
+      "WARNING: The 'withCondition' named export in @freesewing/plugin-bust is deprecated. Conditionality has moved to the preSetDraft lifecycle hook"
+    )
+
+    return true
+  },
 }

--- a/plugins/plugin-bust/src/index.mjs
+++ b/plugins/plugin-bust/src/index.mjs
@@ -23,7 +23,7 @@ export const pluginBust = plugin
 // Helper method to conditionally load this plugin
 export const withCondition = {
   plugin,
-  condition: (settings = false) => {
+  condition: () => {
     console.log(
       "WARNING: The 'withCondition' named export in @freesewing/plugin-bust is deprecated. Conditionality has moved to the preSetDraft lifecycle hook"
     )

--- a/plugins/plugin-bust/tests/plugin.test.mjs
+++ b/plugins/plugin-bust/tests/plugin.test.mjs
@@ -6,9 +6,10 @@ const measurements = {
   chest: 100,
   highBust: 90,
 }
+const options = { draftForHighBust: true }
 
 const Pattern = new Design()
-const pattern = new Pattern({ measurements }).use(plugin)
+const pattern = new Pattern({ measurements, options }).use(plugin)
 pattern.draft()
 
 describe('Bust plugin Tests', () => {
@@ -18,9 +19,7 @@ describe('Bust plugin Tests', () => {
   })
 
   it('Should copy measurement from chest to bust and from highBust to chest', function () {
-    const testPattern = new Design({
-      measurements: [],
-    })
+    const testPattern = new Design({ measurements: [], options })
     const pattern = new testPattern().use(plugin)
     const userMeasurements = { chest: 50, highBust: 60 }
     pattern.settings[0].measurements = userMeasurements
@@ -30,7 +29,7 @@ describe('Bust plugin Tests', () => {
   })
 
   it('Should not overwrite existing bust measurements', function () {
-    let config = { measurements: [] }
+    let config = { measurements: [], options }
     const testPattern = new Design(config, plugin)
     let pattern = new testPattern()
     let userMeasurements = { chest: 50, highBust: 60, bust: 55 }

--- a/sites/shared/components/curated-sets.mjs
+++ b/sites/shared/components/curated-sets.mjs
@@ -86,11 +86,7 @@ const SetLineup = ({ sets = [], lang, href = false, onClick = false }) => (
       let img = <div {...props} key={set.id}></div>
       if (onClick) img = <button {...props} key={set.id}></button>
       else if (href) img = <Link {...props} key={set.id}></Link>
-      return (
-        <SetNameWrapper key={set.id} name={set[`name${capitalize(lang)}`]}>
-          {img}
-        </SetNameWrapper>
-      )
+      return <SetNameWrapper name={set[`name${capitalize(lang)}`]}>{img}</SetNameWrapper>
     })}
   </div>
 )

--- a/sites/shared/components/curated-sets.mjs
+++ b/sites/shared/components/curated-sets.mjs
@@ -50,7 +50,14 @@ import {
 
 export const ns = ['account', 'patterns', 'status', 'measurements', 'sets', inputNs]
 
-const SetLineup = ({ sets = [], href = false, onClick = false }) => (
+const SetNameWrapper = ({ name, children }) => (
+  <div className="flex flex-col items-center">
+    {children}
+    <b>{name}</b>
+  </div>
+)
+
+const SetLineup = ({ sets = [], lang, href = false, onClick = false }) => (
   <div
     className={`w-full flex flex-row ${
       sets.length > 1 ? 'justify-start px-8' : 'justify-center'
@@ -76,9 +83,10 @@ const SetLineup = ({ sets = [], href = false, onClick = false }) => (
       if (onClick) props.onClick = () => onClick(set)
       else if (typeof href === 'function') props.href = href(set.id)
 
-      if (onClick) return <button {...props} key={set.id}></button>
-      else if (href) return <Link {...props} key={set.id}></Link>
-      else return <div {...props} key={set.id}></div>
+      let img = <div {...props} key={set.id}></div>
+      if (onClick) img = <button {...props} key={set.id}></button>
+      else if (href) img = <Link {...props} key={set.id}></Link>
+      return <SetNameWrapper name={set[`name${capitalize(lang)}`]}>{img}</SetNameWrapper>
     })}
   </div>
 )
@@ -95,7 +103,7 @@ const ShowCuratedSet = ({ cset }) => {
     <>
       <h2>{cset[`name${capitalize(lang)}`]}</h2>
       <div className="w-full">
-        <SetLineup sets={[cset]} />
+        <SetLineup sets={[cset]} lang={lang} />
       </div>
 
       <div className="flex flex-wrap flex-row gap-2 w-full mt-4 items-center justify-end">
@@ -206,6 +214,8 @@ export const CuratedSets = ({ href = false, clickHandler = false, published = tr
   // Hooks
   const backend = useBackend()
   const { setLoadingStatus } = useContext(LoadingStatusContext)
+  const { i18n } = useTranslation(ns)
+  const lang = i18n.language
 
   // State
   const [sets, setSets] = useState([])
@@ -236,7 +246,7 @@ export const CuratedSets = ({ href = false, clickHandler = false, published = tr
 
   return (
     <div className="max-w-7xl xl:pl-4">
-      <SetLineup {...lineupProps} />
+      <SetLineup {...lineupProps} lang={lang} />
       {selected && <ShowCuratedSet cset={sets[selected]} />}
     </div>
   )
@@ -245,7 +255,8 @@ export const CuratedSets = ({ href = false, clickHandler = false, published = tr
 // Component for the maintaining the list of curated-sets
 export const CuratedSetsList = ({ href = false }) => {
   // Hooks
-  const { t } = useTranslation(ns)
+  const { t, i18n } = useTranslation(ns)
+  const lang = i18n.language
   const backend = useBackend()
   const { setLoadingStatus, LoadingProgress } = useContext(LoadingStatusContext)
   const [refresh, setRefresh] = useState(0)
@@ -371,7 +382,7 @@ export const CuratedSetsList = ({ href = false }) => {
           ))}
         </tbody>
       </table>
-      <SetLineup {...lineupProps} />
+      <SetLineup {...lineupProps} lang={lang} />
     </div>
   )
 }

--- a/sites/shared/components/curated-sets.mjs
+++ b/sites/shared/components/curated-sets.mjs
@@ -50,14 +50,7 @@ import {
 
 export const ns = ['account', 'patterns', 'status', 'measurements', 'sets', inputNs]
 
-const SetNameWrapper = ({ name, children }) => (
-  <div className="flex flex-col items-center">
-    {children}
-    <b>{name}</b>
-  </div>
-)
-
-const SetLineup = ({ sets = [], lang, href = false, onClick = false }) => (
+const SetLineup = ({ sets = [], href = false, onClick = false }) => (
   <div
     className={`w-full flex flex-row ${
       sets.length > 1 ? 'justify-start px-8' : 'justify-center'
@@ -83,10 +76,9 @@ const SetLineup = ({ sets = [], lang, href = false, onClick = false }) => (
       if (onClick) props.onClick = () => onClick(set)
       else if (typeof href === 'function') props.href = href(set.id)
 
-      let img = <div {...props} key={set.id}></div>
-      if (onClick) img = <button {...props} key={set.id}></button>
-      else if (href) img = <Link {...props} key={set.id}></Link>
-      return <SetNameWrapper name={set[`name${capitalize(lang)}`]}>{img}</SetNameWrapper>
+      if (onClick) return <button {...props} key={set.id}></button>
+      else if (href) return <Link {...props} key={set.id}></Link>
+      else return <div {...props} key={set.id}></div>
     })}
   </div>
 )
@@ -103,7 +95,7 @@ const ShowCuratedSet = ({ cset }) => {
     <>
       <h2>{cset[`name${capitalize(lang)}`]}</h2>
       <div className="w-full">
-        <SetLineup sets={[cset]} lang={lang} />
+        <SetLineup sets={[cset]} />
       </div>
 
       <div className="flex flex-wrap flex-row gap-2 w-full mt-4 items-center justify-end">
@@ -214,8 +206,6 @@ export const CuratedSets = ({ href = false, clickHandler = false, published = tr
   // Hooks
   const backend = useBackend()
   const { setLoadingStatus } = useContext(LoadingStatusContext)
-  const { i18n } = useTranslation(ns)
-  const lang = i18n.language
 
   // State
   const [sets, setSets] = useState([])
@@ -246,7 +236,7 @@ export const CuratedSets = ({ href = false, clickHandler = false, published = tr
 
   return (
     <div className="max-w-7xl xl:pl-4">
-      <SetLineup {...lineupProps} lang={lang} />
+      <SetLineup {...lineupProps} />
       {selected && <ShowCuratedSet cset={sets[selected]} />}
     </div>
   )
@@ -255,8 +245,7 @@ export const CuratedSets = ({ href = false, clickHandler = false, published = tr
 // Component for the maintaining the list of curated-sets
 export const CuratedSetsList = ({ href = false }) => {
   // Hooks
-  const { t, i18n } = useTranslation(ns)
-  const lang = i18n.language
+  const { t } = useTranslation(ns)
   const backend = useBackend()
   const { setLoadingStatus, LoadingProgress } = useContext(LoadingStatusContext)
   const [refresh, setRefresh] = useState(0)
@@ -382,7 +371,7 @@ export const CuratedSetsList = ({ href = false }) => {
           ))}
         </tbody>
       </table>
-      <SetLineup {...lineupProps} lang={lang} />
+      <SetLineup {...lineupProps} />
     </div>
   )
 }

--- a/sites/shared/components/curated-sets.mjs
+++ b/sites/shared/components/curated-sets.mjs
@@ -86,7 +86,11 @@ const SetLineup = ({ sets = [], lang, href = false, onClick = false }) => (
       let img = <div {...props} key={set.id}></div>
       if (onClick) img = <button {...props} key={set.id}></button>
       else if (href) img = <Link {...props} key={set.id}></Link>
-      return <SetNameWrapper name={set[`name${capitalize(lang)}`]}>{img}</SetNameWrapper>
+      return (
+        <SetNameWrapper key={set.id} name={set[`name${capitalize(lang)}`]}>
+          {img}
+        </SetNameWrapper>
+      )
     })}
   </div>
 )


### PR DESCRIPTION
The `plugin-bust` plugin is used to draft designs for high bust rather than full chest circumference. To facilitate that, we provide(d) a named export called `withCondition` that checks whether the plugin is wanted, and if so loads it.

Problem with that is that the conditional loading of a plugin applied to the entire pattern. And since we support drafting patterns for multiple sets (and use this to sample) this means that all of these sets would either get the plugin effect or not, based on the first set.

So, to fix that, we have changed the lifecycle hook used by this plugin to `preSetDraft` (from `preDraft`) and changed the `withCondition` method to always return true.

This means that the plugin will always be loaded, and we have moved the check that used to be in `withCondition` to the lifecycle hook.
In other words, this plugin will now always be loaded and will check for each set whether it needs to do something.

This allows the conditionality to apply to each set in the pattern, rather than to the entire pattern.

Note that conditionally loading plugins pattern-wide is still a valid use-case. It just so happens that for this plugin, it was the wrong approach.

This PR also contains flanking changes:
- Updated brian to always load the bust plugin
- Improved some dev docs