### PR TITLE
Prototype for cornered path joins

### DIFF
--- a/packages/core/src/path.mjs
+++ b/packages/core/src/path.mjs
@@ -1151,9 +1151,9 @@ Path.prototype.trim = function () {
           first = false
         }
         let joint
-        if (trimmedStart.length > 0) joint = __joinPaths(trimmedStart).join(glue)
+        if (trimmedStart.length > 0) joint = __joinPaths([...trimmedStart, glue])
         else joint = glue
-        if (trimmedEnd.length > 0) joint = joint.join(__joinPaths(trimmedEnd))
+        if (trimmedEnd.length > 0) joint = __joinPaths([joint, ...trimmedEnd])
 
         return joint.trim()
       }


### PR DESCRIPTION
As discussed on Discord, this changes the offset, join and close methods so the paths are joined at a continuous angle without cutting off the corners.

Some sample screenshots:
Yuri:
![Bildschirmfoto vom 2024-09-10 19-12-55](https://github.com/user-attachments/assets/0700ffd5-c6bc-4ff8-85a3-67971a8c1c19)
Hortensia:
![Bildschirmfoto vom 2024-09-10 18-55-31](https://github.com/user-attachments/assets/7d32aebf-ac45-4b49-b945-dadee7a4b739)
Simon:
![Bildschirmfoto vom 2024-09-10 18-54-47](https://github.com/user-attachments/assets/ef731d43-e2bd-463a-85dc-59ee82d22c23)
(Some corners are still cut, but this is explicitly coded like that in the pattern)
Teagan:
![image](https://github.com/user-attachments/assets/f6cdc364-c2a0-4eb9-aaf6-99da899c727b)
(not sure what's going on in the one corner of the sleeve, probably the design doing something weird, have not investigated yet)

This should not be merged as is and is more meant for testing. Probably would need a way to gradually test and migrate designs (if desired by the creator?) and maybe add an option for the behavior as some people might like the cut corners. This is open for discussion.