### PR TITLE
fix(shared): Export for Editing PDF files are not generating

### DIFF
--- a/sites/shared/components/workbench/exporting/export-handler.mjs
+++ b/sites/shared/components/workbench/exporting/export-handler.mjs
@@ -176,14 +176,14 @@ export const handleExport = async ({
             setPatternSize: true,
           })
         )
+      }
 
-        // add the strings that are used on the cover page
-        workerArgs.strings = {
-          design: capitalize(design),
-          tagline: t('common:slogan1') + '. ' + t('common:slogan2'),
-          url: window.location.href,
-          cuttingLayout: t('cut:cuttingLayout'),
-        }
+      // add the strings that are used on the cover page
+      workerArgs.strings = {
+        design: capitalize(design),
+        tagline: t('common:slogan1') + '. ' + t('common:slogan2'),
+        url: window.location.href,
+        cuttingLayout: t('cut:cuttingLayout'),
       }
 
       // Initialize the pattern stores


### PR DESCRIPTION
A FreeSewing user discovered that Export for Editing PDFs were not generating, even though Export for Printing PDFs were:
https://discord.com/channels/698854858052075530/1208712564456820766/1208712564456820766
discord://discord.com/channels/698854858052075530/1208712564456820766/1208712564456820766

The coversheet `workerArgs.strings` variable was being initialized only for "Export for Printing" PDFs, resulting in an uninitialized variable error that resulted in the issue.

The error was introduced when I added extra `workerArgs.strings` for additional PDF coverpage info.

![Screenshot 2024-02-18 at 6 54 04 AM](https://github.com/freesewing/freesewing/assets/109869956/a45e48e2-6ca6-451a-8ab8-c876b0ee99f2)
