### PR TITLE
fix(bella): Omit zero or negative width front waist dart

### DIFF
--- a/designs/bella/src/front-side-dart.mjs
+++ b/designs/bella/src/front-side-dart.mjs
@@ -15,6 +15,7 @@ export const frontSideDart = {
     macro,
     utils,
     measurements,
+    log,
     part,
   }) => {
     // Get to work
@@ -152,6 +153,16 @@ export const frontSideDart = {
     let reduce = points.cfHem.dist(points.sideHemInitial) - hemLen
 
     // Waist dart
+    let includeWaistDart = true
+    if (reduce <= 0) {
+      includeWaistDart = false
+      log.info(
+        '`' +
+          part.name +
+          '`: Front waist dart omitted (because the calculated dart' +
+          ' width was 0.0 mm/inches or less).'
+      )
+    }
     points.waistDartHem = new Point(points.bust.x, points.cfHem.y)
     points.waistDartLeft = points.waistDartHem.shift(180, reduce / 2)
     points.waistDartRight = points.waistDartHem.shift(0, reduce / 2)
@@ -168,11 +179,14 @@ export const frontSideDart = {
       points.waistDartHem.dist(points.bust) / 2
     )
 
-    paths.seam = new Path()
-      .move(points.cfHem)
-      .line(points.waistDartLeft)
-      .curve_(points.waistDartLeftCp, points.waistDartTip)
-      ._curve(points.waistDartRightCp, points.waistDartRight)
+    paths.seam = new Path().move(points.cfHem)
+    if (includeWaistDart)
+      paths.seam
+        .line(points.waistDartLeft)
+        .curve_(points.waistDartLeftCp, points.waistDartTip)
+        ._curve(points.waistDartRightCp, points.waistDartRight)
+        .line(points.waistDartRight)
+    paths.seam
       .line(points.sideHem)
       .line(points.bustDartBottom)
       ._curve(points.bustDartCpBottom, points.bustDartTip)
@@ -186,10 +200,9 @@ export const frontSideDart = {
       .close()
       .attr('class', 'fabric')
 
-    paths.saBase = new Path()
-      .move(points.cfHem)
-      .line(points.waistDartLeft)
-      .line(points.waistDartRight)
+    paths.saBase = new Path().move(points.cfHem)
+    if (includeWaistDart) paths.saBase.line(points.waistDartLeft).line(points.waistDartRight)
+    paths.saBase
       .line(points.sideHem)
       .line(points.bustDartBottom)
       .line(points.bustDartEdge)
@@ -248,29 +261,33 @@ export const frontSideDart = {
     })
 
     // Dimensions
-    macro('vd', {
-      id: 'hCfHemToWaistDartTop',
-      from: points.cfHem,
-      to: points.waistDartTip,
-      x: 0 - 15,
-    })
+    let dimensionOffset = 0
+    if (includeWaistDart) {
+      dimensionOffset = 15
+      macro('vd', {
+        id: 'hCfHemToWaistDartTop',
+        from: points.cfHem,
+        to: points.waistDartTip,
+        x: 0 - 15,
+      })
+    }
     macro('vd', {
       id: 'hCfHemToBustPoint',
       from: points.cfHem,
       to: points.bust,
-      x: 0 - 30,
+      x: 0 - 15 - dimensionOffset,
     })
     macro('vd', {
       id: 'hCfHemToNeckCutout',
       from: points.cfHem,
       to: points.cfNeck,
-      x: 0 - 45,
+      x: 0 - 30 - dimensionOffset,
     })
     macro('vd', {
       id: 'hTotal',
       from: points.cfHem,
       to: points.hps,
-      x: 0 - 60,
+      x: 0 - 45 - dimensionOffset,
     })
     macro('hd', {
       id: 'wCfToWaistDartTip',
@@ -284,35 +301,39 @@ export const frontSideDart = {
       to: points.bustDartTip,
       y: points.bust.y - 30,
     })
-    macro('hd', {
-      id: 'wCfToWaistDartLeft',
-      from: points.cfHem,
-      to: points.waistDartLeft,
-      y: points.cfHem.y + sa + 15,
-    })
-    macro('hd', {
-      id: 'wCfToWaistDartRight',
-      from: points.cfHem,
-      to: points.waistDartRight,
-      y: points.cfHem.y + sa + 30,
-    })
+    dimensionOffset = 0
+    if (includeWaistDart) {
+      dimensionOffset = 30
+      macro('hd', {
+        id: 'wCfToWaistDartLeft',
+        from: points.cfHem,
+        to: points.waistDartLeft,
+        y: points.cfHem.y + sa + 15,
+      })
+      macro('hd', {
+        id: 'wCfToWaistDartRight',
+        from: points.cfHem,
+        to: points.waistDartRight,
+        y: points.cfHem.y + sa + 30,
+      })
+    }
     macro('hd', {
       id: 'wHemTotal',
       from: points.cfHem,
       to: points.sideHem,
-      y: points.cfHem.y + sa + 45,
+      y: points.cfHem.y + sa + 15 + dimensionOffset,
     })
     macro('hd', {
       id: 'wCfHemToBustDartBottom',
       from: points.cfHem,
       to: points.bustDartBottom,
-      y: points.cfHem.y + sa + 60,
+      y: points.cfHem.y + sa + 30 + dimensionOffset,
     })
     macro('hd', {
       id: 'wCfHemToBustDartTop',
       from: points.cfHem,
       to: points.bustDartTop,
-      y: points.cfHem.y + sa + 75,
+      y: points.cfHem.y + sa + 45 + dimensionOffset,
     })
     macro('vd', {
       id: 'hHemRightToBustDartBottom',


### PR DESCRIPTION
This PR omits Bella's front waist dart if the width of the dart is zero or negative. (Currently, Bella incorrectly draws negative-width waist darts.)

The fix includes the seam line, the seam allowance line, and dimensions. The fix was tested on Noble and Bee to verify that they still work and produce identical patterns before and after the fix.

![Screenshot 2024-09-18 at 1 38 56 PM](https://github.com/user-attachments/assets/731a17ca-6ec3-491b-b135-3ae11955b1da)
![Screenshot 2024-09-18 at 1 38 43 PM](https://github.com/user-attachments/assets/f6a985ab-b780-4b19-86a3-3d70723f4f01)

![Screenshot 2024-09-18 at 1 56 14 PM](https://github.com/user-attachments/assets/6bdf5c96-6de6-4fd8-ac44-e2cea18060f3)
![Screenshot 2024-09-18 at 1 55 18 PM](https://github.com/user-attachments/assets/349fcee4-7718-4b73-98da-c68f13c6b19d)

This measurement set was used to reproduce the issue and test the fix on Bella. It was also used to verify no side effects affecting Noble or Bee:
```yaml
measurements:
  highBust: 1000
  chest: 1020
  underbust: 1000
  waist: 1100
  waistBack: 550
  bustSpan: 200
  neck: 400
  hpsToBust: 300
  hpsToWaistFront: 500
  hpsToWaistBack: 500
  shoulderToShoulder: 450
  shoulderSlope: 15
  bustPointToUnderbust: 70
```