### PR TITLE
Add/measurement validation

### DIFF
--- a/sites/shared/components/account/en.yaml
+++ b/sites/shared/components/account/en.yaml
@@ -363,6 +363,6 @@ validateMeasurements: Check Measurements
 backChest.t: Back Chest Measurement
 backChest.d: Both calculations should measure the back half of your ribcage and should thus be roughly equal.
 bustFront.t: Front Bust measurements
-bustFront.d: Measuring from the HPS point to the waist across your front should be equal or smaller than the sum of the individual vertical bust measurements.
+bustFront.d: Measuring from the HPS point directly to the waist across your front can't be larger than the sum of the individual vertical bust measurements. However note that waist to underbust is measured at the side of the body instead of at the front, but usually this doesn't make a large difference.
 waistToUpperLeg.t: Vertical leg measurements
-waistToUpperLeg.d: The waist-to-upper-leg measurement goes from the waist along the body to a bit below the crotch and the inseam measurement goes vertically from the crotch to the floor. Thus, going directly vertically from the waist to the floor should be a bit smaller than the sum.
+waistToUpperLeg.d: The waist-to-upper-leg measurement goes from the waist along the body to a bit below the crotch and the inseam measurement goes vertically from the crotch to the floor. Thus, going directly vertically from the waist to the floor should be a bit smaller than the sum of the other measurements.

--- a/sites/shared/components/account/en.yaml
+++ b/sites/shared/components/account/en.yaml
@@ -353,3 +353,16 @@ importSetTip2: Your file can either contain a single measurements set, or an arr
 importing: Importing
 imported: Imported
 importFailed: Import failed
+
+# validation
+shouldBeLarger: "{ lhs } should be larger than { rhs }."
+shouldBeEqual: "{ lhsConstraint } (= { lhsSum }) should be approximately equal to { rhsConstraint } (= { rhsSum })."
+shouldBeSlightlySmaller: "{ lhsConstraint } (= { lhsSum }) should be approximately equal to or smaller than { rhsConstraint } (= { rhsSum })."
+validationSuccess: No problems were found.
+validateMeasurements: Check Measurements
+backChest.t: Back Chest Measurement
+backChest.d: Both calculations should measure the back half of your ribcage and should thus be roughly equal.
+bustFront.t: Front Bust measurements
+bustFront.d: Measuring from the HPS point to the waist across your front should be equal or smaller than the sum of the individual vertical bust measurements.
+waistToUpperLeg.t: Vertical leg measurements
+waistToUpperLeg.d: The waist-to-upper-leg measurement goes from the waist along the body to a bit below the crotch and the inseam measurement goes vertically from the crotch to the floor. Thus, going directly vertically from the waist to the floor should be a bit smaller than the sum.

