### PR TITLE
fix(lily) Locking fitKnee as intended

### DIFF
--- a/designs/lily/i18n/en.json
+++ b/designs/lily/i18n/en.json
@@ -44,10 +44,6 @@
       "t": "Crotch drop",
       "d": "Lowers the crotch for a more relaxed fit"
     },
-    "fitKnee": {
-      "t": "Fit the knee",
-      "d": "Fits the legs from based on the knee circumference, rather than seat circumference"
-    },
     "crossSeamCurveStart": {
       "t": "Start of the cross seam curve",
       "d": "Controls how far into the cross seam we start to curve"

--- a/designs/lily/src/back.mjs
+++ b/designs/lily/src/back.mjs
@@ -563,7 +563,7 @@ export const back = {
   ],
   options: {
     fitGuides: { bool: false, menu: 'advanced' },
-    fitKnee: { bool: true, hide: true },
+    fitKnee: true,
     legBalance: 0.5, // between back and front parts
     waistBalance: 0.5,
     crotchDrop: { pct: 0, min: 0, max: 15, menu: 'advanced' }, // 'downgrade' to advanced menu


### PR DESCRIPTION
fitKnee was intended to be locked not hidden.
This has been updated on back.mjs and the fitKnee translations have been removed from the i18n file.
Found this whilst working on the Lily docs and didn't want it getting muddled with the documentation work.