### PR TITLE
fix(docs): Backend API keys read v3 update

### DIFF
--- a/markdown/dev/reference/backend/apikeys/read/en.md
+++ b/markdown/dev/reference/backend/apikeys/read/en.md
@@ -7,7 +7,7 @@ the moment the API key is created.
 
 ## Access control
 
-- [Permission level](/reference/backend/rbac) `4` or higher is required to read an API key
+- [Permission level](/reference/backend/rbac) `1` or higher is required to read an API key
 
 ## Endpoints
 
@@ -20,7 +20,7 @@ Reading an API key is possible via these endpoints:
 
 ## Request URL
 
-The URL should contain the ID of the API key you wish to remove.
+The URL should contain the ID of the API key you wish to read.
 It replaces the `:id` placeholder in the [endpoints listed above](#endpoints).
 
 ## Response status codes
@@ -30,11 +30,8 @@ Possible status codes for these endpoints are:
 | Status code | Description |
 | ----------: | :---------- |
 | <StatusCode status="200"/> | success |
-| <StatusCode status="400"/> | the request was malformed |
-| <StatusCode status="401"/> | the request lacks authentication |
-| <StatusCode status="403"/> | authentication failed |
+| <StatusCode status="403"/> | insuffcient access level |
 | <StatusCode status="404"/> | API key not found |
-| <StatusCode status="500"/> | server error |
 
 <Note>
 If the status code is not <StatusCode status="200" /> the `error` property
@@ -49,6 +46,7 @@ in the response body should indicate the nature of the problem.
 | `error`             | `string` | Will give info on the nature of the error. Only set if an error occurred. |
 | `apikey.key`        | `string` | The API key |
 | `apikey.level`      | `number` | The privilege level of the API key |
+| `apikey.createdAt`  | `string` | A string representation of the moment the API key was created |
 | `apikey.expiresAt`  | `string` | A string representation of the moment the API key expires |
 | `apikey.name`       | `string` | The name of the API key |
 | `apikey.userId`     | `number` | The ID of the user who created the API key |
@@ -73,6 +71,7 @@ const keyInfo = await axios.get(
   "apikey": {
     "key": "7ea12968-7758-40b6-8c73-75cc99be762b",
     "level": 3,
+    "createdAt": "2022-11-06T15:57:30.190Z",
     "expiresAt": "2022-11-06T15:57:30.190Z",
     "name": "My first API key",
     "userId": 61

--- a/sites/backend/openapi/apikeys.mjs
+++ b/sites/backend/openapi/apikeys.mjs
@@ -148,15 +148,12 @@ paths['/apikeys/{key}/{auth}'] = {
           apikey: local.response.body.regular,
         }),
       },
-      401: response.status['401'],
       403: {
         ...response.status['403'],
         description:
-          response.status['403'].description +
-          errorExamples(['accountStatusLacking', 'insufficientAccessLevel']),
+          response.status['403'].description + errorExamples(['insufficientAccessLevel']),
       },
       404: response.status['404'],
-      500: response.status['500'],
     },
   },
   // Remove API key


### PR DESCRIPTION
Based on what I see in `sites/backend/src/models/apikeys.mjs`.