### PR TITLE
[lily] fix errors related to cutting off too close to the fork

### DIFF
--- a/designs/lily/src/back.mjs
+++ b/designs/lily/src/back.mjs
@@ -208,7 +208,7 @@ function draftLilyBack({
     let requestedLength = (1 - options.lengthReduction) * measurements.waistToFloor
     // leggings must reach to fork at least, so define a minimum
     const waistToFork = points.waistX.dy(points.fork)
-    if (waistToFork >= 0.999 * requestedLength) {
+    if (waistToFork >= 0.99 * requestedLength) {
       log.warn('length reduction capped; cutting off at fork')
       // add one percent to waistToFork to ensure that path length is nonzero
       requestedLength = waistToFork * 1.01


### PR DESCRIPTION
fix errors related to cutting off too close to the fork;
also ensures that capping the cut off does not reduce the length further than any allowed value