### PR TITLE
fix(paco): Use more accurate flap position

### DIFF
--- a/designs/paco/src/front.mjs
+++ b/designs/paco/src/front.mjs
@@ -126,8 +126,15 @@ function pacoFront({
       absoluteOptions.frontPocketFlapSize
     )
 
-    points.flapTopLeft = points.pocketFlapTopOut.flipX(points.pocketFlapTopIn)
-    points.flapBottomLeft = points.pocketFlapBottomOut.flipX(points.pocketFlapBottomIn)
+    points.flapTopLeft = points.pocketFlapTopOut.shiftTowards(
+      points.pocketFlapTopIn,
+      absoluteOptions.frontPocketFlapSize * 2
+    )
+    points.flapBottomLeft = points.pocketFlapBottomOut.translate(
+      points.pocketFlapTopOut.dx(points.flapTopLeft),
+      points.pocketFlapTopOut.dy(points.flapTopLeft)
+    )
+
     points.topLeft = utils.beamsIntersect(
       points.flapBottomLeft,
       points.flapTopLeft,


### PR DESCRIPTION
The flap position can be calculated more accurately by flipping the flap around the outseam line instead of mirroring it on the y-axis.

Before: 
![Bildschirmfoto vom 2024-08-27 19-54-32](https://github.com/user-attachments/assets/a198d9ad-6842-407b-9051-377c64a4cdba)

After:
![Bildschirmfoto vom 2024-08-27 19-54-19](https://github.com/user-attachments/assets/0ee6d4e4-9110-40de-b0d4-49454487e752)
