### PR TITLE
fix(rehype-jargon): Ignore `em` elements that contain nested elements

### DIFF
--- a/packages/rehype-jargon/src/index.mjs
+++ b/packages/rehype-jargon/src/index.mjs
@@ -17,6 +17,7 @@ export default (options) => {
   const isJargon = (node) => {
     if (
       node.tagName === 'em' &&
+      node.children.every((n) => n.type === 'text') &&
       Object.keys(options.jargon).indexOf(node.children[0].value.toLowerCase()) !== -1
     )
       return true


### PR DESCRIPTION
This adds a check if the `em` element only contains text, effectively ignoring `em` elements that contain nested elements.

Fixes #6471 