### PR TITLE
fix(lab): Add jargon file

### DIFF
--- a/sites/lab/components/jargon.mjs
+++ b/sites/lab/components/jargon.mjs
@@ -1,0 +1,16 @@
+import { Term as SharedTerm } from 'shared/components/jargon.mjs'
+
+/*
+ * This object holds jargon terminology for FreeSewing.lab
+ *
+ * - No actual jargon should be added to this file. Instead, add your
+ *   jargon to the org and dev files.
+ * - This file simply needs to exist in order for the lab development
+ *   environment to run.
+ */
+const jargon = {}
+
+/*
+ * DO NOT CHANGE ANYTHING BELOW THIS LINE
+ */
+export const Term = ({ children }) => <SharedTerm {...{ jargon, children }} site="lab" />


### PR DESCRIPTION
The localhost lab needed the new jargon file to be able to run.

![Screenshot 2024-02-18 at 9 12 37 AM](https://github.com/freesewing/freesewing/assets/109869956/d0ff8b61-a25e-4522-8114-bac1c6f5cd70)
