### PR TITLE
fix(hugo): Correct waistband grainline direction

### DIFF
--- a/designs/hugo/i18n/en.json
+++ b/designs/hugo/i18n/en.json
@@ -15,15 +15,15 @@
   },
   "s": {
     "cutPocket.t": "The pocket is not shown",
-    "cutPocket.d": "The **Pocket** (4) is not shown, but you can trace it from the Front part (1), which has the pocket outline on it (not including seam allowance).",
+    "cutPocket.d": "The **Pocket** (4) is not shown, but you can trace it from the Front part (1), which has the pocket outline on it (not including seam allowance). The front part's cut-on-fold-and-grainline is also the pocket's cut-on-fold-and grainline.",
     "cutCuff.t": "The cuff is not shown",
-    "cutCuff.d": "The **Cuff** (9) is a rectangular piece of ribbing fabric {{{ w }}} wide and {{{ l }}} long.",
+    "cutCuff.d": "The **Cuff** (9) is a rectangular piece of ribbing fabric {{{ w }}} wide and {{{ l }}} long, with the grainline parallel to the width.",
     "cutHoodCenter.t": "The hood center is not shown",
-    "cutHoodCenter.d": "The **Hood center** (7) is a rectangular piece of ribbing fabric {{{ w }}} wide and {{{ l }}} long.",
+    "cutHoodCenter.d": "The **Hood center** (7) is a rectangular piece of ribbing fabric {{{ w }}} wide and {{{ l }}} long, with the grainline parallel to the width.",
     "cutNeckBinding.t": "The neck binding is not shown",
-    "cutNeckBinding.d": "The **Neck Binding** (10) is a rectangular piece of ribbing fabric {{{ w }}} wide and {{{ l }}} long.",
+    "cutNeckBinding.d": "The **Neck Binding** (10) is a rectangular piece of ribbing fabric {{{ w }}} wide and {{{ l }}} long, with the grainline parallel to the length.",
     "cutWaistband.t": "The waistband is not shown",
-    "cutWaistband.d": "The **Waistband** (8) is a rectangular piece of ribbing fabric {{{ w }}} wide and {{{ l }}} long"
+    "cutWaistband.d": "The **Waistband** (8) is a rectangular piece of ribbing fabric {{{ w }}} wide and {{{ l }}} long, with the grainline parallel to the width."
   },
   "o": {
     "ribbingHeight": {

--- a/designs/hugo/src/waistband.mjs
+++ b/designs/hugo/src/waistband.mjs
@@ -69,8 +69,8 @@ function hugoWaistband({
 
   // Grainline
   macro('grainline', {
-    from: points.bottomLeft.shift(0, 15),
-    to: points.topLeft.shift(0, 15),
+    from: points.topLeft.shift(290, 25),
+    to: points.topRight.shift(250, 25),
   })
 
   // Dimensions


### PR DESCRIPTION
Fixes #6085.

Also added missing grainline info to expand flag details.

After:
![Screenshot 2024-02-17 at 6 49 08 PM](https://github.com/freesewing/freesewing/assets/109869956/15234dfd-a281-4a45-a7fd-54995b5abc98)
