### PR TITLE
[Bugfix] Opal

### DIFF
--- a/designs/opal/src/back.mjs
+++ b/designs/opal/src/back.mjs
@@ -529,7 +529,7 @@ function draftBack({
   macro('vd', {
     id: 'vLegHemAllowance',
     from: points.outseamHem,
-    to: points.outseamHemAllowance,
+    to: sa ? points.outseamHemAllowance : points.outseamHem,
     x: points.waist.x + (sa + 15),
     noStartMarker: true,
     noEndMarker: true,

--- a/designs/opal/src/front.mjs
+++ b/designs/opal/src/front.mjs
@@ -150,6 +150,7 @@ function draftFront({
       .close()
       .addClass('fabric sa')
   }
+
   if (complete)
     paths.hint = new Path()
       .move(points.crossSeamCurveStart)

--- a/designs/opal/src/front.mjs
+++ b/designs/opal/src/front.mjs
@@ -320,7 +320,8 @@ export const front = {
       pct: 150,
       min: 0,
       max: 400,
-      toAbs: (pct, settings, mergedOptions) => settings.sa * mergedOptions.hemAllowance,
+      toAbs: (pct, settings, mergedOptions) =>
+        settings.sa ? settings.sa : 0 * mergedOptions.hemAllowance,
       menu: 'construction',
     },
     // Sets the hem allowance for the legs. Very large values are used for cuffs. If making a regular hem, setting this equal to hemAllowance can work well.

--- a/designs/opal/src/front.mjs
+++ b/designs/opal/src/front.mjs
@@ -150,7 +150,6 @@ function draftFront({
       .close()
       .addClass('fabric sa')
   }
-
   if (complete)
     paths.hint = new Path()
       .move(points.crossSeamCurveStart)
@@ -249,7 +248,7 @@ function draftFront({
   macro('vd', {
     id: 'vLegHemAllowance',
     from: points.outseamHem,
-    to: points.outseamHemAllowance,
+    to: sa ? points.outseamHemAllowance : points.outseamHem,
     x: points.waist.x + (sa + 15),
     noStartMarker: true,
     noEndMarker: true,
@@ -278,7 +277,6 @@ function draftFront({
     to: points.inseamHem,
     x: points.fork.x - (sa + 30),
   })
-
   points.grainlineTop = points.slashSide.translate(-waistDist * 0.05, 0)
   points.grainlineBottom = new Point(points.grainlineTop.x, points.outseamHem.y)
   macro('grainline', {

--- a/markdown/org/docs/designs/onyx/needs/en.md
+++ b/markdown/org/docs/designs/onyx/needs/en.md
@@ -6,7 +6,7 @@ To make Onyx, you will need the following:
 
 - Basic sewing supplies
 - (Recommended) A serger/overlock machine. Light, strong, and stretchy seams are important for this garment.
-- Between 1 - 5 meters (1.1 - 5.5 yards) of a suitable fabric, depending on size and style ([see Fabric options](/docs/patterns/shelly/fabric))
+- Between 1 - 5 meters (1.1 - 5.5 yards) of a suitable fabric, depending on size and style ([see Fabric options](/docs/patterns/opal/fabric))
 	- Long sleeves, long legs, use of lining, larger measurements, more ease, use of a hood, and use of a skirt will all increase fabric requirements.
 	- A typical adult unisuit with short sleeves and short legs with a self-lined body will take about 2 meters of fabric.
 - (Optional) Rib knit fabric for the neck, arms, and legs, if desired.


### PR DESCRIPTION
Fixes a bug in Opal where it was crashing if sa was == 0 and paperless was true.

There were points that are only generated for the seam allowance that were being referred to in the dimension macros. This bug fix remedies this problem.