### PR TITLE
(feature) Add secret to MFA enable

### DIFF
--- a/sites/shared/components/account/en.yaml
+++ b/sites/shared/components/account/en.yaml
@@ -40,7 +40,7 @@ mfaTipMsg: We do not enforce a password policy, but we do recommend you enable T
 mfaEnabled: Two-Factor Authentication is enabled
 mfaDisabled: Two-Factor Authentication is disabled
 mfaSetup: Set up Two-Factor Authentication
-mfaAdd: Add FreeSewing to your Authenticator App by scanning the QR code above.
+mfaAdd: Add FreeSewing to your Authenticator App by scanning the QR code above. If you can't scan the QR code, you can manually enter the secret below it.
 mfaScratchCodes: MFA Scratch Codes
 mfaScratchCodesMsg1: You can use any of these scratch codes as a one-time MFA code when you do not have access to your code-generating app (for example, when you've lost your phone).
 mfaScratchCodesMsg2: You can use each of these codes only once. Write them down, because this is the only time you will get to see them.

--- a/sites/shared/components/account/mfa.mjs
+++ b/sites/shared/components/account/mfa.mjs
@@ -97,6 +97,7 @@ export const MfaSettings = ({ title = false, welcome = false }) => {
           <div className="flex flex-row items-center justify-center px-8 lg:px-36">
             <div dangerouslySetInnerHTML={{ __html: enable.qrcode }} />
           </div>
+          <p className="flex flex-row items-center justify-center">{enable.secret}</p>
           <Bullet num="1">{t('mfaAdd')}</Bullet>
           <Bullet num="2">{t('confirmWithMfa')}</Bullet>
           <input


### PR DESCRIPTION
I noticed while redoing some of my 2FA things that Freesewing doesn't expose the TOTP secret to the user, except encoded into the QR code. This makes some setups significantly more difficult for no gain, which is why showing the secret as text (either directly or when asked for by the user) is standard.

Side by side of the change:
![SideBySide](https://github.com/freesewing/freesewing/assets/39151688/b94f16fa-2025-4d3b-b9d4-d2b6198fdb69)