### PR TITLE
change(bibi): Minor documentation fixes

### DIFF
--- a/markdown/org/docs/designs/bibi/cutting/de.md
+++ b/markdown/org/docs/designs/bibi/cutting/de.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Cutting Instructions"
+title: "Bibi body block: Cutting Instructions"
 ---
 
 - Cut 1 back on the fold.

--- a/markdown/org/docs/designs/bibi/cutting/en.md
+++ b/markdown/org/docs/designs/bibi/cutting/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Cutting Instructions"
+title: "Bibi body block: Cutting Instructions"
 ---
 
 - Cut 1 back on the fold.

--- a/markdown/org/docs/designs/bibi/cutting/es.md
+++ b/markdown/org/docs/designs/bibi/cutting/es.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Cutting Instructions"
+title: "Bibi body block: Cutting Instructions"
 ---
 
 - Cut 1 back on the fold.

--- a/markdown/org/docs/designs/bibi/cutting/fr.md
+++ b/markdown/org/docs/designs/bibi/cutting/fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Cutting Instructions"
+title: "Bibi body block: Cutting Instructions"
 ---
 
 - Cut 1 back on the fold.

--- a/markdown/org/docs/designs/bibi/cutting/nl.md
+++ b/markdown/org/docs/designs/bibi/cutting/nl.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Cutting Instructions"
+title: "Bibi body block: Cutting Instructions"
 ---
 
 - Cut 1 back on the fold.

--- a/markdown/org/docs/designs/bibi/cutting/uk.md
+++ b/markdown/org/docs/designs/bibi/cutting/uk.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Cutting Instructions"
+title: "Bibi body block: Cutting Instructions"
 ---
 
 - Cut 1 back on the fold.

--- a/markdown/org/docs/designs/bibi/en.md
+++ b/markdown/org/docs/designs/bibi/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block"
+title: "Bibi body block"
 ---
 
 

--- a/markdown/org/docs/designs/bibi/fabric/de.md
+++ b/markdown/org/docs/designs/bibi/fabric/de.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Fabric Options"
+title: "Bibi body block: Fabric Options"
 ---
 
 Bibi is by default designed as a close-fitting top and is best suited to knit fabrics with some stretch, such as jersey.

--- a/markdown/org/docs/designs/bibi/fabric/en.md
+++ b/markdown/org/docs/designs/bibi/fabric/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Fabric Options"
+title: "Bibi body block: Fabric Options"
 ---
 
 Bibi is by default designed as a close-fitting top and is best suited to knit fabrics with some stretch, such as jersey.

--- a/markdown/org/docs/designs/bibi/fabric/es.md
+++ b/markdown/org/docs/designs/bibi/fabric/es.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Fabric Options"
+title: "Bibi body block: Fabric Options"
 ---
 
 Bibi is by default designed as a close-fitting top and is best suited to knit fabrics with some stretch, such as jersey.

--- a/markdown/org/docs/designs/bibi/fabric/fr.md
+++ b/markdown/org/docs/designs/bibi/fabric/fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Fabric Options"
+title: "Bibi body block: Fabric Options"
 ---
 
 Bibi is by default designed as a close-fitting top and is best suited to knit fabrics with some stretch, such as jersey.

--- a/markdown/org/docs/designs/bibi/fabric/nl.md
+++ b/markdown/org/docs/designs/bibi/fabric/nl.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Fabric Options"
+title: "Bibi body block: Fabric Options"
 ---
 
 Bibi is by default designed as a close-fitting top and is best suited to knit fabrics with some stretch, such as jersey.

--- a/markdown/org/docs/designs/bibi/fabric/uk.md
+++ b/markdown/org/docs/designs/bibi/fabric/uk.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Fabric Options"
+title: "Bibi body block: Fabric Options"
 ---
 
 Bibi is by default designed as a close-fitting top and is best suited to knit fabrics with some stretch, such as jersey.

--- a/markdown/org/docs/designs/bibi/instructions/de.md
+++ b/markdown/org/docs/designs/bibi/instructions/de.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Sewing Instructions"
+title: "Bibi body block: Sewing Instructions"
 ---
 
 <Note>

--- a/markdown/org/docs/designs/bibi/instructions/en.md
+++ b/markdown/org/docs/designs/bibi/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Sewing Instructions"
+title: "Bibi body block: Sewing Instructions"
 ---
 
 <Note>

--- a/markdown/org/docs/designs/bibi/instructions/es.md
+++ b/markdown/org/docs/designs/bibi/instructions/es.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Sewing Instructions"
+title: "Bibi body block: Sewing Instructions"
 ---
 
 <Note>

--- a/markdown/org/docs/designs/bibi/instructions/fr.md
+++ b/markdown/org/docs/designs/bibi/instructions/fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Sewing Instructions"
+title: "Bibi body block: Sewing Instructions"
 ---
 
 <Note>

