### PR TITLE
Fix user profile links

### DIFF
--- a/markdown/org/docs/about/faq/womenswear-blocks/en.md
+++ b/markdown/org/docs/about/faq/womenswear-blocks/en.md
@@ -9,7 +9,7 @@ _why even publish this garbage, it doesn't work at all_.
 Let me start by saying that you are not wrong. Both [Breanna](/designs/breanna/)
 and [Bella](/designs/bella/) have serious shortcomings.
 
-I myself ([joost](/makers/joostdecock/)) am painfully aware of them,
+I myself ([joost](/users/user?id=1)) am painfully aware of them,
 and I have toyed with the idea of retracting these patterns altogether.
 
 But there's a subset of people who get good results with them.

--- a/sites/org/pages/profile.mjs
+++ b/sites/org/pages/profile.mjs
@@ -40,7 +40,7 @@ const ProfilePage = ({ page }) => {
       <DynamicAuthWrapper>
         <DynamicAccountProfile />
         <Popout link compact>
-          <PageLink href={`/users/${account.username}`} txt={`/users/${account.username}`} />
+          <PageLink href={`/users/user?id=${account.id}`} txt={`/users/user?id=${account.id}`} />
         </Popout>
       </DynamicAuthWrapper>
       <BackToAccountButton />

--- a/sites/shared/components/mdx/meta.mjs
+++ b/sites/shared/components/mdx/meta.mjs
@@ -21,7 +21,7 @@ const PersonList = ({ list }) =>
       {list.map((id) => (
         <li key={id}>
           {allAuthors[id] ? (
-            <PageLink href={`/users/${allAuthors[id].id}`} txt={allAuthors[id].name} />
+            <PageLink href={`/users/user?id=${allAuthors[id].id}`} txt={allAuthors[id].name} />
           ) : (
             <span className="font-medium">{id}</span>
           )}

--- a/sites/shared/components/support/support.mjs
+++ b/sites/shared/components/support/support.mjs
@@ -48,7 +48,7 @@ const types = [
 ]
 
 export const userCard = (id) =>
-  `[![User ${id}](${config.backend}/users/${id}/card)](https://next.freesewing.org/users/${id})`
+  `[![User ${id}](${config.backend}/users/${id}/card)](https://freesewing.org/users/user?id=${id})`
 
 const templates = {
   bugReport: {


### PR DESCRIPTION
Closes #6990

Fixes old-style user profile links to align with the new way things work. See the issue for more details.