### PR TITLE
fix(shared): Override draft UI button colors for monochrome theme

### DIFF
--- a/sites/shared/components/workbench/views/draft/header.mjs
+++ b/sites/shared/components/workbench/views/draft/header.mjs
@@ -93,8 +93,10 @@ export const DraftHeader = ({
   const { setLoadingStatus } = useContext(LoadingStatusContext)
   const { theme } = useTheme()
 
-  // Override User Experience button color for monochrome theme.
+  // Override button colors for monochrome theme.
   const ueButtonColor = theme !== 'monochrome' ? 'text-primary' : 'text-primary-content'
+  const resetOptionsButtonColor = theme !== 'monochrome' ? 'text-accent' : 'text-warning'
+
   // make the zoom buttons so we can pass them to the mobile menubar
   const headerZoomButtons = useMemo(
     () => <ZoomButtons {...{ t, zoomFunctions, zoomed }} />,
@@ -245,7 +247,9 @@ export const DraftHeader = ({
             <ResetIcon
               stroke={3.5}
               className={`w-6 h-6 ${
-                typeof settings.options === 'undefined' ? 'text-base-100 opacity-30' : 'text-accent'
+                typeof settings.options === 'undefined'
+                  ? 'text-base-100 opacity-30'
+                  : resetOptionsButtonColor
               }`}
             />
           </button>

--- a/sites/shared/components/workbench/views/draft/header.mjs
+++ b/sites/shared/components/workbench/views/draft/header.mjs
@@ -7,6 +7,7 @@ import { useContext, useMemo } from 'react'
 import { useMobileAction } from 'shared/context/mobile-menubar-context.mjs'
 import { useTranslation } from 'next-i18next'
 import { useBackend } from 'shared/hooks/use-backend.mjs'
+import { useTheme } from 'shared/hooks/use-theme.mjs'
 // Context
 import { LoadingStatusContext } from 'shared/context/loading-status-context.mjs'
 // Components
@@ -90,7 +91,10 @@ export const DraftHeader = ({
   const { zoomFunctions, zoomed } = useContext(PanZoomContext)
   const backend = useBackend()
   const { setLoadingStatus } = useContext(LoadingStatusContext)
+  const { theme } = useTheme()
 
+  // Override User Experience button color for monochrome theme.
+  const ueButtonColor = theme !== 'monochrome' ? 'text-primary' : 'text-primary-content'
   // make the zoom buttons so we can pass them to the mobile menubar
   const headerZoomButtons = useMemo(
     () => <ZoomButtons {...{ t, zoomFunctions, zoomed }} />,
@@ -209,7 +213,7 @@ export const DraftHeader = ({
           data-tip={t('ui-settings:control.t')}
         >
           {[1, 2, 3, 4, 5].map((score) => (
-            <button onClick={() => update.setControl(score)} className="text-primary" key={score}>
+            <button onClick={() => update.setControl(score)} className={ueButtonColor} key={score}>
               <BulletIcon fill={control >= score ? true : false} />
             </button>
           ))}


### PR DESCRIPTION
The monochrome theme was the only one where the UE buttons blend into the background.

Before:
![Screenshot 2024-02-20 at 4 26 19 PM](https://github.com/freesewing/freesewing/assets/109869956/e678e691-068d-48a9-8fbc-d90775cd922d)

After:
![Screenshot 2024-02-20 at 4 26 05 PM](https://github.com/freesewing/freesewing/assets/109869956/aa2a882a-ae42-4c8b-9200-e6bfe9ac773f)

The enabled Reset Options button also blends into the background.  (The disabled button shows up just fine.)

Before:
![Screenshot 2024-02-20 at 4 44 55 PM](https://github.com/freesewing/freesewing/assets/109869956/d0702e50-32c1-4e64-b44e-5c4b8b40d376)

After:
![Screenshot 2024-02-20 at 4 47 55 PM](https://github.com/freesewing/freesewing/assets/109869956/6394414a-9dd1-44df-9272-8fac9132fe56)