### PR TITLE
fix(shared): Correct warning logs translation key name

### DIFF
--- a/sites/shared/components/workbench/views/logs/en.yaml
+++ b/sites/shared/components/workbench/views/logs/en.yaml
@@ -1,6 +1,6 @@
 logs: Logs
 error: Error messages
-warning: Warning messages
+warn: Warning messages
 info: Info messages
 debug: Debug messages
 seeLinkOrClick: See { link } or { click }


### PR DESCRIPTION
Before:
![Screenshot 2024-03-17 at 4 17 55 AM](https://github.com/freesewing/freesewing/assets/109869956/fd1d4bc2-532f-4be7-b9eb-a1f97db4609e)

After:
![Screenshot 2024-03-17 at 4 17 16 AM](https://github.com/freesewing/freesewing/assets/109869956/32419d58-239a-4376-8038-bf73cbdd837a)
