### PR TITLE
fix(shared): In Test view, include optional measurements

### DIFF
--- a/sites/shared/components/workbench/views/test/menu.mjs
+++ b/sites/shared/components/workbench/views/test/menu.mjs
@@ -31,6 +31,15 @@ export const TestMenu = ({ design, patternConfig, settings, update }) => {
   const { t } = useTranslation(ns)
 
   const allOptions = flattenOptions(patternConfig.options, settings)
+  const allMeasurements = patternConfig.measurements
+    .concat(patternConfig.optionalMeasurements)
+    .sort((a, b) => {
+      const ta = t(`measurements:${a}`)
+      const tb = t(`measurements:${b}`)
+      if (ta < tb) return -1
+      else if (ta > tb) return 1
+      else return 0
+    })
 
   return (
     <Accordion
@@ -76,8 +85,8 @@ export const TestMenu = ({ design, patternConfig, settings, update }) => {
           </Fragment>,
           <ListInput
             key="b"
-            list={patternConfig.measurements.map((m) => ({
-              label: t(m),
+            list={allMeasurements.map((m) => ({
+              label: t(`measurements:${m}`),
               val: m,
             }))}
             update={(value) => {


### PR DESCRIPTION
- Optional measurements were missing from Test View. This PR adds them.
- It also uses translations and sorts measurements by translated name.

After (`highBust` has been added, `neck` translation temporarily changed to "Zeck circumference" for testing purposes):
![Screenshot 2024-02-22 at 5 43 01 PM](https://github.com/freesewing/freesewing/assets/109869956/6d1fa4c4-0b8f-4351-8895-0f0939e0bb5b)
 
Before (`highBust` missing, no translations):
![Screenshot 2024-02-22 at 5 43 54 PM](https://github.com/freesewing/freesewing/assets/109869956/b15c85e1-ca32-4665-83bc-85d368e34e4a)
