### PR TITLE
fix(core): Fix typo in path.clean() method

### DIFF
--- a/packages/core/src/path.mjs
+++ b/packages/core/src/path.mjs
@@ -219,7 +219,7 @@ Path.prototype.clean = function () {
       if (!op.to.sitsRoughlyOn(cur)) ops.push(op)
     } else if (op.type === 'curve') {
       if (!(op.cp1.sitsRoughlyOn(cur) && op.cp2.sitsRoughlyOn(cur) && op.to.sitsRoughlyOn(cur)))
-        ops.push(ops)
+        ops.push(op)
     }
     cur = op.to
   }


### PR DESCRIPTION
Path.clean() does weird things on paths with curves. Found while messing with Bibi design.