### PR TITLE
fix(shared): Add Missing Settings? tip to pattern draft right menu

### DIFF
--- a/sites/shared/components/workbench/menus/ui-settings/en.yaml
+++ b/sites/shared/components/workbench/menus/ui-settings/en.yaml
@@ -1,5 +1,11 @@
 uiSettings.t: UI Preferences
 uiSettings.d: These preferences control the UI (User Interface) aspects of our online pattern drafting environment.
+missingSettings1.t: (Missing Settings?)
+missingSettings1.d: Can't find a setting (like Seam Allowance, Language, or Included Parts)? Change your User Experience level (using the buttons at the top) to expose settings that have been hidden!
+missingSettings2.t: (Missing Settings?)
+missingSettings2.d: Can't find a setting (like Language, Included Parts, or Details)? Change your User Experience level (using the buttons at the top) to expose settings that have been hidden!
+missingSettings3.t: (Missing Settings?)
+missingSettings3.d: Can't find a setting (like Included Parts, Details, or Expand)? Change your User Experience level (using the buttons at the top) to expose settings that have been hidden!
 renderer.t: Render Engine
 renderer.d: Controls how the pattern is rendered (drawn) on the screen
 renderWithReact.t: Render with FreeSewing's React components

--- a/sites/shared/components/workbench/views/draft/menu.mjs
+++ b/sites/shared/components/workbench/views/draft/menu.mjs
@@ -10,7 +10,7 @@ import {
 import { UiSettings, ns as uiNs } from 'shared/components/workbench/menus/ui-settings/index.mjs'
 import { useTranslation } from 'next-i18next'
 import { patternNsFromPatternConfig, nsMerge } from 'shared/utils.mjs'
-import { SettingsIcon, OptionsIcon, DesktopIcon } from 'shared/components/icons.mjs'
+import { SettingsIcon, OptionsIcon, DesktopIcon, HelpIcon } from 'shared/components/icons.mjs'
 import { Accordion } from 'shared/components/accordion.mjs'
 import {
   FlagsAccordionTitle,
@@ -65,6 +65,13 @@ export const DraftMenu = ({
       menu: <UiSettings {...menuProps} {...{ ui, view, setView }} />,
     },
   ]
+  // Show tip for lower User Experiences
+  if (control <= 3)
+    sections.push({
+      name: 'missingSettings' + control,
+      ns: 'ui-settings',
+      icon: <HelpIcon className="w-8 h-8" />,
+    })
 
   const items = []
   if (flags)


### PR DESCRIPTION
This PR adds a new tip message to the right menu, for User Experience levels 1, 2, and 3, with a different message for each level. No tip is displayed for User Experience levels 4 and 5.

This PR closes #6103. The new tip should help users locate settings that have been hidden, like Seam Allowance.

![Screenshot 2024-02-21 at 11 56 10 AM](https://github.com/freesewing/freesewing/assets/109869956/724ce0e5-e19e-4900-aa28-8bdc228636d3)
![Screenshot 2024-02-21 at 11 56 18 AM](https://github.com/freesewing/freesewing/assets/109869956/baf2174d-bbb3-48cc-a1b2-66e9cc2c821a)
![Screenshot 2024-02-21 at 11 56 28 AM](https://github.com/freesewing/freesewing/assets/109869956/d9da8933-eb05-416f-be0b-95e655b6b862)
![Screenshot 2024-02-21 at 11 56 35 AM](https://github.com/freesewing/freesewing/assets/109869956/09af46ce-93c5-4e2d-9e1f-1ce462e245fb)
![Screenshot 2024-02-21 at 11 56 45 AM](https://github.com/freesewing/freesewing/assets/109869956/87104f52-1c16-4f37-aa56-8f280d22f00b)
