### PR TITLE
fix(shared): In draft header, show/hide kiosk and renderer buttons based on User Experience

### DIFF
--- a/sites/shared/components/workbench/views/draft/header.mjs
+++ b/sites/shared/components/workbench/views/draft/header.mjs
@@ -214,22 +214,24 @@ export const DraftHeader = ({
             </button>
           ))}
         </div>
-        <div className="flex flex-row items-center gap-4">
-          <IconButton
-            Icon={KioskIcon}
-            dflt={ui.kiosk ? false : true}
-            onClick={() => update.ui(['kiosk'], ui.kiosk ? 0 : 1)}
-            title={t('ui-settings:kiosk.t')}
-          />
-        </div>
-        <div className="flex flex-row items-center gap-4">
-          <IconButton
-            Icon={RocketIcon}
-            dflt={ui.renderer !== 'svg'}
-            onClick={() => update.ui(['renderer'], ui.renderer === 'react' ? 'svg' : 'react')}
-            title={t('ui-settings:renderer.t')}
-          />
-        </div>
+        {control < controlLevels.ui.kiosk ? null : (
+          <div className="flex flex-row items-center gap-4">
+            <IconButton
+              Icon={KioskIcon}
+              dflt={ui.kiosk ? false : true}
+              onClick={() => update.ui(['kiosk'], ui.kiosk ? 0 : 1)}
+              title={t('ui-settings:kiosk.t')}
+            />
+            {control < controlLevels.ui.renderer ? null : (
+              <IconButton
+                Icon={RocketIcon}
+                dflt={ui.renderer !== 'svg'}
+                onClick={() => update.ui(['renderer'], ui.renderer === 'react' ? 'svg' : 'react')}
+                title={t('ui-settings:renderer.t')}
+              />
+            )}
+          </div>
+        )}
         <Spacer />
         <div className="flex flex-row items-center gap-4">
           <button


### PR DESCRIPTION
I noticed that the kiosk and renderer buttons weren't under User Experience control.

Before:
![Screenshot 2024-02-20 at 9 15 27 AM](https://github.com/freesewing/freesewing/assets/109869956/0294da49-bb17-4ce6-bd2e-1b20e11c4bb3)

After:
![Screenshot 2024-02-20 at 9 13 54 AM](https://github.com/freesewing/freesewing/assets/109869956/aad7f2d6-6238-4289-8680-52f47a00e98f)
![Screenshot 2024-02-20 at 9 14 01 AM](https://github.com/freesewing/freesewing/assets/109869956/e2c19931-cfc0-458d-96be-181cc5fa9e8c)
![Screenshot 2024-02-20 at 9 14 11 AM](https://github.com/freesewing/freesewing/assets/109869956/b82eac07-7c7a-48a1-b51f-5ee32fca4b69)

