### PR TITLE
fix(shared): No need to divide config.dflt by 100 again

### DIFF
--- a/sites/shared/components/workbench/menus/design-options/inputs.mjs
+++ b/sites/shared/components/workbench/menus/design-options/inputs.mjs
@@ -12,7 +12,7 @@ import {
 
 const PctOptionInput = (props) => {
   const { config, settings, changed } = props
-  const currentOrDefault = changed ? props.current : config.dflt / 100
+  const currentOrDefault = changed ? props.current : config.dflt
 
   return (
     <PctInput {...props}>


### PR DESCRIPTION
That value is already divided by 100 [here](https://github.com/freesewing/freesewing/blob/e4a07a0c93dd1360fb6bdcd1216ce5cd2d105511/sites/shared/utils.mjs#L206). This causes misreported measurements that are at the default value, see for example the zipper length in Onyx:

![image](https://github.com/freesewing/freesewing/assets/4310707/32add4a6-0254-419e-8897-05e629395adc)