--- a/sites/shared/components/account/msetvalidation.mjs
+++ b/sites/shared/components/account/msetvalidation.mjs
@@ -1,0 +1,154 @@
+//  __SDEFILE__ - This file is a dependency for the stand-alone environment
+import { formatMm } from '../../utils.mjs'
+
+const descendingCheck = [
+  ['hpsToWaistFront', 'hpsToBust'],
+  ['hpsToWaistFront', 'waistToUnderbust'],
+  ['shoulderToWrist', 'shoulderToElbow'],
+  ['waistToFloor', 'waistToKnee', 'waistToUpperLeg', 'waistToSeat', 'waistToHips'],
+  ['waistToFloor', 'inseam'],
+  ['crossSeam', 'crossSeamFront'],
+  ['seat', 'seatBack'],
+  ['highBust', 'highBustFront'],
+  ['chest', 'bustFront', 'bustSpan'],
+  ['waist', 'waistBack'],
+]
+
+const constraintCheck = [
+  {
+    lhs: [
+      { m: 'highBust', coefficient: 1 },
+      { m: 'highBustFront', coefficient: -1 },
+    ],
+    rhs: [
+      { m: 'chest', coefficient: 1 },
+      { m: 'bustFront', coefficient: -1 },
+    ],
+    tolerance: 0.05,
+    key: 'backChest',
+  },
+  {
+    lhs: [{ m: 'hpsToWaistFront', coefficient: 1 }],
+    rhs: [
+      { m: 'hpsToBust', coefficient: 1 },
+      { m: 'bustPointToUnderbust', coefficient: 1 },
+      { m: 'waistToUnderbust', coefficient: 1 },
+    ],
+    lhsMustBeSmaller: true,
+    tolerance: 0.1,
+    key: 'bustFront',
+  },
+  {
+    lhs: [{ m: 'waistToFloor', coefficient: 1 }],
+    rhs: [
+      { m: 'waistToUpperLeg', coefficient: 1 },
+      { m: 'inseam', coefficient: 1 },
+    ],
+    tolerance: 0.1,
+    lhsMustBeSmaller: true,
+    key: 'waistToUpperLeg',
+  },
+]
+
+function checkDescendingSet(t, set, warnings, measies) {
+  let biggerValue = null
+  let biggerMeasurement = null
+  for (const measurement of set) {
+    let value = measies[measurement]
+    if (value !== null) {
+      if (biggerValue !== null && value >= biggerValue) {
+        warnings.push(t('shouldBeLarger', { lhs: t(biggerMeasurement), rhs: t(measurement) }))
+      } else {
+        biggerValue = value
+        biggerMeasurement = measurement
+      }
+    }
+  }
+}
+
+function formatSum(t, params) {
+  let result = ''
+  for (const e of params) {
+    let prefix = ' + '
+    if (e.coefficient === -1) {
+      prefix = ' - '
+    } else if (e.coefficient !== 1 && e.coefficient > 0) {
+      prefix = ' + ' + e.coefficient + '×'
+    } else if (e.coefficient !== 1 && e.coefficient < 0) {
+      prefix = ' - ' + -e.coefficient + '×'
+    }
+    result += prefix + t(e.m)
+  }
+  return result.replaceAll(/^ \+ /g, '').trim()
+}
+
+function sumMeasurements(params, measies) {
+  let result = 0
+  for (const e of params) {
+    if (!measies[e.m]) {
+      return false
+    }
+    result += e.coefficient * measies[e.m]
+  }
+  return result
+}
+
+function formatWarningMessage(t, constraint, lhsSum, rhsSum, imperial) {
+  let leftConstraint = formatSum(t, constraint.lhs)
+  let rightConstraint = formatSum(t, constraint.rhs)
+
+  return (
+    t(constraint.key + '.t') +
+    ': ' +
+    t(constraint.lhsMustBeSmaller ? 'shouldBeSlightlySmaller' : 'shouldBeEqual', {
+      lhsSum: formatMm(lhsSum, imperial),
+      lhsConstraint: leftConstraint,
+      rhsSum: formatMm(rhsSum, imperial),
+      rhsConstraint: rightConstraint,
+    }) +
+    ' ' +
+    t(constraint.key + '.d')
+  )
+}
+
+function checkConstraint(t, constraint, warnings, measies, imperial) {
+  let lhsSum = sumMeasurements(constraint.lhs, measies)
+  let rhsSum = sumMeasurements(constraint.rhs, measies)
+  if (lhsSum === false || rhsSum === false) {
+    // Some measurements are missing
+    return
+  }
+  const difference = Math.abs(((lhsSum - rhsSum) / (lhsSum + rhsSum)) * 2)
+  if (difference <= constraint.tolerance) {
+    // minor difference
+    return
+  }
+  if (constraint.lhsMustBeSmaller) {
+    if (lhsSum > rhsSum) {
+      warnings.push(formatWarningMessage(t, constraint, lhsSum, rhsSum, imperial))
+    }
+  } else {
+    warnings.push(formatWarningMessage(t, constraint, lhsSum, rhsSum, imperial))
+  }
+}
+
+function checkDescendingSets(t, warnings, measies) {
+  for (const e of descendingCheck) {
+    checkDescendingSet(t, e, warnings, measies)
+  }
+}
+function checkConstraints(t, warnings, measies, imperial) {
+  for (const e of constraintCheck) {
+    checkConstraint(t, e, warnings, measies, imperial)
+  }
+}
+
+export function validateMset(t, measies, imperial) {
+  const warnings = []
+  checkDescendingSets(t, warnings, measies)
+  checkConstraints(t, warnings, measies, imperial)
+  if (warnings.length === 0) {
+    warnings.push(t('validationSuccess'))
+  }
+  return warnings
+}

