### PR TITLE
fix(shared): Nailed it! seen on export failure

### DIFF
--- a/sites/shared/components/workbench/exporting/export-handler.mjs
+++ b/sites/shared/components/workbench/exporting/export-handler.mjs
@@ -107,6 +107,7 @@ export const handleExport = async ({
   t,
   startLoading,
   stopLoading,
+  stopLoadingFail,
   onComplete,
   onError,
   ui,
@@ -134,15 +135,16 @@ export const handleExport = async ({
       }
       // do additional business
       onComplete && onComplete(e)
+      // stop the loader
+      if (typeof stopLoading === 'function') stopLoading()
     }
     // on error
     else {
       console.log(e.data.error)
       onError && onError(e)
+      // stop the loader
+      if (typeof stopLoadingFail === 'function') stopLoadingFail()
     }
-
-    // stop the loader
-    if (typeof stopLoading === 'function') stopLoading()
   })
 
   // pdf settings
@@ -229,7 +231,6 @@ export const handleExport = async ({
       }
     } catch (err) {
       console.log(err)
-      if (typeof stopLoading === 'function') stopLoading()
       onError && onError(err)
     }
   }

--- a/sites/shared/components/workbench/views/exporting/index.mjs
+++ b/sites/shared/components/workbench/views/exporting/index.mjs
@@ -23,6 +23,7 @@ export const ExportView = ({ settings, ui, design, Design }) => {
 
   const startLoading = () => setLoadingStatus([true, 'exporting'])
   const stopLoading = () => setLoadingStatus([true, 'status:nailedIt', true, true])
+  const stopLoadingFail = () => setLoadingStatus([true, 'status:failed', true])
 
   const { t } = useTranslation(ns)
   const doExport = (format) => {
@@ -37,6 +38,7 @@ export const ExportView = ({ settings, ui, design, Design }) => {
       ui,
       startLoading,
       stopLoading,
+      stopLoadingFail,
       onComplete: (e) => {
         if (e.data.link) {
           setLink(e.data.link)

--- a/sites/shared/i18n/status/en.yaml
+++ b/sites/shared/i18n/status/en.yaml
@@ -4,6 +4,7 @@ contactingGitHub: Contacting GitHub
 contactingGoogle: Contacting Google
 copiedToClipboard: Copied to clipboard
 dataLoaded: Loaded data from the FreeSewing backend
+failed: Failed
 generatingPdf: Generating your PDF, one moment please
 nailedIt: Nailed it!
 pdfFailed: An unexpected error occurred while generating your PDF


### PR DESCRIPTION
This PR addresses the issue that the "Nailed it!" success message is seen when an export fails. It defines an additional `stopLoadingFail()` method and calls the appropriate method in the event listener depending on success or failure.

It also removes a `stopLoading()` call upon failure during the setup phase which is also currently showing the "Nailed it!" success message upon failure: 
- I removed this setup failure `stopLoading()` entirely instead of simply changing it to `stopLoadingFail()`. This is because doing so could result in a situation where a "Failed" message is seen (during setup) immediately followed by a "Nailed it!" success message, a situation where there is an error during setup that doesn't stop the export from succeeding.
- With the removal of this `stopLoading()` call during the setup phase, I'm counting on it eventually being run during the event listener phase, either the success or failure version.