### PR TITLE
fix(docs): Update tutorials with new stand-alone environment instructions

### DIFF
--- a/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
@@ -149,9 +149,9 @@ environment](/tutorials/getting-started-linux/dev-start).
 
 - Select a new folder name to create a new installation
 - Select a folder name containing an existing installation to:
-  - `Overwrite` the installation with an entirely new installation
-  - `Re-initialize` the installation by re-installing dependencies and re-dowloading files
-  - `Re-download` files in the installation
+  - `Overwrite` the installation with an entirely new installation;
+  - `Re-initialize` the installation by re-installing dependencies and re-dowloading files; or
+  - `Re-download` files in the installation.
 
 #### What package manager to use
 

--- a/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/dev-setup/en.md
@@ -141,27 +141,17 @@ environment inside.
 Now you're ready to [start the development
 environment](/tutorials/getting-started-linux/dev-start).
 
-<Tip compact>The folder will have the name you chose above.</Tip>
-
 <Note>
 
 ### Questions
 
-#### What template to use
+#### What folder name to use
 
-Use `From scratch` unless you want to start from our of our blocks:
-
-- Use `Extend Brian` to start from [Brian](https://freesewing.org/designs/brian)
-- Use `Extend Bent` to start from [Bent](https://freesewing.org/designs/bent)
-- Use `Extend Bella` to start from [Bella](https://freesewing.org/designs/bella)
-- Use `Extend Breanna` to start from [Breanna](https://freesewing.org/designs/breanna)
-- Use `Extend Titan` to start from [Titan](https://freesewing.org/designs/titan)
-
-#### What name to use
-
-This will become the name of your design. Stick to \[a-z] here to avoid problems.
-
-If you're not certain what to pick, just mash some keys, it doesn't matter.
+- Select a new folder name to create a new installation
+- Select a folder name containing an existing installation to:
+  - `Overwrite` the installation with an entirely new installation
+  - `Re-initialize` the installation by re-installing dependencies and re-dowloading files
+  - `Re-download` files in the installation
 
 #### What package manager to use
 

--- a/markdown/dev/tutorials/getting-started-linux/dev-start/en.md
+++ b/markdown/dev/tutorials/getting-started-linux/dev-start/en.md
@@ -33,12 +33,6 @@ Just make sure to re-start the lab afterwards with `yarn lab`
 
 ## Stand-alone development
 
-You will have a new folder that has the name you picked for your design.
-If you chose `test`, you will have a folder named `test`.
-If you chose `banana`, you'll have a folder named `banana`.
-(Within this new folder, the `design` subfolder holds your design's configuration file and source code.
-You can ignore all other subfolders and files; they are part of the development environment.)
-
 To start the development environment, enter the folder that was created
 and run `yarn dev` (or `npm run dev` if you're using npm as a package manager).
 

--- a/markdown/dev/tutorials/getting-started-mac/dev-setup/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/dev-setup/en.md
@@ -134,9 +134,9 @@ environment](/tutorials/getting-started-linux/dev-start).
 
 - Select a new folder name to create a new installation
 - Select a folder name containing an existing installation to:
-  - `Overwrite` the installation with an entirely new installation
-  - `Re-initialize` the installation by re-installing dependencies and re-dowloading files
-  - `Re-download` files in the installation
+  - `Overwrite` the installation with an entirely new installation;
+  - `Re-initialize` the installation by re-installing dependencies and re-dowloading files; or
+  - `Re-download` files in the installation.
 
 #### What package manager to use
 

--- a/markdown/dev/tutorials/getting-started-mac/dev-setup/en.md
+++ b/markdown/dev/tutorials/getting-started-mac/dev-setup/en.md
@@ -126,27 +126,17 @@ environment inside.
 Now you're ready to [start the development
 environment](/tutorials/getting-started-linux/dev-start).
 
-<Tip compact>The folder will have the name you chose above.</Tip>
-
 <Note>
 
 ### Questions
 
-#### What template to use
+#### What folder name to use
 
-Use `From scratch` unless you want to start from our of our blocks:
-
-- Use `Extend Brian` to start from [Brian](https://freesewing.org/designs/brian)
-- Use `Extend Bent` to start from [Bent](https://freesewing.org/designs/bent)
-- Use `Extend Bella` to start from [Bella](https://freesewing.org/designs/bella)
-- Use `Extend Breanna` to start from [Breanna](https://freesewing.org/designs/breanna)
-- Use `Extend Titan` to start from [Titan](https://freesewing.org/designs/titan)
-
-#### What name to use
-
-This will become the name of your design. Stick to \[a-z] here to avoid problems.
-
-If you're not certain what to pick, just mash some keys, it doesn't matter.
+- Select a new folder name to create a new installation
+- Select a folder name containing an existing installation to:
+  - `Overwrite` the installation with an entirely new installation
+  - `Re-initialize` the installation by re-installing dependencies and re-dowloading files
+  - `Re-download` files in the installation
 
 #### What package manager to use
 

--- a/markdown/dev/tutorials/getting-started-windows/en.md
+++ b/markdown/dev/tutorials/getting-started-windows/en.md
@@ -172,9 +172,9 @@ When it's done, you will have a new folder with the development environment insi
 
 - Select a new folder name to create a new installation
 - Select a folder name containing an existing installation to:
-  - `Overwrite` the installation with an entirely new installation
-  - `Re-initialize` the installation by re-installing dependencies and re-dowloading files
-  - `Re-download` files in the installation
+  - `Overwrite` the installation with an entirely new installation;
+  - `Re-initialize` the installation by re-installing dependencies and re-dowloading files; or
+  - `Re-download` files in the installation.
 
 #### What package manager to use
 

--- a/markdown/dev/tutorials/getting-started-windows/en.md
+++ b/markdown/dev/tutorials/getting-started-windows/en.md
@@ -165,26 +165,16 @@ In VSCode or in a terminal, navigate to the folder you wish to contain your new 
 After you've answered [some questions](#questions), it will take a while to set everything up.
 When it's done, you will have a new folder with the development environment inside.
 
-<Tip compact>The folder will have the name you chose above.</Tip>
-
 <Note>
 ### Questions
 
-#### What template to use
+#### What folder name to use
 
-Use `From scratch` unless you want to start from our of our blocks:
-
-- Use `Extend Brian` to start from [Brian](https://freesewing.org/designs/brian)
-- Use `Extend Bent` to start from [Bent](https://freesewing.org/designs/bent)
-- Use `Extend Bella` to start from [Bella](https://freesewing.org/designs/bella)
-- Use `Extend Breanna` to start from [Breanna](https://freesewing.org/designs/breanna)
-- Use `Extend Titan` to start from [Titan](https://freesewing.org/designs/titan)
-
-#### What name to use
-
-This will become the name of your design. Stick to \[a-z] here to avoid problems.
-
-If you're not certain what to pick, just mash some keys, it doesn't matter.
+- Select a new folder name to create a new installation
+- Select a folder name containing an existing installation to:
+  - `Overwrite` the installation with an entirely new installation
+  - `Re-initialize` the installation by re-installing dependencies and re-dowloading files
+  - `Re-download` files in the installation
 
 #### What package manager to use
 
@@ -197,12 +187,6 @@ You can choose either `yarn` or `npm` as you wish.
 </Note>
 
 ## Start the development environment
-
-You will have a new folder that has the name you picked for your design.
-If you chose `test`, you will have a folder named `test`.
-If you chose `banana`, you'll have a folder named `banana`.
-(Within this new folder, the `design` subfolder holds your design's configuration file and source code.
-You can ignore all other subfolders and files; they are part of the development environment.)
 
 To start the development environment, navigate to the folder that was created
 and run `yarn dev` (or `npm run dev` if you're using npm as a package manager).

--- a/markdown/dev/tutorials/pattern-design/part1/new-design/en.md
+++ b/markdown/dev/tutorials/pattern-design/part1/new-design/en.md
@@ -14,12 +14,11 @@ To set it up, I will open a terminal and enter the following command:
 npx @freesewing/new-design
 ```
 
-It will ask if it is ok to install the development environment in a new folder
-named `freesewing`. You can accept the default, or pick a different folder name
-if you prefer.
+It will ask what folder name to create and install the development
+environment into.
 
-It will also ask what package manager you would like to use. 
-Here too the default (`npm`) is fine., unless you are certain you have **yarn** installed.
+It will also ask what package manager you would like to use.
+Here too the default (`npm`) is fine, unless you are certain you have `yarn` installed.
 
 After answering these questions, files will be downloaded, dependencies installed,
 and it will also initialize a git repository for you (if you have git on your system).
@@ -31,7 +30,7 @@ of dependencies that need to be downloaded.
 
 </Note>
 
-When it's ready, you can enter the `freesewing` directory that was just created and run `npm run dev`:
+When it's ready, you can enter the directory that was just created and run `npm run dev`:
 
 ```sh
 cd freesewing


### PR DESCRIPTION
The `npx @freesewing/new-design` process was changed so it no longer asks what design name and template to use. This PR changes the tutorials to reflect the new process.