### PR TITLE
fix(tests, charlie): Add menu translation keys

### DIFF
--- a/designs/charlie/i18n/en.json
+++ b/designs/charlie/i18n/en.json
@@ -102,13 +102,16 @@
       "d": "Controls how curved the waistband is."
     },
     "backpockets": {
-      "t": "Back Pockets"
+      "t": "Back Pockets",
+      "d": "Back Pockets"
     },
     "frontpockets": {
-      "t": "Front Pockets"
+      "t": "Front Pockets",
+      "d": "Front Pocketsa"
     },
     "fly": {
-      "t": "Fly"
+      "t": "Fly",
+      "d": "Fly"
     }
   }
 }

--- a/designs/charlie/i18n/en.json
+++ b/designs/charlie/i18n/en.json
@@ -103,15 +103,15 @@
     },
     "backpockets": {
       "t": "Back Pockets",
-      "d": "Back Pockets"
+      "d": "menu"
     },
     "frontpockets": {
       "t": "Front Pockets",
-      "d": "Front Pocketsa"
+      "d": "menu"
     },
     "fly": {
       "t": "Fly",
-      "d": "Fly"
+      "d": "menu"
     }
   }
 }

--- a/designs/charlie/i18n/en.json
+++ b/designs/charlie/i18n/en.json
@@ -100,6 +100,15 @@
     "waistbandCurve": {
       "t": "Waistband Curve",
       "d": "Controls how curved the waistband is."
+    },
+    "backpockets": {
+      "t": "Back Pockets"
+    },
+    "frontpockets": {
+      "t": "Front Pockets"
+    },
+    "fly": {
+      "t": "Fly"
     }
   }
 }

--- a/tests/designs/i18n.mjs
+++ b/tests/designs/i18n.mjs
@@ -69,7 +69,7 @@ export const testPatternI18n = (Pattern, i18n) => {
             it(`  - The No translation of boolean option o.${key} should have a corresponding Yes translation`, () => {
               expect(typeof i18n.en.o[key.slice(0, -2) + 'Yes'].t).to.equal('string')
             })
-          } else {
+          } else if (i18n.en.o[key].d !== 'menu') {
             it(`  - The translation of o.${key} should correspond to a known option`, () => {
               expect(options.includes(key)).to.equal(true)
             })


### PR DESCRIPTION
This PR includes a change to the design i18n tests to allow design menu translation keys. If `o.<key>.d` is set to `menu`, it means that the item is menu name and not an actual option. This causes the test to check for an actual option to be skipped.

So, to add a translation key for a menu:
```json
   "o": {
    "myMenu": {
      "t": "My Menu",
      "d": "menu"
    },
```

This PR also adds 3 menu translations for Charlie.