### PR TITLE
fix(shared): Include conditional options in docs

### DIFF
--- a/markdown/org/docs/designs/brian/options/draftforhighbust/en.md
+++ b/markdown/org/docs/designs/brian/options/draftforhighbust/en.md
@@ -1,8 +1,8 @@
 ---
-title: undefined
+title: Draft for high bust
 ---
 
-undefined
+Draft the pattern for the high bust measurement (if available) rather than the (full) chest. This will result in a more fitted garment for people with breasts.
 
 
 

--- a/sites/backend/src/models/set.mjs
+++ b/sites/backend/src/models/set.mjs
@@ -377,7 +377,6 @@ SetModel.prototype.asPublicSet = function () {
     about: 'Contains measurements in mm as well as metadata',
     ...this.asSet(),
   }
-  delete data.userId
   data.measurements = data.measies
   delete data.measies
   data.units = data.imperial ? 'imperial' : 'metric'

--- a/sites/shared/components/account/sets.mjs
+++ b/sites/shared/components/account/sets.mjs
@@ -353,7 +353,7 @@ export const Mset = ({ id, publicOnly = false }) => {
           <MsetCard set={mset} control={control} />
         </div>
         <div className="flex flex-col justify-end gap-2 mb-2 grow">
-          {account.control > 3 && mset.public && mset.userId !== account.id ? (
+          {account.control > 2 && mset.public && mset.userId !== account.id ? (
             <div className="flex flex-row gap-2 items-center">
               <a
                 className="badge badge-secondary font-bold badge-lg"
@@ -401,7 +401,7 @@ export const Mset = ({ id, publicOnly = false }) => {
           ) : (
             <span></span>
           )}
-          {account.control > 2 && mset.public && mset.userId !== account.id ? (
+          {account.id && account.control > 2 && mset.public && mset.userId !== account.id ? (
             <button className="btn btn-primary" title={t('account:importSet')} onClick={importSet}>
               <div className="flex flex-row gap-4 justify-between items-center w-full">
                 <UploadIcon />
@@ -510,18 +510,20 @@ export const Mset = ({ id, publicOnly = false }) => {
         )}
         {control >= controlLevels.sets.public && (
           <>
-            <DisplayRow title={t('public')}>
-              <div className="flex flex-row gap-2 items-center justify-between">
-                {mset.public ? (
-                  <OkIcon className="w-6 h-6 text-success" stroke={4} />
-                ) : (
-                  <NoIcon className="w-6 h-6 text-error" stroke={3} />
-                )}
-                <button className="btn btn-secondary btn-sm" onClick={togglePublic}>
-                  {t(`account:make${mset.public ? 'Private' : 'Public'}`)}
-                </button>
-              </div>
-            </DisplayRow>
+            {mset.userId === account.id && (
+              <DisplayRow title={t('public')}>
+                <div className="flex flex-row gap-2 items-center justify-between">
+                  {mset.public ? (
+                    <OkIcon className="w-6 h-6 text-success" stroke={4} />
+                  ) : (
+                    <NoIcon className="w-6 h-6 text-error" stroke={3} />
+                  )}
+                  <button className="btn btn-secondary btn-sm" onClick={togglePublic}>
+                    {t(`account:make${mset.public ? 'Private' : 'Public'}`)}
+                  </button>
+                </div>
+              </DisplayRow>
+            )}
             {mset.public && (
               <DisplayRow title={t('permalink')}>
                 <PageLink href={`/set?id=${mset.id}`} txt={`/set?id=${mset.id}`} />

--- a/sites/shared/components/designs/info.mjs
+++ b/sites/shared/components/designs/info.mjs
@@ -59,7 +59,7 @@ const OptionGroup = ({ id, group, t, design }) => (
   </li>
 )
 export const SimpleOptionsList = ({ options, t, design }) => {
-  const structure = optionsMenuStructure(options, {})
+  const structure = optionsMenuStructure(options, {}, true)
   const output = []
   for (const [key, entry] of Object.entries(structure)) {
     const shared = { key, t, design, id: key }

--- a/sites/shared/components/workbench/en.yaml
+++ b/sites/shared/components/workbench/en.yaml
@@ -23,6 +23,7 @@ clearTimingData: Clear timing data
 closure: Closure
 collar: Collar
 columns: columns
+conditional: Conditional
 configurePattern: Configure pattern
 construction: Construction
 continueEditingTitle: Continue editing

--- a/sites/shared/hooks/use-account.mjs
+++ b/sites/shared/hooks/use-account.mjs
@@ -4,7 +4,7 @@ import useLocalStorageState from 'use-local-storage-state'
 /*
  * Make it possible to always check for account.username and account.control
  */
-const noAccount = { username: false, control: 2 }
+const noAccount = { username: false, control: 3 }
 
 /*
  * The useAccount hook

--- a/sites/shared/utils.mjs
+++ b/sites/shared/utils.mjs
@@ -190,7 +190,7 @@ export const measurementAsMm = (value, units = 'metric') => {
   }
 }
 
-export const optionsMenuStructure = (options, settings) => {
+export const optionsMenuStructure = (options, settings, asFullList = false) => {
   if (!options) return options
   const sorted = {}
   for (const [name, option] of Object.entries(options)) {
@@ -205,7 +205,9 @@ export const optionsMenuStructure = (options, settings) => {
       option.dflt = option.dflt || option[oType]
       if (oType === 'pct') option.dflt /= 100
       if (typeof option.menu === 'function')
-        option.menu = option.menu(settings, mergeOptions(settings, options))
+        option.menu = asFullList
+          ? 'conditional'
+          : option.menu(settings, mergeOptions(settings, options))
       if (option.menu) {
         // Handle nested groups that don't have any direct children
         if (option.menu.includes('.')) {


### PR DESCRIPTION
Closes #6121

This adds an extra parameter to the method that generated the menu structure for options to include all options. Which means that conditional options will be sorted under a 'conditional' menu heading.