### PR TITLE
fix(markdown): In pattern design tutorial, add links to setup tutorials

### DIFF
--- a/markdown/dev/tutorials/pattern-design/part1/new-design/en.md
+++ b/markdown/dev/tutorials/pattern-design/part1/new-design/en.md
@@ -50,6 +50,20 @@ If all goes well, we'll should see this landing page:
 
 <Tip>
 
+##### More detailed setup tutorials are available
+
+This pattern design tutorial contains only an abbreviated overview
+of the setup process.
+For more detailed instructions, please refer to one of our setup tutorials:
+
+- [Getting started on Linux](/tutorials/getting-started-linux)
+- [Getting started on Mac](/tutorials/getting-started-mac)
+- [Getting started on Windows](/tutorials/getting-started-windows)
+
+</Tip>
+
+<Tip>
+
 ##### Need help?
 
 If you run into any issues, head over to [FreeSewing.org/support](https://next.freesewing.org/support)


### PR DESCRIPTION
There seemed to be a "doc escape" for a user recently, where they had difficulty setting up their Windows system using the pattern design tutorial. This PR adds links to the setup tutorials to hopefully help in this type of situation.

https://discord.com/channels/698854858052075530/698862765053575188/1212401887924592730
discord://discord.com/channels/698854858052075530/698862765053575188/1212401887924592730
