### PR TITLE
fix(markdown): close frontmatter properly in Jane documentation

### DIFF
--- a/markdown/org/docs/designs/jane/options/sleevelength/en.md
+++ b/markdown/org/docs/designs/jane/options/sleevelength/en.md
@@ -1,4 +1,5 @@
 ---
 title: Sleeve Length
+---
 
 This option controls the extra length added to the sleeve. If you want a length appropriate for 1790's then you don't use this option. 


### PR DESCRIPTION
Causes `yarn build` on `sites/org` to fail.