### PR TITLE
fix(markdown): Correct and normalize utils docs

### DIFF
--- a/markdown/dev/reference/api/utils/deg2rad/en.md
+++ b/markdown/dev/reference/api/utils/deg2rad/en.md
@@ -7,7 +7,7 @@ The `utils.deg2read()` function returns the degrees you pass to it as radians.
 ## Signature
 
 ```js
-float deg2rad(float degrees)
+float utils.deg2rad(float degrees)
 ```
 
 ## Notes

--- a/markdown/dev/reference/api/utils/generatestacktransform/en.md
+++ b/markdown/dev/reference/api/utils/generatestacktransform/en.md
@@ -1,8 +1,8 @@
 ---
-title: generateStackTransform
+title: utils.generateStackTransform()
 ---
 
-This method will generate the SVG transform to implement a given layout configuration on [a stack](/reference/api/stack).
+The `utils.generateStackTransform()` function will generate the SVG transform to implement a given layout configuration on [a stack](/reference/api/stack).
 
 ## Signature
 
@@ -28,7 +28,7 @@ In other words, it rotates the stack.
 The fourth and fifth parameters flip the part along the X or Y axis respectively.
 
 <Note compact>
-This is a low-level method to facilitate intervening in the pattern layout late in the draft process.
+This is a low-level function to facilitate intervening in the pattern layout late in the draft process.
 It is unlikely you will want to use this.
 </Note>
 

--- a/markdown/dev/reference/api/utils/gettransformedbounds/en.md
+++ b/markdown/dev/reference/api/utils/gettransformedbounds/en.md
@@ -1,8 +1,8 @@
 ---
-title: getTransformedBounds
+title: utils.getTransformedBounds()
 ---
 
-This methods re-calculates the bounding box of an object (a stack or a part) after applying the passed-in transform(s).
+The `utils.getTransformedBounds()` function re-calculates the bounding box of an object (a stack or a part) after applying the passed-in transform(s).
 
 The object passed in should have its `topLeft` and `bottomRight` properties set.
 It will return on object that with (only) the updated `topLeft` and `bottomRight` properties set.
@@ -10,13 +10,13 @@ It will return on object that with (only) the updated `topLeft` and `bottomRight
 ## Signature
 
 ```js
-Object getTransformedBounds(
+Object utils.getTransformedBounds(
   Object stack,
   Array transforms
 )
 ```
 
 <Note compact>
-This is a low-level method to facilitate intervening in the pattern layout late in the draft process.
+This is a low-level function to facilitate intervening in the pattern layout late in the draft process.
 It is unlikely you will want to use this.
 </Note>

--- a/markdown/dev/reference/api/utils/mergei18n/en.md
+++ b/markdown/dev/reference/api/utils/mergei18n/en.md
@@ -1,14 +1,14 @@
 ---
-title: mergeI18n
+title: utils.mergeI18n()
 ---
 
-The `mergeI18n` method merges translation files from different designs.
+The `utils.mergeI18n()` function merges translation files from different designs.
 
 When your design re-uses parts from other designs, it should provide
 translation for those parts and any strings or options they use.  Rather than
 re-creating this content in your own design, you can pull it out of of the
 design you are using the part from by importing the `i18n` named export, and
-then use this method to merge it with your own translations.
+then use this function to merge it with your own translations.
 
 ## Signature
 
@@ -21,7 +21,7 @@ Object mergeI18n({
 
 ## Use
 
-In its simplest form, this method will receive an Array of translation data
+In its simplest form, this function will receive an Array of translation data
 (typically the `i18n` named export of a design) and merge them:
 
 ```js
@@ -75,7 +75,7 @@ const i18n = mergeI18n(
 )
 ```
 
-The method will check each key under the `s`, `p`, and `o` top-level keys in the translation files.
+The function will check each key under the `s`, `p`, and `o` top-level keys in the translation files.
 For each it will:
 
 - Check whether there is a `drop` array configured. If there is, it will remove the entry if its key is included in the `drop` Array.

--- a/markdown/dev/reference/api/utils/mergeoptions/en.md
+++ b/markdown/dev/reference/api/utils/mergeoptions/en.md
@@ -8,7 +8,7 @@ options from the pattern configuration.
 ## Signature
 
 ```js
-float deg2rad(object settings, object optionsConfig)
+object mergeOptions(object settings, object optionsConfig)
 ```
 
 ## Notes

--- a/markdown/dev/reference/api/utils/mergeoptions/en.md
+++ b/markdown/dev/reference/api/utils/mergeoptions/en.md
@@ -8,7 +8,10 @@ options from the pattern configuration.
 ## Signature
 
 ```js
-object mergeOptions(object settings, object optionsConfig)
+Object utils.mergeOptions(
+  Object settings,
+  Object optionsConfig
+)
 ```
 
 ## Notes
@@ -20,7 +23,7 @@ and if it's not get the default value from the pattern config. Furthermore,
 where the default is stored and whether or not it should be further transformed
 depends on the option type.
 
-This method exists to facilitate this. You pass it the user-provided settings,
+This function exists to facilitate this. You pass it the user-provided settings,
 and the pattern config options key, and it will return an object where all
 options are populated with the user-provided values, or their defaults if the
 user did not provide any input.

--- a/markdown/dev/reference/api/utils/rad2deg/en.md
+++ b/markdown/dev/reference/api/utils/rad2deg/en.md
@@ -7,6 +7,6 @@ The `utils.rad2dag()` function returns the radians you pass to it as degrees.
 ## Signature 
 
 ```js
-float rad2deg(float radians)
+float utils.rad2deg(float radians)
 ```
 


### PR DESCRIPTION
Some corrections to `utils` docs and changes to "normalize" the newer docs so they match the naming and formatting of the older ones.

Previously, some were named differently, throwing off the sorting. Before:
![Screenshot 2024-02-22 at 5 25 58 AM](https://github.com/freesewing/freesewing/assets/109869956/cc007dc2-bf16-47e0-bc6b-2517138553a2)
