### PR TITLE
fix(docs): Add plugin-bin-pack doc and update related docs

### DIFF
--- a/markdown/dev/reference/plugins/annotations/en.md
+++ b/markdown/dev/reference/plugins/annotations/en.md
@@ -86,13 +86,6 @@ The annotations plugin also provides store methods:
 
 ## Installation
 
-<Note>
-
-This plugin is part of [core-plugins](/reference/plugins/core), so there is no
-need to install it manually unless you want to forego loading of core plugins,
-yet still want to load this plugin.
-</Note>
-
 ```sh
 npm install @freesewing/plugin-annotations
 ```
@@ -104,6 +97,7 @@ npm install @freesewing/plugin-annotations
 This plugin is part of [core-plugins](/reference/plugins/core), so there is no
 need to load it manually unless you want to forego loading of core plugins,
 yet still want to load this plugin.
+
 </Note>
 
 Either [add it as a part plugin](/reference/api/part/config/plugins) in your
@@ -115,3 +109,8 @@ To import the plugin for use:
 import { plugin } from '@freesewing/plugin-annotations'
 ```
 
+## Notes
+
+This plugin is part of [core-plugins](/reference/plugins/core),
+so there is no need to load it manually unless you wish to forego
+loading of core plugins yet still want to load this plugin.

--- a/markdown/dev/reference/plugins/annotations/en.md
+++ b/markdown/dev/reference/plugins/annotations/en.md
@@ -92,14 +92,6 @@ npm install @freesewing/plugin-annotations
 
 ## Usage
 
-<Note>
-
-This plugin is part of [core-plugins](/reference/plugins/core), so there is no
-need to load it manually unless you want to forego loading of core plugins,
-yet still want to load this plugin.
-
-</Note>
-
 Either [add it as a part plugin](/reference/api/part/config/plugins) in your
 design, or [add it to a pattern instance with
 Pattern.use()](/reference/api/pattern/use).
@@ -111,6 +103,6 @@ import { plugin } from '@freesewing/plugin-annotations'
 
 ## Notes
 
-This plugin is part of [core-plugins](/reference/plugins/core),
-so there is no need to load it manually unless you wish to forego
+This plugin is part of the [core-plugins bundle](/reference/plugins/core),
+so there is no need to install or import it manually unless you wish to forego
 loading of core plugins yet still want to load this plugin.

--- a/markdown/dev/reference/plugins/bin-pack/en.md
+++ b/markdown/dev/reference/plugins/bin-pack/en.md
@@ -29,8 +29,8 @@ import { binpackPlugin } from '@freesewing/plugin-bin-pack'
 
 ## Notes
 
-This plugin is part of [core-plugins](/reference/plugins/core),
-so there is no need to load it manually unless you wish to forego
+This plugin is part of the [core-plugins bundle](/reference/plugins/core),
+so there is no need to install or import it manually unless you wish to forego
 loading of core plugins yet still want to load this plugin.
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-bin-pack

--- a/markdown/dev/reference/plugins/bin-pack/en.md
+++ b/markdown/dev/reference/plugins/bin-pack/en.md
@@ -1,0 +1,36 @@
+---
+title: plugin-bin-pack
+---
+
+Published as [@freesewing/plugin-bin-pack][1], this plugin provides
+an optimized [pack()](/reference/store-methods/pack) store method which
+automatically lays out pattern parts.
+
+## Installation
+
+```sh
+npm install @freesewing/plugin-bin-pack
+```
+
+## Usage
+
+Either [add it as a part plugins](/reference/api/part/config/plugins) in your
+design, or [add it to a pattern instance with
+Pattern.use()](/reference/api/pattern/use).
+
+To import the plugin for use:
+```js
+import { packPlugin } from '@freesewing/plugin-bin-pack'
+// or
+import { binPackPlugin } from '@freesewing/plugin-bin-pack'
+// or
+import { binpackPlugin } from '@freesewing/plugin-bin-pack'
+```
+
+## Notes
+
+This plugin is part of [core-plugins](/reference/plugins/core),
+so there is no need to load it manually unless you wish to forego
+loading of core plugins yet still want to load this plugin.
+
+[1]: https://www.npmjs.com/package/@freesewing/plugin-bin-pack

--- a/markdown/dev/reference/plugins/core/en.md
+++ b/markdown/dev/reference/plugins/core/en.md
@@ -10,7 +10,7 @@ Specifically, loading this plugin will have the same effect as loading these
 plugins individually:
 
 
-- [plugin-annotations](/reference/plugins/annotations)
+- [plugin-annotations](/reference/plugins/annotations) : A variety of snippets, macros, and store methods for annotating patterns
 - [plugin-measurements](/reference/plugins/measurements) : Make extra, calculated measurements available to your patterns
 - [plugin-mirror](/reference/plugins/mirror) : Mirror points and paths in your patterns
 - [plugin-round](/reference/plugins/round) : Create rounded corners in your patterns

--- a/markdown/dev/reference/plugins/measurements/en.md
+++ b/markdown/dev/reference/plugins/measurements/en.md
@@ -42,8 +42,8 @@ import { pluginMeasurements } from '@freesewing/plugin-measurements'
 
 ## Notes
 
-This plugin is part of [core-plugins](/reference/plugins/core),
-so there is no need to load it manually unless you wish to forego
+This plugin is part of the [core-plugins bundle](/reference/plugins/core),
+so there is no need to install or import it manually unless you wish to forego
 loading of core plugins yet still want to load this plugin.
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-measurements

--- a/markdown/dev/reference/plugins/measurements/en.md
+++ b/markdown/dev/reference/plugins/measurements/en.md
@@ -42,6 +42,8 @@ import { pluginMeasurements } from '@freesewing/plugin-measurements'
 
 ## Notes
 
-The measurements plugin is part of our [core-plugins bundle](/reference/plugins/core)
+This plugin is part of [core-plugins](/reference/plugins/core),
+so there is no need to load it manually unless you wish to forego
+loading of core plugins yet still want to load this plugin.
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-measurements

--- a/markdown/dev/reference/plugins/mirror/en.md
+++ b/markdown/dev/reference/plugins/mirror/en.md
@@ -27,8 +27,8 @@ import { pluginMirror } from '@freesewing/plugin-mirror'
 
 ## Notes
 
-This plugin is part of [core-plugins](/reference/plugins/core),
-so there is no need to load it manually unless you wish to forego
+This plugin is part of the [core-plugins bundle](/reference/plugins/core),
+so there is no need to install or import it manually unless you wish to forego
 loading of core plugins yet still want to load this plugin.
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-mirror

--- a/markdown/dev/reference/plugins/mirror/en.md
+++ b/markdown/dev/reference/plugins/mirror/en.md
@@ -27,6 +27,8 @@ import { pluginMirror } from '@freesewing/plugin-mirror'
 
 ## Notes
 
-The mirror plugin is part of our [core-plugins bundle](/reference/plugins/core)
+This plugin is part of [core-plugins](/reference/plugins/core),
+so there is no need to load it manually unless you wish to forego
+loading of core plugins yet still want to load this plugin.
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-mirror

--- a/markdown/dev/reference/plugins/round/en.md
+++ b/markdown/dev/reference/plugins/round/en.md
@@ -29,8 +29,8 @@ import { pluginRound } from '@freesewing/plugin-round'
 The `round` macro is intended for rounding 90° angles.
 It does not support rounding other angles/corners.
 
-This plugin is part of [core-plugins](/reference/plugins/core),
-so there is no need to load it manually unless you wish to forego
+This plugin is part of the [core-plugins bundle](/reference/plugins/core),
+so there is no need to install or import it manually unless you wish to forego
 loading of core plugins yet still want to load this plugin.
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-round

--- a/markdown/dev/reference/plugins/round/en.md
+++ b/markdown/dev/reference/plugins/round/en.md
@@ -29,6 +29,8 @@ import { pluginRound } from '@freesewing/plugin-round'
 The `round` macro is intended for rounding 90° angles.
 It does not support rounding other angles/corners.
 
-The round plugin is part of our [core-plugins bundle](/reference/plugins/core)
+This plugin is part of [core-plugins](/reference/plugins/core),
+so there is no need to load it manually unless you wish to forego
+loading of core plugins yet still want to load this plugin.
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-round

--- a/markdown/dev/reference/plugins/sprinkle/en.md
+++ b/markdown/dev/reference/plugins/sprinkle/en.md
@@ -28,8 +28,8 @@ import { pluginSprinkle } from '@freesewing/plugin-sprinkle'
 
 ## Notes
 
-This plugin is part of [core-plugins](/reference/plugins/core),
-so there is no need to load it manually unless you wish to forego
+This plugin is part of the [core-plugins bundle](/reference/plugins/core),
+so there is no need to install or import it manually unless you wish to forego
 loading of core plugins yet still want to load this plugin.
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-sprinkle

--- a/markdown/dev/reference/plugins/sprinkle/en.md
+++ b/markdown/dev/reference/plugins/sprinkle/en.md
@@ -28,6 +28,8 @@ import { pluginSprinkle } from '@freesewing/plugin-sprinkle'
 
 ## Notes
 
-The sprinkle plugin is part of our [core-plugins bundle](/reference/plugins/core)
+This plugin is part of [core-plugins](/reference/plugins/core),
+so there is no need to load it manually unless you wish to forego
+loading of core plugins yet still want to load this plugin.
 
 [1]: https://www.npmjs.com/package/@freesewing/plugin-sprinkle

--- a/markdown/dev/reference/store-methods/pack/en.md
+++ b/markdown/dev/reference/store-methods/pack/en.md
@@ -2,10 +2,38 @@
 title: pack()
 ---
 
-The `pack()` store method is used to automatically layout patterns in the core library.
-It is implemented as a store method to allow you to override this method and implement 
-your own algorithm to generate the layout.
+The `pack()` store method is used to arrange items into a
+pattern layout.
+The core library uses this method to arrange stacks of parts to
+generate layouts for drafted patterns.
 
-<Fixme>
-Document this in more detail
-</Fixme>
+`pack()` is implemented as a store method to allow you to override this
+method and implement your own algorithm to generate the layout.
+
+## Signature
+
+```js
+Object store.pack(
+  Array items,
+  Pattern pattern,
+)
+```
+
+## Example
+
+```js
+const result = store.pack(parts, pattern)
+
+const layout_width = result.width
+const layout_height = result.height
+```
+
+## Notes
+
+An optimized `pack()` store method is provided by
+[plugin-bin-pack](/reference/plugins/bin-pack)
+which is part of [core-plugins](/reference/plugins/core) and loaded
+by the core library by default.
+
+The core library also provides a basic, unoptimized `pack()` store method
+that is used if core plugins are not loaded.


### PR DESCRIPTION
Fixes #5888

1. Adds missing`plugin-bin-pack` documentation.
2. Adds details to the `pack()` store method documentation.
3. Updates note for plugins provided by `core-plugins`

![Screenshot 2024-08-29 at 5 36 23 PM](https://github.com/user-attachments/assets/86b4845a-e51b-4fc0-8ce7-10d2879b6863)
