### PR TITLE
fix(ringsector) Add missing line to path

### DIFF
--- a/plugins/plugin-ringsector/src/index.mjs
+++ b/plugins/plugin-ringsector/src/index.mjs
@@ -153,6 +153,7 @@ export const plugin = {
         .line(points[ids.in2])
         .curve(points[ids.in2c], points[ids.in1c], points[ids.in1])
         .curve(points[ids.in1cFlipped], points[ids.in2cFlipped], points[ids.in2Flipped])
+        .line(points[ids.ex2Flipped])
         .close()
 
       /*


### PR DESCRIPTION
Closes #6792

Adds missing line to ringsector path.
Fixes the issue with Sandy's curved waistband,
Tristan's seam allowance paths are changed here #6798 to accomadate this change. 