### PR TITLE
fix(backend,docs): Backend API keys whoami v3 update

### DIFF
--- a/markdown/dev/reference/backend/apikeys/whoami/en.md
+++ b/markdown/dev/reference/backend/apikeys/whoami/en.md
@@ -2,9 +2,9 @@
 title: Read the current API key
 ---
 
-Reads the current API key used to authenticate the request. 
+Reads the current API key used to authenticate the request.
 For obvious reasons, this endpoint is only available with API key authentication.
-However, there's an equivalent endpoint for JWT authentication.
+There is no equivalent endpoint for JWT authentication.
 
 ## Access control
 
@@ -23,10 +23,7 @@ Possible status codes for these endpoints are:
 | Status code | Description |
 | ----------: | :---------- |
 | <StatusCode status="200"/> | success |
-| <StatusCode status="400"/> | the request was malformed |
-| <StatusCode status="401"/> | the request lacks authentication |
-| <StatusCode status="403"/> | authentication failed |
-| <StatusCode status="500"/> | server error |
+| <StatusCode status="404"/> | API key not found |
 
 <Note>
 If the status code is not <StatusCode status="200" /> the `error` property
@@ -41,6 +38,7 @@ in the response body should indicate the nature of the problem.
 | `error`             | `string` | Will give info on the nature of the error. Only set if an error occurred. |
 | `apikey.key`        | `string` | The API key |
 | `apikey.level`      | `number` | The privilege level of the API key |
+| `apikey.createdAt`  | `string` | A string representation of the moment the API key was created |
 | `apikey.expiresAt`  | `string` | A string representation of the moment the API key expires |
 | `apikey.name`       | `string` | The name of the API key |
 | `apikey.userId`     | `number` | The ID of the user who created the API key |
@@ -66,6 +64,7 @@ const keyInfo = await axios.get(
   "apikey": {
     "key": "7ea12968-7758-40b6-8c73-75cc99be762b",
     "level": 3,
+    "createdAt": "2022-11-06T15:57:30.190Z",
     "expiresAt": "2022-11-06T15:57:30.190Z",
     "name": "My first API key",
     "userId": 61

--- a/markdown/dev/reference/backend/apikeys/whoami/en.md
+++ b/markdown/dev/reference/backend/apikeys/whoami/en.md
@@ -25,11 +25,6 @@ Possible status codes for these endpoints are:
 | <StatusCode status="200"/> | success |
 | <StatusCode status="404"/> | API key not found |
 
-<Note>
-If the status code is not <StatusCode status="200" /> the `error` property
-in the response body should indicate the nature of the problem.
-</Note>
-
 ## Response body
 
 | Value               | Type     | Description |

--- a/sites/backend/openapi/apikeys.mjs
+++ b/sites/backend/openapi/apikeys.mjs
@@ -189,12 +189,10 @@ paths['/whoami/key'] = {
     description:
       'Retrieves information about the API key that ' +
       'was used to authenticate the request.\n\n' +
-      '**Note:** _See `GET /whoami/jwt` for the JWT equivalent._',
+      '**Note:** _There is no JWT equivalent._',
     responses: {
       200: paths['/apikeys/{key}/{auth}'].get.responses['200'],
-      401: response.status['401'],
-      403: paths['/apikeys/{key}/{auth}'].get.responses['403'],
-      500: response.status['500'],
+      404: response.status['404'],
     },
   },
 }

--- a/sites/backend/src/controllers/apikeys.mjs
+++ b/sites/backend/src/controllers/apikeys.mjs
@@ -66,6 +66,7 @@ ApikeysController.prototype.whoami = async (req, res, tools) => {
       apikey: {
         key: key[0].id,
         level: key[0].level,
+        createdAt: key[0].createdAt,
         expiresAt: key[0].expiresAt,
         name: Apikey.decrypt(key[0].name),
         userId: key[0].userId,


### PR DESCRIPTION
This PR includes:
1. A fix to backend code to add the `createdAt` property to the retrieved whoami API key.
2. v3 doc update for API keys whoami.