### PR TITLE
fix(shared): Add translation keys for social media

### DIFF
--- a/sites/shared/components/account/en.yaml
+++ b/sites/shared/components/account/en.yaml
@@ -292,8 +292,14 @@ newDev: Design / Develop
 
 generateANewThing: "Generate a new { thing }"
 
-website: Website
 linkedIdentities: Linked Identities
+github: GitHub
+instagram: Instagram
+mastodon: Mastodon
+reddit: Reddit
+twitch: Twitch
+tiktok: TikTok
+website: Website
 
 websiteTitle: Do you have a website or other URL you'd like to add?
 platformTitle: Who are you on { platform }?

--- a/sites/shared/components/account/links.mjs
+++ b/sites/shared/components/account/links.mjs
@@ -215,7 +215,7 @@ export const AccountLinks = () => {
                 <AccountLink href={`/account/${item}`} title={t(item)} key={item}>
                   <div className="flex flex-row items-center gap-3 font-medium">
                     {itemIcons[item]}
-                    {capitalize(t(item))}
+                    {t(item)}
                   </div>
                   <div className="">{itemPreviews[item]}</div>
                 </AccountLink>


### PR DESCRIPTION
Added missing translation keys for social media. This allows stylized capitalization like for "GitHub" and "TikTok".

Also removed forced capitalization of social media names, to allow for the possibility of some future social media that might style its name with an initial lowercase letter. 

After:
![Screenshot 2024-02-21 at 2 08 28 PM](https://github.com/freesewing/freesewing/assets/109869956/3692d37e-ff64-4053-a9fe-dd879d1ce9c0)

Before:
![Screenshot 2024-02-21 at 2 08 54 PM](https://github.com/freesewing/freesewing/assets/109869956/330cab90-faa5-404f-87a2-7e3217ca9bf7)
