### PR TITLE
DRAFT: fix(core): Add non-cloneable attributes functionality

### DIFF
--- a/markdown/dev/reference/api/attributes/clone/en.md
+++ b/markdown/dev/reference/api/attributes/clone/en.md
@@ -21,3 +21,7 @@ const attr = new Attributes()
 const cloned = attr.clone()
 ```
 
+## Notes
+
+Individual attributes with a `key` containing the string `noclone` will not
+be cloned and will be omitted from the new Attributes object.

--- a/packages/core/src/attributes.mjs
+++ b/packages/core/src/attributes.mjs
@@ -84,8 +84,11 @@ Attributes.prototype.asRenderProps = function () {
  * @return {object} this - The Attributes instance
  */
 Attributes.prototype.clone = function () {
+  const cloneableList = {}
+  for (const key in this.list)
+    if (key.indexOf('noclone') === -1) cloneableList[key] = this.list[key]
   let clone = new Attributes()
-  clone.list = JSON.parse(JSON.stringify(this.list))
+  clone.list = JSON.parse(JSON.stringify(cloneableList))
 
   return clone
 }

--- a/plugins/plugin-mirror/src/index.mjs
+++ b/plugins/plugin-mirror/src/index.mjs
@@ -19,7 +19,7 @@ const mirrorGen = (start, end) => {
     point.x = uNom / denom
     point.y = vNom / denom
 
-    const mirrorCount = Number(point.attributes.get('data-mirrored'))
+    const mirrorCount = Number(point.attributes.get('data-mirrored-noclone'))
     // some points returned by utils do not have logs
     if (mirrorCount > 0 && point.log)
       point.log.warn(
@@ -27,7 +27,7 @@ const mirrorGen = (start, end) => {
           mirrorCount + 1
         }) which can lead to hard to trace bugs`
       )
-    point.attributes.set('data-mirrored', mirrorCount + 1)
+    point.attributes.set('data-mirrored-noclone', mirrorCount + 1)
 
     return point
   }


### PR DESCRIPTION
Even though the mirrored paths' Points are cloned, Uma displays warning messages for 2 points:
![Screenshot 2024-03-17 at 6 35 42 AM](https://github.com/freesewing/freesewing/assets/109869956/d9362f20-e2c1-494c-8913-10209c5c7662)

To fix this issue, this PR adds non-cloneable attributes (designated by having `noclone` in the key) that are filtered out during a `clone()` operation. It also makes the `plugin-mirror`'s `data-mirrored` attribute non-cloneable. The idea is that cloned Points should be considered to be fresh, new Points that haven't been mirrored before.

(There are other ways this issue could be fixed, like renaming non-cloneable attributes to "get rid" of them while also preserving them. Or, setting `data-mirrored` count back to zero. But, I chose the method that has non-cloneable attributes that simply get omitted.)

(There is another bug in `plugin-mirror` where it uses the non-existent `point.name` in the warning message, resulting the `Point undefined` wording. But, I think I want to handle it in a separate PR.) 

Creating as a Draft PR for review, to see if the idea is okay. Also, I need to add tests for this new functionality.