### PR TITLE
fix(plugins) Logo missing when Exported to PDF

### DIFF
--- a/plugins/plugin-annotations/src/logo.mjs
+++ b/plugins/plugin-annotations/src/logo.mjs
@@ -7,6 +7,6 @@ export const logoDefs = [
     def: (scale) =>
       `<g id="logo" transform="scale(${
         2 * scale
-      }) translate(-23 -36)"><path class="logo" stroke="none" fill="currentColor" d="${logoPath}"/></g>`,
+      }) translate(-23 -36)"><path class="logo" fill="currentColor" d="${logoPath}"/></g>`,
   },
 ]


### PR DESCRIPTION
Closes #3905
The answer is that we want it as outline. When printing the outline requires less ink.
By removing the stroke it is once again in the export.