### PR TITLE
Fix user ID in showcase post

### DIFF
--- a/markdown/org/showcase/sleeveless-simon-by-lasermonkey12/en.md
+++ b/markdown/org/showcase/sleeveless-simon-by-lasermonkey12/en.md
@@ -5,7 +5,7 @@ date: 20240106
 intro: "Maker lasermonkey12 has made lots of great Simon shirts, including this sleeveless one."
 designs: ["simone"]
 maker: lasermonkey12
-author: 22007
+author: 31287
 ---
 
 Maker lasermonkey12 has made lots of great Simon and Simone shirts. This sleeveless one is a Simone. We love the fresh look, well-suited for hot weather! This was shared on [Discord](https://discord.freesewing.org/) and is reposted here with permission.


### PR DESCRIPTION
This showcase was attributed to the correct maker name but wrong user ID.