### PR TITLE
feat: Add terminoloy/glossary page and component

### DIFF
--- a/markdown/org/docs/about/terms/en.md
+++ b/markdown/org/docs/about/terms/en.md
@@ -2,12 +2,12 @@
 title: Terminology
 ---
 
-This page includes a glossary of terms that are used on FreeSewing.dev.
+This page includes a glossary of terms that are used on FreeSewing.org.
 
 <Note>
 ##### The purpose of this glossary
 
-To avoid having to explain what (for example) __esm__ means each time
+To avoid having to explain what (for example) __edgestitching__ means each time
 we use it, we maintain a central list of terminology (jargon) with a link to
 its documentation.
 
@@ -15,9 +15,9 @@ its documentation.
 
 We also make it easy for documentation authors to include definitions for
 glossary terms they use by merely emphasising the term, like this:
-_esm_.
+_edgestitching_.
 
-For more details, refer to [our Markdown guide](https://freesewing.dev/guides/markdown/jargon).
+For more details, refer to [our Markdown guide](https://freesewing.dev/guides/markdown/jargon) on [FreeSewing.dev](https://freesewing.dev/).
 
 </Note>
 

--- a/sites/dev/components/jargon.mjs
+++ b/sites/dev/components/jargon.mjs
@@ -1,4 +1,4 @@
-import { Term as SharedTerm } from 'shared/components/jargon.mjs'
+import { Term as SharedTerm, termList } from 'shared/components/jargon.mjs'
 
 /*
  * This object holds jargon terminology for FreeSewing.dev
@@ -24,3 +24,4 @@ const jargon = {
  * DO NOT CHANGE ANYTHING BELOW THIS LINE
  */
 export const Term = ({ children }) => <SharedTerm {...{ jargon, children }} site="dev" />
+export const TermList = termList(jargon)

--- a/sites/org/components/jargon.mjs
+++ b/sites/org/components/jargon.mjs
@@ -1,4 +1,4 @@
-import { Term as SharedTerm } from 'shared/components/jargon.mjs'
+import { Term as SharedTerm, termList } from 'shared/components/jargon.mjs'
 
 /*
  * This object holds jargon terminology for FreeSewing.dev
@@ -13,7 +13,7 @@ import { Term as SharedTerm } from 'shared/components/jargon.mjs'
  *   - Since this uses dynamic MDX loaded from GitHub,it won't work until pushed
  */
 // prettier-ignore
-const jargon = {
+export const jargon = {
   en: {
     // Sewing
     'basic sewing supplies':     'docs/sewing/basic-sewing-supplies',
@@ -234,3 +234,4 @@ const jargon = {
  * DO NOT CHANGE ANYTHING BELOW THIS LINE
  */
 export const Term = ({ children }) => <SharedTerm {...{ jargon, children }} site="org" />
+export const TermList = termList(jargon, 'org')

--- a/sites/shared/components/jargon.mjs
+++ b/sites/shared/components/jargon.mjs
@@ -1,8 +1,12 @@
+import { useTranslation } from 'next-i18next'
 import { useContext } from 'react'
 import { useRouter } from 'next/router'
 import { ModalContext } from 'shared/context/modal-context.mjs'
 import { ModalWrapper } from 'shared/components/wrappers/modal.mjs'
 import { DynamicMdx } from 'shared/components/mdx/dynamic.mjs'
+import { PageLink } from 'shared/components/link.mjs'
+
+export const ns = ['docs']
 
 /*
  * Lowercase and strip dots, then check if we have a definition for the term
@@ -31,7 +35,7 @@ export const Term = ({ children, site, jargon = {} }) => {
 
   return term ? (
     <button
-      className="italic underline decoration-warning decoration-dotted decoration-2 bg-warning bg-opacity-10 px-1 hover:bg-transparent hover:decoration-solid hover:cursor-help"
+      className="italic underline text-left decoration-warning decoration-dotted decoration-2 bg-warning bg-opacity-10 px-1 hover:bg-transparent hover:decoration-solid hover:cursor-help"
       onClick={() =>
         setModal(
           <ModalWrapper>
@@ -45,4 +49,44 @@ export const Term = ({ children, site, jargon = {} }) => {
   ) : (
     <em>{children}</em>
   )
+}
+
+// THis takes a jargon object as input and returns a React component
+export const termList = (jargon, site) => () => {
+  const router = useRouter()
+  const lang = router.locale
+  const { t } = useTranslation(ns)
+
+  return (
+    <table className="table border-collapse table-auto table-striped min-w-full">
+      <thead>
+        <tr>
+          <th className="text-right font-base-content">{t('docs:term')}</th>
+          <th>MDX</th>
+          <th>{t('docs:docs')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {Object.keys(jargon[lang])
+          .sort()
+          .map((key, i) => (
+            <tr
+              key={key}
+              className={`${i % 2 === 0 ? 'bgsecondary bg-opacity-10' : 'bg-transparent'} border border-base-300 border-r-0 border-l-0 border-b-0`}
+            >
+              <td className="py-1 text-right font-bold">{key}</td>
+              <td className="py-1 ">
+                <Term site={site} jargon={jargon}>
+                  {key}
+                </Term>
+              </td>
+              <td className="py-1 ">
+                <PageLink href={`/${jargon[lang][key]}`} txt={`/${jargon[lang][key]}`} />
+              </td>
+            </tr>
+          ))}
+      </tbody>
+    </table>
+  )
+  return <pre>{JSON.stringify(jargon, null, 2)}</pre>
 }

--- a/sites/shared/components/jargon.mjs
+++ b/sites/shared/components/jargon.mjs
@@ -51,8 +51,7 @@ export const Term = ({ children, site, jargon = {} }) => {
   )
 }
 
-// THis takes a jargon object as input and returns a React component
-export const termList = (jargon, site) => () => {
+const TermList = () => {
   const router = useRouter()
   const lang = router.locale
   const { t } = useTranslation(ns)
@@ -88,5 +87,7 @@ export const termList = (jargon, site) => () => {
       </tbody>
     </table>
   )
-  return <pre>{JSON.stringify(jargon, null, 2)}</pre>
 }
+
+// This takes a jargon object as input and returns a React component
+export const termList = (jargon, site) => <TermList {...{ jargon, site }} />

--- a/sites/shared/components/jargon.mjs
+++ b/sites/shared/components/jargon.mjs
@@ -51,7 +51,7 @@ export const Term = ({ children, site, jargon = {} }) => {
   )
 }
 
-const TermList = () => {
+const TermList = ({ jargon, site }) => {
   const router = useRouter()
   const lang = router.locale
   const { t } = useTranslation(ns)

--- a/sites/shared/components/mdx/index.mjs
+++ b/sites/shared/components/mdx/index.mjs
@@ -17,7 +17,7 @@ import { DesignMeasurements } from './design-measurements.mjs'
 import { DesignOptions } from './design-options.mjs'
 import { MeasieImage } from 'shared/components/measurements/image.mjs'
 // Dev/Org jargon
-import { Term } from 'site/components/jargon.mjs'
+import { Term, TermList } from 'site/components/jargon.mjs'
 
 export const components = (site = 'org', slug = []) => {
   const base = {
@@ -34,6 +34,7 @@ export const components = (site = 'org', slug = []) => {
     Warning: (props) => <Popout {...props} warning />,
     em: (props) => <Term {...props} />,
   }
+
   const extra = {
     pre: (props) => <Highlight {...props} />,
     YouTube,
@@ -51,6 +52,12 @@ export const components = (site = 'org', slug = []) => {
   }
 
   if (site === 'sde') return base
+
+  // TermList
+  if (site === 'dev' && Array.isArray(slug) && slug.join('/') === 'reference/terms')
+    extra.TermList = TermList
+  else if (site === 'org' && Array.isArray(slug) && slug.join('/') === 'about/terms')
+    extra.TermList = TermList
 
   if (site === 'dev')
     return {

--- a/sites/shared/i18n/docs/en.yaml
+++ b/sites/shared/i18n/docs/en.yaml
@@ -31,4 +31,4 @@ iKnowWhoMadeThis: I know who made this
 iKnowWhoWroteThis: I know who wrote this
 iWroteThis: I wrote this
 iMadeThis: I made this
-
+term: Term


### PR DESCRIPTION
Inspired by the proposed documentation changes in #6230 I have added a new component and documentation pages that list the various terms.