### PR TITLE
fix(uma): fix back exposure if expand is off

### DIFF
--- a/designs/uma/src/back.mjs
+++ b/designs/uma/src/back.mjs
@@ -120,14 +120,13 @@ function draftUmaBack({
     // Also Y-flip these central points
     points.cfWaistbandDipBack = points.cfWaistbandDipBack.flipY()
     points.cfBackGusset = points.cfBackGusset.flipY()
-    paths.saBase = new Path()
-      .move(points.cfWaistbandDipBack)
-      .curve_(points.cfWaistbandDipCpBack, points.sideWaistbandBack)
-      .line(points.sideLegBack)
-      .curve(points.backGussetSplitCpBottom, points.backGussetSplitCpTop, points.backGussetSplit)
-      .line(new Point(0, points.backGussetSplit.y))
-      .reverse()
-      .hide()
+    macro('mirror', {
+      mirror: [new Point(0, 0), new Point(100, 0)],
+      paths: ['back'],
+      clone: true,
+    })
+    paths.mirroredBack.hide()
+    paths.saBase = paths.mirroredBack.reverse().hide()
 
     paths.seam = paths.saBase
       .clone()

--- a/designs/uma/src/base.mjs
+++ b/designs/uma/src/base.mjs
@@ -170,7 +170,7 @@ function draftUmaBase({
   /*
    * Make checking for bulge easy
    */
-  store.set('bulge', options.bulge >= 2 ? true : false)
+  store.set('bulge', options.bulge >= 2)
 
   /*
    * Split back from gusset unless bulge is set
@@ -280,7 +280,7 @@ function draftUmaBase({
      *
      * If not, we will split the front from the gusset
      */
-    if (options.bulge && options.bulge >= 2) {
+    if (store.get('bulge')) {
       /*
        * First, we rotate the curve to create room for the bulge
        */

--- a/designs/uma/src/front.mjs
+++ b/designs/uma/src/front.mjs
@@ -28,13 +28,11 @@ function draftUmaFront({
   if (store.get('bulge')) {
     /*
      * Return the bulge version of the front which means that:
-     * - Front and gusset togeter form one part
+     * - Front and gusset together form one part
      * - Front cannot be cut on the fold
      */
-    paths.seam = store.get('bulge')
-      ? paths.bulge.clone().setClass('fabric')
-      : paths.frontAndGusset.clone().setClass('fabric')
-    if (store.get('bulge')) delete paths.bulge
+    paths.seam = paths.bulge.clone().setClass('fabric')
+    delete paths.bulge
     delete paths.back
     delete paths.frontAndGusset
 


### PR DESCRIPTION
Fixes #6239

The main fix is the reuse of the existing path in designs/uma/src/back.mjs instead of building an (inferior) copy, the rest is minor code style improvement or removal of useless code (in front.mjs)