### PR TITLE
fix(shared): Workaround for Units not updating on edit measurements page

### DIFF
--- a/sites/shared/components/account/en.yaml
+++ b/sites/shared/components/account/en.yaml
@@ -261,6 +261,7 @@ itIsAvailableAt: It is available at
 csetNameMsg: Each curated set has a name. You can suggest your own name or a pseudonym.
 missing: Missing
 andMore: and more
+unitsMustSave: "Note: You must save after changing Units to have the change take effect on this page."
 
 patternNew: Generate a new pattern
 patternNewInfo: Pick a design, add your measurements set, and we'll generate a bespoke sewing pattern for you.

--- a/sites/shared/components/account/sets.mjs
+++ b/sites/shared/components/account/sets.mjs
@@ -598,35 +598,38 @@ export const Mset = ({ id, publicOnly = false }) => {
       {/* units: Control level determines whether or not to show this */}
       <span id="units"></span>
       {account.control >= conf.account.sets.units ? (
-        <ListInput
-          id="set-units"
-          label={t('units')}
-          update={setImperial}
-          list={[
-            {
-              val: false,
-              label: (
-                <div className="flex flex-row items-center flex-wrap justify-between w-full">
-                  <span>{t('metricUnits')}</span>
-                  <span className="text-inherit text-2xl pr-2">cm</span>
-                </div>
-              ),
-              desc: t('metricUnitsd'),
-            },
-            {
-              val: true,
-              label: (
-                <div className="flex flex-row items-center flex-wrap justify-between w-full">
-                  <span>{t('imperialUnits')}</span>
-                  <span className="text-inherit text-4xl pr-2">″</span>
-                </div>
-              ),
-              desc: t('imperialUnitsd'),
-            },
-          ]}
-          current={imperial}
-          docs={docs.units}
-        />
+        <>
+          <ListInput
+            id="set-units"
+            label={t('units')}
+            update={setImperial}
+            list={[
+              {
+                val: false,
+                label: (
+                  <div className="flex flex-row items-center flex-wrap justify-between w-full">
+                    <span>{t('metricUnits')}</span>
+                    <span className="text-inherit text-2xl pr-2">cm</span>
+                  </div>
+                ),
+                desc: t('metricUnitsd'),
+              },
+              {
+                val: true,
+                label: (
+                  <div className="flex flex-row items-center flex-wrap justify-between w-full">
+                    <span>{t('imperialUnits')}</span>
+                    <span className="text-inherit text-4xl pr-2">″</span>
+                  </div>
+                ),
+                desc: t('imperialUnitsd'),
+              },
+            ]}
+            current={imperial}
+            docs={docs.units}
+          />
+          <span className="text-large text-warning">{t('unitsMustSave')}</span>
+        </>
       ) : null}
 
       {/* notes: Control level determines whether or not to show this */}


### PR DESCRIPTION
This PR adds a text message to the Edit Measurements page as a workaround for the second issue of #5646.

![Screenshot 2024-02-22 at 9 10 49 AM](https://github.com/freesewing/freesewing/assets/109869956/18486cbf-9475-4079-97d9-e907348936da)
