### PR TITLE
fix(org): Correct showcase author claim label

### DIFF
--- a/sites/org/components/layouts/post.mjs
+++ b/sites/org/components/layouts/post.mjs
@@ -84,7 +84,7 @@ const createIssue = async ({ account, setLoadingStatus, title, body, backend, se
   const issueData = {
     title,
     body: account ? `${body}\n\n${userCard(account.id || false)}` : body,
-    labels: ['%3A%2B1%3A+good+first+issue'],
+    labels: [':+1: good first issue'],
   }
   const result = await backend.createIssue(issueData)
   if (result.success) {


### PR DESCRIPTION
I am not sure, but I think that this code change might fix the incorrect label?

Before:
![Screenshot 2024-02-28 at 9 17 19 PM](https://github.com/freesewing/freesewing/assets/109869956/7ce05604-05ac-4821-b5a5-33d9834c1d96)
