### PR TITLE
fix(charlie): adjust messages, so they match the expanded parts

### DIFF
--- a/designs/charlie/src/beltloops.mjs
+++ b/designs/charlie/src/beltloops.mjs
@@ -25,7 +25,7 @@ function draftCharlieBeltLoops({
       msg: `charlie:cutBeltloops`,
       notes: ['flag:saUnused', 'flag:partHiddenByExpand'],
       replace: {
-        count: 7,
+        count: count,
         width: units(width * 4),
         length: units(length / count),
       },

--- a/designs/charlie/src/waistband.mjs
+++ b/designs/charlie/src/waistband.mjs
@@ -33,7 +33,7 @@ function draftCharlieWaistband({
       msg: `charlie:cutWaistband`,
       notes: [sa ? 'flag:saIncluded' : 'flag:saExcluded', 'flag:partHiddenByExpand'],
       replace: {
-        width: units(2 * absoluteOptions.waistbandWidth + extraSa),
+        width: units(2 * absoluteOptions.waistbandWidth + extraSa * 1.5),
         length: units(
           2 * store.get('waistbandBack') +
             2 * store.get('waistbandFront') +


### PR DESCRIPTION
Cut count of belt loops was hardcoded to 7, when it should follow the option (which defaults to 8, anyway)

Waistband has double seam allowance on the left side, so for the final width the extra width is `1.5 * extraSa`