### PR TITLE
fix(charlie, titan): Handle bad cross-seam-front and waist-to-seat measurements

### DIFF
--- a/config/changelog.yaml
+++ b/config/changelog.yaml
@@ -9,6 +9,8 @@ Unreleased:
     cathrin:
       - Allow negative values in backDrop option. Fixes #6563
       - Allow negative values for the frontRise options. Fixes #6563
+    charlie:
+      - Fix crash when drawing the jseamStitchLine is not possible. Fixes #6271
     bibi:
       - Changed the algorithm to draft the side seam, so the measurements are followed more precisely
       - Reduced default influence of the seat back measurement and added an option to adjust it.
@@ -29,7 +31,8 @@ Unreleased:
       - Always load plugin-bust due to its changes in how it handle conditionality.
     teagan:
       - Increased default lengthBonus from 5% to 15%. Fixes #6820
-
+    titan:
+      - Adjust cross seam curves after fitting the waist. Fixes #6271
     wahid:
       - Add a warning when waist and hip reduction are both zero, so no back dart is required
 

--- a/designs/charlie/src/front.mjs
+++ b/designs/charlie/src/front.mjs
@@ -117,21 +117,24 @@ function draftCharlieFront({
 
   // Too small to draw for dolls
   if (measurements.waist > 500) {
-    paths.completeJseam = JseamCurve.split(points.flyBottomSeamLine)[0]
-      .clone()
-      .setClass('dashed')
-      .addText('jseamStitchLine', 'center text-sm')
+    const splitElement = JseamCurve.split(points.flyBottomSeamLine)[0]
+    if (splitElement) {
+      paths.completeJseam = splitElement
+        .clone()
+        .setClass('dashed')
+        .addText('jseamStitchLine', 'center text-sm')
 
-    paths.flyRightLegExtension = crotchCurve
-      .clone()
-      .split(points.flyBottom)[1]
-      .offset(topStitchDist)
-      .line(points.styleWaistIn)
-      .reverse()
-      .line(points.flyExtensionBottom)
-      .reverse()
-      .setClass('fabric')
-      .addText('rightLegSeamline', 'center fill-note text-sm')
+      paths.flyRightLegExtension = crotchCurve
+        .clone()
+        .split(points.flyBottom)[1]
+        .offset(topStitchDist)
+        .line(points.styleWaistIn)
+        .reverse()
+        .line(points.flyExtensionBottom)
+        .reverse()
+        .setClass('fabric')
+        .addText('rightLegSeamline', 'center fill-note text-sm')
+    }
   }
 
   // Construct pocket slant

--- a/designs/titan/i18n/en.json
+++ b/designs/titan/i18n/en.json
@@ -9,7 +9,11 @@
     "crossSeamFitFailedBack.t": "Back cross seam compromised",
     "crossSeamFitFailedBack.d": "No solution was found to fit the cross seam in the back part. As a compromise, we've used the best available solution instead.\n\nPlease verify your measurements before contacting support.",
     "crossSeamFitFailedFront.t": "Front cross seam compromised",
-    "crossSeamFitFailedFront.d": "No solution was found to fit the cross seam in the front part. As a compromise, we've used the best available solution instead.\n\nPlease verify your measurements before contacting support."
+    "crossSeamFitFailedFront.d": "No solution was found to fit the cross seam in the front part. As a compromise, we've used the best available solution instead.\n\nPlease verify your measurements before contacting support.",
+    "lowFrontHeight.t": "Front waist too low",
+    "lowFrontHeight.d": "The front cross seam curve was adjusted as the front waistband was unexpectedly low.\n\nThe generated pattern is likely not correct. Please verify your measurements before contacting support.",
+    "lowBackHeight.t": "Back waist too low",
+    "lowBackHeight.d": "The back cross seam curve was adjusted as the back waistband was unexpectedly low.\n\nThe generated pattern is likely not correct. Please verify your measurements before contacting support."
   },
   "o": {
     "kneeEase": {

--- a/designs/titan/src/back.mjs
+++ b/designs/titan/src/back.mjs
@@ -226,6 +226,13 @@ function titanBack({
       points.waistIn,
       points.crossSeamCurveStart
     )
+    if (points.styleWaistIn.y >= points.crossSeamCurveStart.y) {
+      store.flag.warn({ msg: 'titan:lowBackHeight' })
+      points.crossSeamCurveStart = points.styleWaistIn.shiftFractionTowards(
+        points.crossSeamCurveMax,
+        0.001
+      )
+    }
   } else {
     points.styleWaistIn = points.waistIn.clone()
     points.styleWaistOut = points.waistOut.clone()

--- a/designs/titan/src/front.mjs
+++ b/designs/titan/src/front.mjs
@@ -304,6 +304,13 @@ function titanFront({
       points.waistIn,
       points.crotchSeamCurveStart
     )
+    if (points.styleWaistIn.y >= points.crotchSeamCurveStart.y) {
+      store.flag.warn({ msg: 'titan:lowFrontHeight' })
+      points.crotchSeamCurveStart = points.styleWaistIn.shiftFractionTowards(
+        points.crotchSeamCurveMax,
+        0.001
+      )
+    }
   } else {
     points.styleWaistIn = points.waistIn.clone()
     points.styleWaistOut = points.waistOut.clone()


### PR DESCRIPTION
Fixes #6271

This will flag a warning message when the created front waist or back waist is below the cross-seam curve control point and will adjust that control point to be (very slightly) below the waistband in order to not cause weird shapes or follow-up problems in designs like Charlie.

I also added a check in charlie that would fix the crash on its own, but results in a very bad shape.

See discussion in the mentioned issue (including the linked discord thread) for details.