### PR TITLE
fix: Bruce is a bottom, not a top

### DIFF
--- a/config/software/designs.json
+++ b/config/software/designs.json
@@ -179,7 +179,7 @@
     "lab": true,
     "org": true,
     "tags": [
-      "tops",
+      "bottoms",
       "underwear"
     ],
     "techniques": [


### PR DESCRIPTION
This fixes Bruce's tagging to show that it's a bottom, not a top.

Fixes #6803