--- a/sites/shared/components/account/msetvalidation.mjs
+++ b/sites/shared/components/account/msetvalidation.mjs
@@ -4,6 +4,8 @@ import { formatMm } from '../../utils.mjs'
 const descendingCheck = [
   ['hpsToWaistFront', 'hpsToBust'],
   ['hpsToWaistFront', 'waistToUnderbust'],
+  ['hpsToWaistFront', 'waistToArmpit'],
+  ['hpsToWaistBack', 'waistToArmpit'],
   ['shoulderToWrist', 'shoulderToElbow'],
   ['waistToFloor', 'waistToKnee', 'waistToUpperLeg', 'waistToSeat', 'waistToHips'],
   ['waistToFloor', 'inseam'],
@@ -47,6 +49,26 @@ const constraintCheck = [
     tolerance: 0.1,
     lhsMustBeSmaller: true,
     key: 'waistToUpperLeg',
+  },
+  {
+    lhs: [{ m: 'waist', coefficient: 1 }],
+    rhs: [{ m: 'waistBack', coefficient: 2 }],
+    tolerance: 0.1,
+    lhsMustBeSmaller: true,
+    key: 'waistBack',
+  },
+  {
+    lhs: [{ m: 'chest', coefficient: 1 }],
+    rhs: [{ m: 'bustFront', coefficient: 2 }],
+    tolerance: 0.1,
+    lhsMustBeSmaller: true,
+    key: 'bustFront',
+  },
+  {
+    lhs: [{ m: 'highBust', coefficient: 1 }],
+    rhs: [{ m: 'highBustFront', coefficient: 2 }],
+    tolerance: 0.1,
+    key: 'highBustFront',
   },
 ]
 

--- a/sites/shared/components/account/sets.mjs
+++ b/sites/shared/components/account/sets.mjs
@@ -41,6 +41,7 @@ import {
   BoolYesIcon,
   BoolNoIcon,
   CloneIcon,
+  DetailIcon,
 } from 'shared/components/icons.mjs'
 import { ModalWrapper } from 'shared/components/wrappers/modal.mjs'
 import { Mdx } from 'shared/components/mdx/dynamic.mjs'
@@ -58,6 +59,7 @@ import {
 } from 'shared/components/inputs.mjs'
 import { BookmarkButton } from 'shared/components/bookmarks.mjs'
 import { DynamicMdx } from 'shared/components/mdx/dynamic.mjs'
+import { validateMset } from './msetvalidation.mjs'
 
 export const ns = [inputNs, 'account', 'patterns', 'status', 'measurements', 'sets']
 
@@ -324,6 +326,11 @@ export const Mset = ({ id, publicOnly = false }) => {
     } else setLoadingStatus([true, 'backendError', true, false])
   }
 
+  const validateMeasurements = (measies) => {
+    alert(validateMset(t, measies).join('\n\n'))
+    return true
+  }
+
   const importSet = async () => {
     setLoadingStatus([true, t('account.importing')])
     // Compile data
@@ -471,6 +478,14 @@ export const Mset = ({ id, publicOnly = false }) => {
               )}
             </>
           )}
+          {!edit ? (
+            <button onClick={() => validateMeasurements(measies)} className="btn btn-secondary">
+              <div className="flex flex-row gap-4 justify-between items-center w-full">
+                <DetailIcon />
+                {t('validateMeasurements')}
+              </div>
+            </button>
+          ) : null}
           {account.control > 2 && mset.userId === account.id ? (
             <button className="btn btn-neutral" title={t('account:cloneSet')} onClick={importSet}>
               <div className="flex flex-row gap-4 justify-between items-center w-full">
@@ -742,13 +757,19 @@ export const Mset = ({ id, publicOnly = false }) => {
           docs={docs.notes}
         />
       ) : null}
-      <button
-        onClick={save}
-        className="btn btn-primary btn-lg flex flex-row items-center gap-4 mx-auto mt-8"
-      >
-        <UploadIcon />
-        {t('saveThing', { thing: t('account:set') })}
-      </button>
+      <div className="flex flex-row justify-center gap-4 mt-8">
+        <button onClick={save} className="btn btn-primary btn-lg flex flex-row items-center gap-4">
+          <UploadIcon />
+          {t('saveThing', { thing: t('account:set') })}
+        </button>
+        <button
+          onClick={() => validateMeasurements(measies)}
+          className="btn btn-secondary btn-lg flex flex-row items-center gap-4"
+        >
+          <DetailIcon />
+          {t('validateMeasurements')}
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
WIP.

Example messages:

```
Chest circumference should be larger than Bust front.

Back Chest Measurement: High bust - High bust front (= 61.4cm) should be approximately equal to Chest circumference - Bust front (= 64.6cm). Both calculations should measure the back half of your ribcage and should thus be roughly equal.

Front Bust measurements: HPS to waist front (= 47.6cm) should be smaller than HPS to bust + Bust point to underbust + Waist to underbust (= 53.8cm). Measuring from the HPS point to the waist across your front should be equal or smaller (due to e.g. skin folds) than the sum of the individual vertical bust measurements.

Vertical leg measurements: Waist to floor (= 117.4cm) should be smaller than Waist to upper leg + Inseam (= 116cm). The waist-to-upper-leg measurement goes from the waist along the body to a bit below the crotch and the inseam measurement goes vertically from the crotch to the floor. Thus, going directly vertically from the waist to the floor should be a bit smaller than the sum.
```

Fixes #6576