### PR TITLE
Clarify documentation of waist-to-upper-leg measurement

### DIFF
--- a/markdown/org/docs/measurements/waisttoupperleg/en.md
+++ b/markdown/org/docs/measurements/waisttoupperleg/en.md
@@ -2,5 +2,5 @@
 title: Waist to upper leg
 ---
 
-The **waist to upper leg** is measured from your waist down to the top of your leg. Measure it at the side of your body.
+The **waist to upper leg** is measured from your waist down to where your upper leg circumference measurement is. Measure it at the side of your body.
 <MeasieImage />


### PR DESCRIPTION
If you haven't done the upper leg circumference measurement yet, or you forgot it exist, measuring to the of of the leg is unclear and would probably lead to a much smaller measurement than intended. (I'd measure to right below my hip bones)