### PR TITLE
fix(org,shared): Use singular words for page titles

### DIFF
--- a/sites/org/pages/account/bookmark.mjs
+++ b/sites/org/pages/account/bookmark.mjs
@@ -58,7 +58,7 @@ const BookmarkPage = ({ page }) => {
   }, [id, backend, setLoadingStatus])
 
   return (
-    <PageWrapper {...page} title={`${t('bookmarks')}: ${bookmark?.title}`}>
+    <PageWrapper {...page} title={`${t('bookmark')}: ${bookmark?.title}`}>
       <DynamicAuthWrapper>
         <DynamicBookmark bookmark={bookmark} />
       </DynamicAuthWrapper>

--- a/sites/org/pages/account/pattern.mjs
+++ b/sites/org/pages/account/pattern.mjs
@@ -43,7 +43,7 @@ const PatternPage = ({ page }) => {
   }, [id])
 
   return (
-    <PageWrapper {...page} title={`${t('patterns')}: #${id}`}>
+    <PageWrapper {...page} title={`${t('pattern')}: #${id}`}>
       <DynamicAuthWrapper>
         <DynamicPattern id={id} />
       </DynamicAuthWrapper>

--- a/sites/org/pages/account/set.mjs
+++ b/sites/org/pages/account/set.mjs
@@ -43,7 +43,7 @@ const SetPage = ({ page }) => {
   }, [id])
 
   return (
-    <PageWrapper {...page} title={`${t('sets')}: #${id}`}>
+    <PageWrapper {...page} title={`${t('set')}: #${id}`}>
       <DynamicAuthWrapper>
         <DynamicSet id={id} />
       </DynamicAuthWrapper>

--- a/sites/shared/components/account/en.yaml
+++ b/sites/shared/components/account/en.yaml
@@ -270,6 +270,7 @@ unitsMustSave: "Note: You must save after changing Units to have the change take
 makePublic: Make public
 makePrivate: Make private
 
+pattern: Pattern
 patternNew: Generate a new pattern
 patternNewInfo: Pick a design, add your measurements set, and we'll generate a bespoke sewing pattern for you.
 


### PR DESCRIPTION
Changes page titles to use singular words, for Bookmark, Pattern, and Measurements Set pages.

Before/after for Patterns:
Before:
![Screenshot 2024-03-19 at 9 49 53 AM](https://github.com/freesewing/freesewing/assets/109869956/ad27c6e8-60cc-494f-9d73-da4a1617cf8c)

After:
![Screenshot 2024-03-19 at 9 50 08 AM](https://github.com/freesewing/freesewing/assets/109869956/21e5f156-86c6-4989-837d-04356092f56c)
