### PR TITLE
Add <Spoiler> tag for markdown content

### DIFF
--- a/sites/org/pages/admin/subscribers.mjs
+++ b/sites/org/pages/admin/subscribers.mjs
@@ -1,9 +1,8 @@
 // Dependencies
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { nsMerge, getSearchParam } from 'shared/utils.mjs'
+import { nsMerge } from 'shared/utils.mjs'
 // Hooks
-import { useTranslation } from 'next-i18next'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useBackend } from 'shared/hooks/use-backend.mjs'
 // Components
 import { PageWrapper, ns as pageNs } from 'shared/components/wrappers/page.mjs'
@@ -14,7 +13,6 @@ import { SearchIcon } from 'shared/components/icons.mjs'
 const ns = nsMerge(pageNs, authNs)
 
 const SubscribersPage = ({ page }) => {
-  const { t } = useTranslation(ns)
   const [subscribers, setSubscribers] = useState()
   const [q, setQ] = useState()
   const [hits, setHits] = useState([])

--- a/sites/shared/components/mdx/index.mjs
+++ b/sites/shared/components/mdx/index.mjs
@@ -2,6 +2,7 @@
 import { Popout } from 'shared/components/popout/index.mjs'
 import { Highlight } from './highlight.mjs'
 import { YouTube } from './youtube.mjs'
+import { Spoiler } from './spoiler.mjs'
 //import { Figure } from './figure.mjs'
 import { ReadMore } from './read-more.mjs'
 import { Tab, Tabs } from '../tabs.mjs'
@@ -42,6 +43,7 @@ export const components = (site = 'org', slug = []) => {
   const extra = {
     pre: (props) => <Highlight {...props} />,
     YouTube,
+    Spoiler,
     // This Figure component causes hydration errors
     //img: Figure,
     table: (props) => (

--- a/sites/shared/components/mdx/spoiler.mjs
+++ b/sites/shared/components/mdx/spoiler.mjs
@@ -1,0 +1,8 @@
+export const Spoiler = ({ children = null }) => {
+  return (
+    <label role="presentation" className="spoiler-wrapper">
+      <input type="checkbox" aria-hidden="true" />
+      <div className="spoiler-blur">{children}</div>
+    </label>
+  )
+}

--- a/sites/shared/styles/globals.css
+++ b/sites/shared/styles/globals.css
@@ -444,6 +444,35 @@
   .pattern-logs code {
     @apply px-1 rounded font-bold bg-neutral bg-opacity-10 font-mono;
   }
+
+  /*
+   * Spoiler
+   */
+  .spoiler-wrapper {
+    position: relative;
+    display: block;
+    overflow: clip;
+  }
+  .spoiler-wrapper > input {
+    display: none;
+  }
+  .spoiler-wrapper > input + .spoiler-blur {
+    filter: blur(2rem) contrast(80%);
+    cursor: pointer;
+    opacity: 80%;
+    transition:
+      100ms filter,
+      100ms opacity;
+  }
+  .spoiler-wrapper > input:hover + .spoiler-blur {
+    filter: blur(2rem);
+    cursor: pointer;
+  }
+  .spoiler-wrapper > input:checked + .spoiler-blur {
+    filter: none;
+    opacity: 100%;
+    cursor: default;
+  }
 }
 
 progress.progress-white {


### PR DESCRIPTION
Fixes #6005

Based on the code by @BenJamesBen from the issue

[Demo](https://github.com/freesewing/freesewing/assets/4310707/16be03ce-c979-4949-8326-0b64ceacb10e)

Usage: Just put whatever you want to hide (text, images, ...) inside 
```
<Spoiler>
....
</Spoiler>
```