### PR TITLE
fix(markdown): In Jargon guide, add freesewing.org translation process

### DIFF
--- a/markdown/dev/guides/markdown/jargon/en.md
+++ b/markdown/dev/guides/markdown/jargon/en.md
@@ -40,6 +40,36 @@ const jargon = {
 }
 ```
 
+### Adding freesewing.org jargon translations
+
+Because the freesewing.org jargon file contains keys for all supported
+languages, a key/value pair for each supported language must be added
+to the file when adding a new jargon term.
+To do this, you will need to know the jargon term's translation in
+each language, information which you may not have initially.
+
+**Because the jargon file itself does not get translated as part of the
+regular FreeSewing translation process, it will be your responsibility
+to obtain the translations and add them to the file manually.**
+We have developed a process to help you do this:
+
+1. Add key/value pairs for your new jargon term to the jargon file,
+temporarily using the English-language key as the key for all the
+other languages.
+2. Add the jargon file and the English documentation web page file
+to the repository.
+3. File a GitHub Issue to track the chore that the temporary
+English-language keys will need to be replaced with the actual
+translations once they become available.
+4. Eventually FreeSewing's translation process will result in the
+English documentation web page getting translated into the other
+supported languages.
+When this happens the needed translations for the jargon term will
+be available in the translated documentation files.
+5. Edit the jargon file to replace the temporary English-language
+keys with the actual translations, and close the GitHub issue once
+the edited jargon file is added to the repository.
+
 ## Using jargon terms in MDX content
 
 To use jargon inside MDX content (like the markdown of our documentation, blog


### PR DESCRIPTION
(I came up with the best procedure I could think of, but perhaps there is a better one. Maybe a procedure that would get the needed translations before the additions are made to the jargon file. Or, perhaps there could be a technical solution splitting up the jargon into individual language JSON files, allowing them to be translated through the regular Crowdin process.)

![Screenshot 2024-02-29 at 7 12 53 AM](https://github.com/freesewing/freesewing/assets/109869956/5ff58eb3-15cc-448d-9f2d-e2cd85f66f38)