--- a/markdown/org/docs/designs/bibi/instructions/nl.md
+++ b/markdown/org/docs/designs/bibi/instructions/nl.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Sewing Instructions"
+title: "Bibi body block: Sewing Instructions"
 ---
 
 <Note>

--- a/markdown/org/docs/designs/bibi/instructions/uk.md
+++ b/markdown/org/docs/designs/bibi/instructions/uk.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Sewing Instructions"
+title: "Bibi body block: Sewing Instructions"
 ---
 
 <Note>

--- a/markdown/org/docs/designs/bibi/measurements/de.md
+++ b/markdown/org/docs/designs/bibi/measurements/de.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Required Measurements"
+title: "Bibi body block: Required Measurements"
 ---
 
 <DesignMeasurements design='bibi' />

--- a/markdown/org/docs/designs/bibi/measurements/en.md
+++ b/markdown/org/docs/designs/bibi/measurements/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Required Measurements"
+title: "Bibi body block: Required Measurements"
 ---
 
 <DesignMeasurements design='bibi' />

--- a/markdown/org/docs/designs/bibi/measurements/es.md
+++ b/markdown/org/docs/designs/bibi/measurements/es.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Required Measurements"
+title: "Bibi body block: Required Measurements"
 ---
 
 <DesignMeasurements design='bibi' />

--- a/markdown/org/docs/designs/bibi/measurements/fr.md
+++ b/markdown/org/docs/designs/bibi/measurements/fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Required Measurements"
+title: "Bibi body block: Required Measurements"
 ---
 
 <DesignMeasurements design='bibi' />

--- a/markdown/org/docs/designs/bibi/measurements/nl.md
+++ b/markdown/org/docs/designs/bibi/measurements/nl.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Required Measurements"
+title: "Bibi body block: Required Measurements"
 ---
 
 <DesignMeasurements design='bibi' />

--- a/markdown/org/docs/designs/bibi/measurements/uk.md
+++ b/markdown/org/docs/designs/bibi/measurements/uk.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Required Measurements"
+title: "Bibi body block: Required Measurements"
 ---
 
 <DesignMeasurements design='bibi' />

--- a/markdown/org/docs/designs/bibi/needs/de.md
+++ b/markdown/org/docs/designs/bibi/needs/de.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: What You Need"
+title: "Bibi body block: What You Need"
 ---
 
 To make Bibi, you will need the following:

--- a/markdown/org/docs/designs/bibi/needs/en.md
+++ b/markdown/org/docs/designs/bibi/needs/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: What You Need"
+title: "Bibi body block: What You Need"
 ---
 
 To make Bibi, you will need the following:

--- a/markdown/org/docs/designs/bibi/needs/es.md
+++ b/markdown/org/docs/designs/bibi/needs/es.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: What You Need"
+title: "Bibi body block: What You Need"
 ---
 
 To make Bibi, you will need the following:

--- a/markdown/org/docs/designs/bibi/needs/fr.md
+++ b/markdown/org/docs/designs/bibi/needs/fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: What You Need"
+title: "Bibi body block: What You Need"
 ---
 
 To make Bibi, you will need the following:

--- a/markdown/org/docs/designs/bibi/needs/nl.md
+++ b/markdown/org/docs/designs/bibi/needs/nl.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: What You Need"
+title: "Bibi body block: What You Need"
 ---
 
 To make Bibi, you will need the following:

--- a/markdown/org/docs/designs/bibi/needs/uk.md
+++ b/markdown/org/docs/designs/bibi/needs/uk.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: What You Need"
+title: "Bibi body block: What You Need"
 ---
 
 To make Bibi, you will need the following:

--- a/markdown/org/docs/designs/bibi/notes/de.md
+++ b/markdown/org/docs/designs/bibi/notes/de.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Designer Notes"
+title: "Bibi body block: Designer Notes"
 ---
 
 When I was designing the Tina top, I originally was basing the pattern on 

--- a/markdown/org/docs/designs/bibi/notes/en.md
+++ b/markdown/org/docs/designs/bibi/notes/en.md
@@ -1,8 +1,8 @@
 ---
-title: "Bibi Body Block: Designer Notes"
+title: "Bibi body block: Designer Notes"
 ---
 
-When I was designing the Tina top, I originally was basing the pattern on 
+When I was designing my (in progress) Tina top, I originally was basing the pattern on 
 Teagan and Brian. However, Tina is supposed to work for people with breasts
 and Brian is mostly designed for menswear and doesn't support much body
 and bust fitting. So I created Bibi as a base for Tina.

