### PR TITLE
fix(shared): For Test view option menus, use design and workbench translation keys

### DIFF
--- a/sites/shared/components/workbench/views/test/menu.mjs
+++ b/sites/shared/components/workbench/views/test/menu.mjs
@@ -50,7 +50,7 @@ export const TestMenu = ({ design, patternConfig, settings, update }) => {
               label: [
                 ...option.path.map((p) => (
                   <>
-                    <span>{t(`${p}.t`)}</span>
+                    <span>{t([`${design}:${p}.t`, `workbench:${p}`])}</span>
                     {spacer}
                   </>
                 )),


### PR DESCRIPTION
Before (no translations for menu and submenu names):
![Screenshot 2024-02-22 at 4 26 41 PM](https://github.com/freesewing/freesewing/assets/109869956/6b126131-d83f-4bbf-b94a-b043007d42aa)

After (translations from Workbench (Fit and Pockets) and from the Charlie i18n files (with some test translation keys added for `backpockets` and `frontpockets`) :
![Screenshot 2024-02-22 at 4 25 39 PM](https://github.com/freesewing/freesewing/assets/109869956/3c80e279-48ee-42cb-aa12-c156b797d07f)

The translation keys used for testing:
![Screenshot 2024-02-22 at 4 29 31 PM](https://github.com/freesewing/freesewing/assets/109869956/56432432-b83d-4655-9879-c9742d5c14ef)
