### PR TITLE
fix(shared): Correct Discord support channel name

### DIFF
--- a/sites/shared/components/sponsors/en.yaml
+++ b/sites/shared/components/sponsors/en.yaml
@@ -1,4 +1,4 @@
 algolia: Search powered by Algolia
-bugsnag: Error reporting by Bugsnag
+bugsnag: Error reporting by BugSnag
 crowdin: Translation powered by Crowdin
 vercel: Builds and Hosting by Vercel

--- a/sites/shared/i18n/support/en.yaml
+++ b/sites/shared/i18n/support/en.yaml
@@ -9,7 +9,7 @@ confirmedIssues: Confirmed issues
 createSupportRequest: Create a support request
 commentAdded: Comment added
 communitySupport: Community Support
-communitySupport1: For the fastest response, head over to <b>discord.freesewing.org</b> and post your question in the <b>Support</b> channel.
+communitySupport1: For the fastest response, head over to <b>discord.freesewing.org</b> and post your question in the <b>need-help</b> channel.
 communitySupport2: The FreeSewing community is a helpful bunch, so there is a good chance they are able to help you.
 contributorSupport: Contributor Support
 contributorSupport1: If something is broken or you have found a bug, you can <b>create an issue on GitHub</b>.


### PR DESCRIPTION
Corrected the Discord channel name to "need-help".

Also contains a small fix to correct the stylized capitalization of "BugSnag".