### PR TITLE
Fix broken links in freesewing.dev

### DIFF
--- a/markdown/dev/tutorials/pattern-design/part2/constructing-the-neck-opening/en.md
+++ b/markdown/dev/tutorials/pattern-design/part2/constructing-the-neck-opening/en.md
@@ -157,7 +157,7 @@ paths.quarterNeck = new Path()
 - We're following up with a `Path.move()` call that takes one Point as argument
 - Then, there's a `Path.curve()` call that takes 3 points as arguments
 
-If you've read through the high-level [Pattern guide](/guides/patterns) you
+If you've read through the high-level [Design guide](/guides/designs) you
 will have learned that paths always start with a `move()` operation. In this
 case, we moved to our `right` points.
 

--- a/markdown/dev/tutorials/pattern-design/part3/conclusion/en.md
+++ b/markdown/dev/tutorials/pattern-design/part3/conclusion/en.md
@@ -8,12 +8,12 @@ rather simple, we have learned a bunch of things along the way.
 
 ## More reading material
 
-- If you haven't done so already, read through [the pattern
-  guide](/guides/patterns/) which provides a good overview of how patterns work
+- If you haven't done so already, read through [the design
+  guide](/guides/designs/) which provides a good overview of how designs work
   under the hood
 - Bookmark [the FreeSewing API docs](/reference/api/), they are your reference
   every time you're not entirely certain how something works
-- Have a look at [the design guide](/guides/best-practices/) for best practices
+- Have a look at [the pattern design best practices](/guides/best-practices/) for best practices
   that will help you make the best possible patterns
 
 ## What to do next

--- a/sites/dev/pages/404.mjs
+++ b/sites/dev/pages/404.mjs
@@ -29,8 +29,8 @@ const Page404 = () => (
               <h5>Did you arrive here from a link?</h5>
               <p>In that case, that link is broken.</p>
               <p>
-                If it was one of our links, please <PageLink href="/contact" txt="let us know" /> so
-                we can fix it.
+                If it was one of our links, please{' '}
+                <PageLink href="/howtos/help" txt="let us know" /> so we can fix it.
               </p>
             </Popout>
           </div>


### PR DESCRIPTION
Closes #6887 and fixes other related problems discovered at the same time.

For the 404 page, I chose the simple [help page](https://freesewing.dev/howtos/help), since if references both Discord and GitHub issues. I don't think it matters too much, so long as it points to something other than another 404 :sweat_smile: 