### PR TITLE
Replace input type="number" with input type="text" inputmode="numeric"/"decimal"

### DIFF
--- a/sites/org/components/github/inputs.mjs
+++ b/sites/org/components/github/inputs.mjs
@@ -16,7 +16,9 @@ export const AuthorInput = ({ author, setAuthor }) => (
     className={`input input-text input-bordered input-lg w-full mb-2 ${
       author ? 'input-success' : 'input-error'
     }`}
-    type="number"
+    type="text"
+    inputMode="numeric"
+    pattern="[0-9]*"
     value={author}
     placeholder="Enter the user ID here"
     onChange={(evt) => setAuthor(evt.target.value)}

--- a/sites/shared/components/account/mfa.mjs
+++ b/sites/shared/components/account/mfa.mjs
@@ -103,7 +103,9 @@ export const MfaSettings = ({ title = false, welcome = false }) => {
             value={code}
             onChange={(evt) => setCode(evt.target.value)}
             className="input w-64 m-auto text-4xl  input-bordered input-lg flex flex-row text-center mb-8 tracking-widest"
-            type="number"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]{6}"
             placeholder={t('000000')}
           />
           <button className="btn btn-success btn-lg block w-full" onClick={confirmMfa}>

--- a/sites/shared/components/inputs.mjs
+++ b/sites/shared/components/inputs.mjs
@@ -156,7 +156,8 @@ export const NumberInput = ({
   <FormControl {...{ label, labelBL, labelBR, docs }} forId={id}>
     <input
       id={id}
-      type="number"
+      type="text"
+      inputMode="decimal"
       placeholder={placeholder}
       value={current}
       onChange={(evt) => update(evt.target.value)}
@@ -578,7 +579,9 @@ export const MeasieInput = ({
     >
       <input
         id={id}
-        type="number"
+        type="text"
+        inputMode="numeric"
+        pattern="[0-9]*"
         placeholder={placeholder}
         value={localVal}
         onChange={(evt) => localUpdate(evt.target.value)}

--- a/sites/shared/components/patrons/subscribe.mjs
+++ b/sites/shared/components/patrons/subscribe.mjs
@@ -14,15 +14,6 @@ const PaypalFormBody = ({ amount, period, currency, language }) => (
     ].map(([name, value]) => (
       <input type="hidden" {...{ name, value }} key={name} />
     ))}
-    <input
-      type="hidden"
-      name="item_number"
-      value={
-        period === 'x'
-          ? `donate-${amount}-${currency}`
-          : `subscribe-${amount}-${currency}-${period}`
-      }
-    />
     {period === 'x' ? (
       <>
         <input type="hidden" name="item_number" value={`donate-${amount}-${currency}`} />
@@ -71,8 +62,10 @@ export const Subscribe = ({
             <span className="label-text-alt text-inherit">{t('patrons:yourContribution')}</span>
           </label>
           <input
-            type="number"
+            type="text"
+            inputMode="decimal"
             placeholder="Enter amount here"
+            pattern="[0-9]+([.][0-9]+)?"
             className="input input-bordered w-full text-base-content"
             value={amount}
             onChange={(evt) => setAmount(evt.target.value)}
@@ -149,7 +142,7 @@ export const Subscribe = ({
         <PaypalFormBody {...{ currency, amount, period, language }} />
         <button
           className={`btn btn-${color} w-full mt-4`}
-          disabled={Number(amount) < 1}
+          disabled={!(Number(amount) > 0)}
           type="submit"
         >
           {period === 'x' ? t('patrons:donate') : t('patrons:subscribe')}

--- a/sites/shared/components/workbench/menus/shared/inputs.mjs
+++ b/sites/shared/components/workbench/menus/shared/inputs.mjs
@@ -120,7 +120,7 @@ export const NumberInput = ({
   return (
     <input
       type="text"
-      inputMode="number"
+      inputMode="decimal"
       className={`input input-secondary ${className || 'input-sm grow text-base-content'}
         ${valid.current === false && 'input-error'}
         ${valid.current && 'input-success'}
@@ -247,8 +247,8 @@ export const ListInput = ({
     const titleKey = config.choiceTitles
       ? config.choiceTitles[entry]
       : isDesignOption
-      ? `${design}:${name}.${entry}`
-      : `${name}.o.${entry}`
+        ? `${design}:${name}.${entry}`
+        : `${name}.o.${entry}`
     const title = config.titleMethod ? config.titleMethod(entry, t) : t(`${titleKey}.t`)
     const desc = config.valueMethod ? config.valueMethod(entry, t) : t(`${titleKey}.d`)
     const sideBySide = config.sideBySide || desc.length + title.length < 42


### PR DESCRIPTION
Fixes #6542

Also fixes some other small issues:

* duplicate `item_number` input element in patron Paypal code
* replaced invalid `inputMode="number"` with `inputMode="decimal"`
* replaced `disabled={Number(amount) < 1}` with `disabled={!(Number(amount) > 0)}` (an invalid value would be `NaN`, which wouldn't be less than 1.)