### PR TITLE
fix(brian): Reword description for Draft for High Bust option

### DIFF
--- a/designs/brian/i18n/en.json
+++ b/designs/brian/i18n/en.json
@@ -47,15 +47,15 @@
     },
     "draftForHighBust": {
       "t": "Draft for high bust",
-      "d": "Draft the pattern for the high bust measurement (if available) rather than the (full) chest. This will result in a more fitted garment for people with breasts."
+      "d": "Draft the pattern using the high bust measurement if it is available, instead of using the chest measurement. This can result in a more fitted garment for people with breasts. (Please note that no additional adjustments or shaping is performed. Further manual adjustments may be needed for those with a larger difference between high bust and chest measurements.)"
     },
     "draftForHighBustYes": {
       "t": "Draft using the high bust measurement",
-      "d": "Drafts a pattern using the high bust measurements as the chest measurement. Recommended for people with breasts."
+      "d": "Drafts a pattern using the high bust measurement instead of the chest measurement. Suggested for most people with breasts."
     },
     "draftForHighBustNo": {
       "t": "Draft using the chest measurement",
-      "d": "Drafts a pattern using the chest measurement. Recommended for people without breasts."
+      "d": "Drafts a pattern using the chest measurement. Suggested for most people without breasts."
     },
     "frontArmholeDeeper": {
       "t": "Front armhole extra cutout",


### PR DESCRIPTION
Closes #6118.

New wording:
![Screenshot 2024-02-25 at 5 43 44 PM](https://github.com/freesewing/freesewing/assets/109869956/308c387c-4cdb-4c0a-a012-a3e186f8a1f7)

Wording based on input and feedback from Discord:
https://discord.com/channels/698854858052075530/1209868328408059954/1210033408772800543
discord://discord.com/channels/698854858052075530/1209868328408059954/1210033408772800543
https://discord.com/channels/698854858052075530/1209868328408059954/1211329125558779935
discord://discord.com/channels/698854858052075530/1209868328408059954/1211329125558779935

This PR affects only the wording seen in the UI. There is a related Issue #6124 to write the documentation page for the Draft for High Bust option.
