### PR TITLE
fix(shared): Use "Bookmark this" translation strings

### DIFF
--- a/markdown/org/docs/about/site/bookmarks/type/en.md
+++ b/markdown/org/docs/about/site/bookmarks/type/en.md
@@ -6,5 +6,5 @@ Every bookmark has a **type** attribute that is mandatory.
 
 When you manually create a bookmark, the type is always **custom** so you cannot choose it.
 
-Other types include **pattern**, **docs**, or **set** which will automatically be set when you bookmark a pattern, documentation page, or measurements set respectively.
+Other types include **pattern**, **doc**, or **set** which will automatically be set when you bookmark a pattern, documentation page, or measurements set respectively.
 

--- a/sites/shared/components/account/en.yaml
+++ b/sites/shared/components/account/en.yaml
@@ -204,6 +204,8 @@ customBookmark: Custom Bookmarks
 yourBookmarks: Your bookmarks
 bookmarkThisThing: Bookmark this { thing }
 page: Page
+doc: Documentation
+pattern: Pattern
 
 # sets
 set: Measurements Set

--- a/sites/shared/components/bookmarks.mjs
+++ b/sites/shared/components/bookmarks.mjs
@@ -36,7 +36,7 @@ export const CreateBookmark = ({ type, title, slug }) => {
 
   return (
     <>
-      <h2>{t('account:bookmarkThisPage')}</h2>
+      <h2>{t('account:bookmarkThisThing', { thing: t(`account:${type}`) })}</h2>
       <StringInput
         label={t('account:title')}
         current={name}
@@ -45,7 +45,7 @@ export const CreateBookmark = ({ type, title, slug }) => {
         labelBL={url}
       />
       <button className="btn btn-primary w-full mt-4" onClick={bookmark}>
-        <span>{t('account:bookmarkThisPage')}</span>
+        <span>{t('account:bookmarkThisThing', { thing: t(`account:${type}`) })}</span>
       </button>
     </>
   )


### PR DESCRIPTION
Uses the `bookmarkThisThing` translation key that already existed.

Note: This PR adds the "`pattern`" translation key to `sites/shared/components/account/en.yaml`. However, PR #6402 also adds the same `pattern` translation key in a different location in the file. Depending on which PR gets merged first, the other PR might need to be modified to remove the duplicate `pattern` key.

There is already a `page` translation key that exists, so "Bookmark this Documentation" could be changed to "Bookmark this Page", if preferred.

The typo changes "docs" to "doc" which is the actual bookmark type.

After:
![Screenshot 2024-03-19 at 10 27 06 AM](https://github.com/freesewing/freesewing/assets/109869956/0545224f-e5e9-4bc4-9b29-ba41e799b266)
![Screenshot 2024-03-19 at 10 29 15 AM](https://github.com/freesewing/freesewing/assets/109869956/9bb5fa77-6ed4-4880-8c3a-eff2b8285046)

Before:
![Screenshot 2024-03-19 at 10 42 05 AM](https://github.com/freesewing/freesewing/assets/109869956/8ba0ba93-3d45-42ef-993c-38db9b874e0f)
![Screenshot 2024-03-19 at 10 42 28 AM](https://github.com/freesewing/freesewing/assets/109869956/0af558b2-0357-477f-8eec-8e20c1dcda7c)
