### PR TITLE
enhancement(bella,docs): Add front waist dart curve option and allow longer waist dart

### DIFF
--- a/designs/bee/src/cup.mjs
+++ b/designs/bee/src/cup.mjs
@@ -28,6 +28,7 @@ export const cup = {
     bustDartCurve: 1,
     bustDartLength: 1,
     waistDartLength: 1,
+    waistDartCurve: 1,
     backHemSlope: 2.5,
     backNeckCutout: 0.06,
     //catergory changed from Bella

--- a/designs/bella/i18n/en.json
+++ b/designs/bella/i18n/en.json
@@ -50,6 +50,10 @@
       "t": "Bust dart curve",
       "d": "Controls the curvature of the bust dart"
     },
+    "waistDartCurve": {
+      "t": "Waist dart curve",
+      "d": "Controls the curvature of the waist dart"
+    },
     "armholeDepth": {
       "t": "Armhole depth",
       "d": "Controls the depth of the armhole"

--- a/designs/bella/src/back.mjs
+++ b/designs/bella/src/back.mjs
@@ -33,7 +33,8 @@ export const back = {
     backDartHeight: { pct: 46, min: 38, max: 54, menu: 'darts' },
     bustDartCurve: { pct: 100, min: 0, max: 100, menu: 'darts' },
     bustDartLength: { pct: 90, min: 75, max: 100, menu: 'darts' },
-    waistDartLength: { pct: 90, min: 75, max: 95, menu: 'darts' },
+    waistDartCurve: { pct: 100, min: -100, max: 100, menu: 'darts' },
+    waistDartLength: { pct: 90, min: 75, max: 100, menu: 'darts' },
     // Armhole
     armholeDepth: { pct: 44, min: 38, max: 46, menu: 'armhole' },
     backArmholeCurvature: { pct: 63, min: 50, max: 85, menu: 'armhole' },

--- a/designs/bella/src/front-side-dart.mjs
+++ b/designs/bella/src/front-side-dart.mjs
@@ -167,6 +167,19 @@ export const frontSideDart = {
       90,
       points.waistDartHem.dist(points.bust) / 2
     )
+    // Apply option-controlled curvature to waist dart
+    points.waistDartLeftMid = new Path()
+      .move(points.bust)
+      .line(points.waistDartLeft)
+      .shiftFractionAlong(0.5)
+    points.waistDartRightMid = new Path()
+      .move(points.bust)
+      .line(points.waistDartRight)
+      .shiftFractionAlong(0.5)
+    const waistDartCpWidth =
+      points.waistDartLeftMid.dist(points.waistDartLeftCp) * options.waistDartCurve
+    points.waistDartLeftCp.x = points.waistDartLeftMid.x - waistDartCpWidth
+    points.waistDartRightCp.x = points.waistDartRightMid.x + waistDartCpWidth
 
     paths.seam = new Path()
       .move(points.cfHem)

--- a/designs/noble/src/options.mjs
+++ b/designs/noble/src/options.mjs
@@ -4,6 +4,7 @@ import { pctBasedOn } from '@freesewing/core'
 export const shoulderToShoulderCorrection = 0.995
 export const bustDartCurve = 1
 export const bustDartLength = 0.9
+export const waistDartCurve = 1
 // Percentages
 export const bustSpanEase = { pct: 0, min: -5, max: 20, ...pctBasedOn('bustSpan'), menu: 'fit' }
 export const backHemSlope = { deg: 2.5, min: 0, max: 5, menu: 'advanced' }

--- a/markdown/org/docs/designs/bella/options/waistdartcurve/en.md
+++ b/markdown/org/docs/designs/bella/options/waistdartcurve/en.md
@@ -1,0 +1,10 @@
+---
+title: "Waist dart curve"
+---
+
+***
+
+<!-- ![The effect of the bust dart curve option on the pattern](sample.png) -->
+
+The **waist dart curve** option controls the curvature of the waist dart.
+From slightly concave, to straight, to slightly convex.


### PR DESCRIPTION
1. Adds a `waistDartCurve` option  to Bella's front, to allow straight and convex curved darts.
2. Increases the max length of the waist dart to 100%. 
3. Adds new documentation for the new option.

![Screenshot 2024-09-19 at 7 22 16 PM](https://github.com/user-attachments/assets/ce228907-d422-4867-a710-0a3d87020b7f)
![Screenshot 2024-09-19 at 7 22 56 PM](https://github.com/user-attachments/assets/d7cd93a0-d8e2-4aa3-a8da-14127e3da545)

I didn't generate test sample images for the new option or for the updated option.

The enhancements to Bella's darts were originally requested by a customer.
https://discord.com/channels/698854858052075530/757632180980547686/1113170603701190706
discord://discord.com/channels/698854858052075530/757632180980547686/1113170603701190706