--- a/markdown/org/docs/designs/bibi/notes/es.md
+++ b/markdown/org/docs/designs/bibi/notes/es.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Designer Notes"
+title: "Bibi body block: Designer Notes"
 ---
 
 When I was designing the Tina top, I originally was basing the pattern on 

--- a/markdown/org/docs/designs/bibi/notes/fr.md
+++ b/markdown/org/docs/designs/bibi/notes/fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Designer Notes"
+title: "Bibi body block: Designer Notes"
 ---
 
 When I was designing the Tina top, I originally was basing the pattern on 

--- a/markdown/org/docs/designs/bibi/notes/nl.md
+++ b/markdown/org/docs/designs/bibi/notes/nl.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Designer Notes"
+title: "Bibi body block: Designer Notes"
 ---
 
 When I was designing the Tina top, I originally was basing the pattern on 

--- a/markdown/org/docs/designs/bibi/notes/uk.md
+++ b/markdown/org/docs/designs/bibi/notes/uk.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Designer Notes"
+title: "Bibi body block: Designer Notes"
 ---
 
 When I was designing the Tina top, I originally was basing the pattern on 

--- a/markdown/org/docs/designs/bibi/options/de.md
+++ b/markdown/org/docs/designs/bibi/options/de.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Design Options"
+title: "Bibi body block: Design Options"
 ---
 
 <DesignOptions design='bibi' />

--- a/markdown/org/docs/designs/bibi/options/en.md
+++ b/markdown/org/docs/designs/bibi/options/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Design Options"
+title: "Bibi body block: Design Options"
 ---
 
 <DesignOptions design='bibi' />

--- a/markdown/org/docs/designs/bibi/options/es.md
+++ b/markdown/org/docs/designs/bibi/options/es.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Design Options"
+title: "Bibi body block: Design Options"
 ---
 
 <DesignOptions design='bibi' />

--- a/markdown/org/docs/designs/bibi/options/fitwaist/en.md
+++ b/markdown/org/docs/designs/bibi/options/fitwaist/en.md
@@ -2,9 +2,9 @@
 title: "Fit the waist"
 ---
 
-Enable this option to fit the waist of your Teagan, rather than draft a straight T-shirt shape.
+Enable this option to fit the waist, rather than drafting a straight rectangular shape.
 
-This will yield best results for those with a smaller waist who are looking for a more hourglass-shaped fitted T-shirt.
+Fitting the waist will yield best results for those with a smaller waist who are looking for a more hourglass-shaped fitted top.
 
-If your waist is larger than your hips, you should not enable this option as you may end up with a T-shirt that you can't get in to.
+Not fitting the waist will instead create something that looks more like a loose men's t-shirt.
 

--- a/markdown/org/docs/designs/bibi/options/fr.md
+++ b/markdown/org/docs/designs/bibi/options/fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Design Options"
+title: "Bibi body block: Design Options"
 ---
 
 <DesignOptions design='bibi' />

--- a/markdown/org/docs/designs/bibi/options/length/en.md
+++ b/markdown/org/docs/designs/bibi/options/length/en.md
@@ -2,7 +2,7 @@
 title: "Length"
 ---
 
-Which measurement to use for the hem. Of the length bonus is zero, the bottom of the garment will be at exactly the selected measurement.
+Which measurement to use for the hem. If the length bonus is zero, the bottom of the garment will be at exactly the selected measurement.
 
 Note that the options *underbust*, *knee* and *floor* require the corresponding optional vertical measurements.
 If they are missing, a very rough estimate is used instead.

--- a/markdown/org/docs/designs/bibi/options/nl.md
+++ b/markdown/org/docs/designs/bibi/options/nl.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Design Options"
+title: "Bibi body block: Design Options"
 ---
 
 <DesignOptions design='bibi' />

--- a/markdown/org/docs/designs/bibi/options/uk.md
+++ b/markdown/org/docs/designs/bibi/options/uk.md
@@ -1,5 +1,5 @@
 ---
-title: "Bibi Body Block: Design Options"
+title: "Bibi body block: Design Options"
 ---
 
 <DesignOptions design='bibi' />

--- a/markdown/org/docs/designs/bibi/options/waistease/en.md
+++ b/markdown/org/docs/designs/bibi/options/waistease/en.md
@@ -2,6 +2,6 @@
 title: "Waist ease"
 ---
 
-If (and only if) you request to [fit the waist](/docs/designs/teagan/options/curvetowaist), this option allows you to control the amount of ease at the waist.
+If (and only if) you request to [fit the waist](/docs/designs/bibi/options/fitwaist), this option allows you to control the amount of ease at the waist.
 
 If the waist is not fitted, this option is disabled.


### PR DESCRIPTION
Fix a few instances where I errorneusly copied documentation from teagan without adjusting it properly.

Don't captitalize "block body" in the titles (to match other designs). 

Mention that Tina is not yet released.