### PR TITLE
Load markdown text and images from the server rather than from GitHub when markdown is dynamically loaded

### DIFF
--- a/sites/dev/prebuild.mjs
+++ b/sites/dev/prebuild.mjs
@@ -34,6 +34,11 @@ prebuildRunner({
     docs: true,
 
     /*
+     * Always prebuild the MD raw file list
+     */
+    mdRaw: true,
+
+    /*
      * Always prebuild the translation files
      * Even if we only support English on FreeSewing.dev,
      * we still rely on the (English) translation of strings

--- a/sites/lab/prebuild.mjs
+++ b/sites/lab/prebuild.mjs
@@ -25,6 +25,7 @@ prebuildRunner({
     git: false,
     patrons: false,
     posts: false,
+    mdRaw: false,
   },
 })
 

--- a/sites/org/prebuild.mjs
+++ b/sites/org/prebuild.mjs
@@ -39,6 +39,11 @@ prebuildRunner({
     posts: true,
 
     /*
+     * Always prebuild the MD raw file list
+     */
+    mdRaw: true,
+
+    /*
      * Always prebuild the translation files
      * Even if we only support English on FreeSewing.dev,
      * we still rely on the (English) translation of strings

--- a/sites/sde/prebuild.mjs
+++ b/sites/sde/prebuild.mjs
@@ -22,5 +22,6 @@ prebuildRunner({
     git: false,
     patrons: false,
     posts: false,
+    mdRaw: false,
   },
 })

--- a/sites/shared/components/mdx/dynamic.mjs
+++ b/sites/shared/components/mdx/dynamic.mjs
@@ -9,8 +9,8 @@ import { useState, useEffect } from 'react'
 import { MdxWrapper } from 'shared/components/wrappers/mdx.mjs'
 import { Loading } from 'shared/components/spinner.mjs'
 
-const ghPrefix = 'https://raw.githubusercontent.com/freesewing/freesewing/develop/markdown'
-const fromGithub = true
+const remotePrefix = '/markdown'
+const fromRemote = true
 
 const titles = {
   1: ({ title }) => <h1>{title}</h1>,
@@ -27,9 +27,9 @@ export const DynamicMdx = ({ site = 'org', slug, language, title = 1 }) => {
 
   useEffect(() => {
     const loadMdx = async () => {
-      const response = await fetch(`${ghPrefix}/${site}/${slug}/${language}.md`)
+      const response = await fetch(`${remotePrefix}/${site}/${slug}/${language}.md`)
       const md = await response.text()
-      const mdx = await compileMdx({ site, slug, language, md, fromGithub })
+      const mdx = await compileMdx({ site, slug, language, md, fromRemote })
       const { frontmatter: fm } = await run(mdx, runtime)
       setMdx(mdx)
       setFrontmatter(fm)

--- a/sites/shared/mdx/browser-compile.mjs
+++ b/sites/shared/mdx/browser-compile.mjs
@@ -7,7 +7,7 @@ import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
 import remarkGfm from 'remark-gfm'
 import smartypants from 'remark-smartypants'
 // FreeSewing custom remark plugins
-import { remarkGithubImages } from './remark-github-images.mjs'
+import { remarkRemoteImages } from './remark-remote-images.mjs'
 
 /*
  * Compiles markdown/mdx to a function body
@@ -22,7 +22,7 @@ export const compileMdx = async ({
    * This is also used for inline markdown (like what users provide)
    * in which case we do not need this plugin
    */
-  if (site && slug) remarkPlugins.push([remarkGithubImages, { site, slug }])
+  if (site && slug) remarkPlugins.push([remarkRemoteImages, { site, slug }])
   const mdx = String(
     await compile(md, {
       outputFormat: 'function-body',

--- a/sites/shared/mdx/compile.mjs
+++ b/sites/shared/mdx/compile.mjs
@@ -11,7 +11,7 @@ import smartypants from 'remark-smartypants'
 // FreeSewing custom remark plugins
 import { remarkIntroAsFrontmatter } from './remark-intro-as-frontmatter.mjs'
 import { remarkTocAsFrontmatter } from './remark-toc-as-frontmatter.mjs'
-import { remarkGithubImages } from './remark-github-images.mjs'
+import { remarkRemoteImages } from './remark-remote-images.mjs'
 // Rehype plugins from the ecosystem
 import rehypeHighlight from 'rehype-highlight'
 import rehypeAutolinkHeadings from 'rehype-autolink-headings'
@@ -25,7 +25,7 @@ export const compileMdx = async ({
   md, // A string holding the markdown
   site, // The site folder, one of 'org' or 'dev'
   slug, // The slug to the page below the folder (like 'guides/plugins')
-  fromGithub = false, // Set this to true when dynamically loading mdx from Github
+  fromRemote = false, // Set this to true when dynamically loading mdx from the server
 }) => {
   const mdx = String(
     await compile(md, {
@@ -37,8 +37,8 @@ export const compileMdx = async ({
         remarkMdxFrontmatter,
         remarkGfm,
         smartypants,
-        fromGithub
-          ? remarkGithubImages
+        fromRemote
+          ? remarkRemoteImages
           : [
               remarkCopyLinkedFiles,
               {

--- a/sites/shared/mdx/load.mjs
+++ b/sites/shared/mdx/load.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { compileMdx } from './compile.mjs'
-import { ghPrefix } from './remark-github-images.mjs'
+import { remotePrefix } from './remark-remote-images.mjs'
 
 /*
  * Loads markdown/mdx from disk
@@ -30,14 +30,14 @@ export const loadMdxFromDisk = async ({
 }
 
 /*
- * Loads markdown/mdx from Github
+ * Loads markdown/mdx from server
  */
-export const loadMdxFromGithub = async ({
+export const loadMdxFromRemote = async ({
   language, // The language code of the markdown to load (like 'en')
   site, // The site folder, one of 'dev' or 'org'
   slug, // The slug below that folder, like 'guides/plugins'
 }) => {
-  const response = await fetch(`${ghPrefix}/${site}/${slug}/${language}.md`)
+  const response = await fetch(`${remotePrefix}/${site}/${slug}/${language}.md`)
   const md = await response.text()
 
   return md

--- a/sites/shared/mdx/remark-remote-images.mjs
+++ b/sites/shared/mdx/remark-remote-images.mjs
@@ -1,22 +1,22 @@
 //  __SDEFILE__ - This file is a dependency for the stand-alone environment
 /*
  * This is a remark plugin that will update the src of local images to
- * load them from Github. It is used when we load markdown/mdx dynamically
- * from Github rather than from disk.
+ * load them from the server. It is used when we load markdown/mdx dynamically
+ * for client-side rendering.
  */
 import { visit } from 'unist-util-visit'
 
-export const ghPrefix = 'https://raw.githubusercontent.com/freesewing/freesewing/develop/markdown'
+export const remotePrefix = '/markdown'
 
 const convertUrl = ({ site, slug, url }) => {
   if (url.slice(0, 1) === 'http://') return url
   if (url.slice(0, 7) === 'http://') return url
   if (url.slice(0, 8) === 'https://') return url
 
-  return `${ghPrefix}/${site}/${slug}/${url}`
+  return `${remotePrefix}/${site}/${slug}/${url}`
 }
 
-export function remarkGithubImages({ site, slug }) {
+export function remarkRemoteImages({ site, slug }) {
   return (tree) => {
     visit(tree, function (node) {
       if (node.type === 'image') node.url = convertUrl({ site, slug, url: node.url })

--- a/sites/shared/prebuild/markdown.mjs
+++ b/sites/shared/prebuild/markdown.mjs
@@ -309,6 +309,28 @@ const writeFile = async (filename, exportname, site, content) => {
 }
 
 /*
+ * Copy all the markdown resources + image assets to the public folder
+ */
+const copyMdRawFiles = async (site) => {
+  const src = await path.resolve(process.cwd(), '..', '..', 'markdown', site)
+  const dst = await path.resolve(process.cwd(), '..', site, 'public', 'markdown')
+
+  await new Promise((resolve, reject) => {
+    exec(`mkdir -p ${dst}`, { maxBuffer: 2048 * 1024 }, (error, stdout, stderr) => {
+      if (error) reject(error)
+      resolve(stdout)
+    })
+  })
+
+  await new Promise((resolve, reject) => {
+    exec(`cp -r ${src} ${dst}`, { maxBuffer: 2048 * 1024 }, (error, stdout, stderr) => {
+      if (error) reject(error)
+      resolve(stdout)
+    })
+  })
+}
+
+/*
  * Main method that does what needs doing for the docs
  */
 export const prebuildDocs = async (store) => {
@@ -341,4 +363,11 @@ export const prebuildPosts = async (store) => {
   await writeFile('showcase-meta', 'meta', 'org', store.posts.showcase.meta)
   await writeFile('design-examples', 'examples', 'org', store.posts.showcase.designShowcases)
   await writeFile('authors', 'authors', 'org', store.users)
+}
+
+/*
+ * Main method to collect all the raw resource paths to be served as static resources for client-side rendering
+ */
+export const prebuildMdRaw = async (store) => {
+  await copyMdRawFiles(store.site)
 }

--- a/sites/shared/prebuild/runner.mjs
+++ b/sites/shared/prebuild/runner.mjs
@@ -2,7 +2,11 @@
 import { oraPromise } from 'ora'
 import { capitalize } from '../utils.mjs'
 // Handlers
-import { prebuildDocs as docs, prebuildPosts as posts } from './markdown.mjs'
+import {
+  prebuildDocs as docs,
+  prebuildPosts as posts,
+  prebuildMdRaw as mdRaw,
+} from './markdown.mjs'
 import { prebuildNavigation as navigation } from './navigation.mjs'
 import { prebuildGitData as git } from './git.mjs'
 import { prebuildContributors as contributors } from './contributors.mjs'
@@ -40,6 +44,7 @@ const handlers = {
   'Page Templates': true,
   search,
   ogImages,
+  mdRaw,
 }
 
 /*


### PR DESCRIPTION
Currently the website loads markdown from GitHub for client-side rendering. I am not sure what the reason for this is, however it creates confusion and barriers to being able to fully test local changes to the documentation pages and to being able to run a full local copy of the site (e.g. if you add documentation for a new sewing pattern that is not in upstream, this will not display in the site, or if you modify existing documentation your changes won't actually display). (see Discord: https://discord.com/channels/698854858052075530/698862765053575188/1246570558024323143)

I have changed it to load from the actual server that is being used. I am not sure if there is a reason why it is not done this way. I am not sure if there is a problem with the way that I have done it, or if this approach was already ruled out for some other reason. If so please can you explain, or let me know if you need me to structure the code differently or whatever (I'm not familiar with React). Sorry if this is unwelcome. However, it was very frustrating to me that I am unable to simply add my own design and have it properly appear in my own local copy of the website.