### PR TITLE
fix(backend): 404 errors do not use a result string

### DIFF
--- a/sites/backend/src/controllers/apikeys.mjs
+++ b/sites/backend/src/controllers/apikeys.mjs
@@ -27,7 +27,7 @@ ApikeysController.prototype.list = async (req, res, tools) => {
   const apikeys = await Apikey.userApikeys(req.user.uid)
 
   if (apikeys) Apikey.setResponse(200, 'success', { apikeys })
-  else Apikey.setResponse(404, 'notFound')
+  else Apikey.setResponse(404)
 
   return Apikey.sendResponse(res)
 }
@@ -71,7 +71,7 @@ ApikeysController.prototype.whoami = async (req, res, tools) => {
         userId: key[0].userId,
       },
     })
-  else Apikey.setResponse(404, 'notFound')
+  else Apikey.setResponse(404)
 
   return Apikey.sendResponse(res)
 }

--- a/sites/backend/src/controllers/bookmarks.mjs
+++ b/sites/backend/src/controllers/bookmarks.mjs
@@ -33,7 +33,7 @@ BookmarksController.prototype.list = async (req, res, tools) => {
   const bookmarks = await Bookmark.userBookmarks(req.user.uid)
 
   if (bookmarks) Bookmark.setResponse(200, 'success', { bookmarks })
-  else Bookmark.setResponse(404, 'notFound')
+  else Bookmark.setResponse(404)
 
   return Bookmark.sendResponse(res)
 }

--- a/sites/backend/src/controllers/curated-sets.mjs
+++ b/sites/backend/src/controllers/curated-sets.mjs
@@ -36,7 +36,7 @@ CuratedSetsController.prototype.list = async (req, res, tools, format = false) =
   if (curatedSets) {
     if (!format) CuratedSet.setResponse(200, 'success', { curatedSets })
     else CuratedSet.setResponse(200, 'success', curatedSets, true)
-  } else CuratedSet.setResponse(404, 'notFound')
+  } else CuratedSet.setResponse(404)
 
   return format === 'yaml' && curatedSets
     ? CuratedSet.sendYamlResponse(res)

--- a/sites/backend/src/controllers/option-packs.mjs
+++ b/sites/backend/src/controllers/option-packs.mjs
@@ -35,7 +35,7 @@ OptionPacksController.prototype.list = async (req, res, tools, format = false) =
   if (optionPacks) {
     if (!format) OptionPack.setResponse(200, 'success', { optionPacks })
     else OptionPack.setResponse(200, 'success', optionPacks, true)
-  } else OptionPack.setResponse(404, 'notFound')
+  } else OptionPack.setResponse(404)
 
   return format === 'yaml' && optionPacks
     ? OptionPack.sendYamlResponse(res)

--- a/sites/backend/src/controllers/patterns.mjs
+++ b/sites/backend/src/controllers/patterns.mjs
@@ -11,7 +11,7 @@ PatternsController.prototype.list = async (req, res, tools) => {
   const patterns = await Pattern.userPatterns(req.user.uid)
 
   if (patterns) Pattern.setResponse(200, 'success', { patterns })
-  else Pattern.setResponse(404, 'notFound')
+  else Pattern.setResponse(404)
 
   return Pattern.sendResponse(res)
 }

--- a/sites/backend/src/controllers/sets.mjs
+++ b/sites/backend/src/controllers/sets.mjs
@@ -33,7 +33,7 @@ SetsController.prototype.list = async (req, res, tools) => {
   const sets = await Set.userSets(req.user.uid)
 
   if (sets) Set.setResponse(200, 'success', { sets })
-  else Set.setResponse(404, 'notFound')
+  else Set.setResponse(404)
 
   return Set.sendResponse(res)
 }

--- a/sites/backend/src/models/pattern.mjs
+++ b/sites/backend/src/models/pattern.mjs
@@ -182,7 +182,7 @@ PatternModel.prototype.guardedRead = async function ({ params, user }) {
   /*
    * Return 404 if it cannot be found
    */
-  if (!this.record) return this.setResponse(404, 'notFound')
+  if (!this.record) return this.setResponse(404)
 
   /*
    * You need at least the bughunter role to read another user's pattern

--- a/sites/backend/src/models/subscriber.mjs
+++ b/sites/backend/src/models/subscriber.mjs
@@ -240,7 +240,7 @@ SubscriberModel.prototype.verifySubscription = async function (body) {
   /*
    * If it is not found, return 404
    */
-  if (!this.record) return this.setResponse(404, 'subscriberNotFound')
+  if (!this.record) return this.setResponse(404)
 
   return this
 }


### PR DESCRIPTION
According to the code, no result string is used when the response code is 404:
https://github.com/freesewing/freesewing/blob/85214486b500f69c9b9b8417dc8af952c9bd0e07/sites/backend/src/utils/model-decorator.mjs#L241

So, including a result string when calling `setResponse()` does nothing. This PR removes the superfluous result string from `setResponse()` calls to avoid confusion.
