### PR TITLE
fix(bent): Base sleeve width on biceps circumference

### DIFF
--- a/designs/bent/src/sleeve.mjs
+++ b/designs/bent/src/sleeve.mjs
@@ -5,7 +5,8 @@ function draftBentSleeve({ Path, paths, points, store, options, part }) {
     let { Point, Path, points, store, options, measurements, utils } = part.shorthand()
     // Sleeve frame
     points.top = new Point(0, 0)
-    points.boxTopRight = points.top.shift(0, (store.get('sleevecapTarget') / 5.8) * tweak)
+    const easedQuarterBiceps = (measurements.biceps / 4) * (1 + options.bicepsEase)
+    points.boxTopRight = points.top.shift(0, easedQuarterBiceps * tweak)
     points.boxTopLeft = points.boxTopRight.flipX()
     points.boxBottom = points.top.shift(
       -90,


### PR DESCRIPTION
Fixes #6023

This changes the sleeve width algorithm to be based on biceps circumference. Previously the algorithm used a set fraction of the sleeve opening as the sleeve width.

(I am initially filing this as Draft status. I will post to Discord to get feedback on the PR, and within 7 days I will either move this PR out of Draft status or close it entirely.)

Comparing before/after patterns using curated measurements sets, it seems that this new formula produces roughly the same patterns as before. However, as biceps circumference increases, the sleeve width now increases instead of decreasing.

![Screenshot 2024-09-20 at 7 15 41 AM](https://github.com/user-attachments/assets/6b2bbd0e-7d95-41e7-b5a4-3f289c44ac52)
![Screenshot 2024-09-20 at 7 16 00 AM](https://github.com/user-attachments/assets/0c9d693d-72be-4f64-8da4-112da4915a40)

![Screenshot 2024-09-20 at 7 18 47 AM](https://github.com/user-attachments/assets/c9aaf1e9-64b9-4c49-99f4-1d0f8573a71a)
![Screenshot 2024-09-20 at 7 18 10 AM](https://github.com/user-attachments/assets/3e9bcc64-3949-40d8-8f7f-bdf58075d437)

![Screenshot 2024-09-20 at 7 15 18 AM](https://github.com/user-attachments/assets/f690f706-e5b1-4a78-949f-caf7c34d4ec7)
![Screenshot 2024-09-20 at 7 15 02 AM](https://github.com/user-attachments/assets/edcc5419-7144-4a76-8f55-8a9d2617e1e4)

![Screenshot 2024-09-20 at 7 19 24 AM](https://github.com/user-attachments/assets/4d017f62-b718-407e-aee7-ec0686eb21c8)
![Screenshot 2024-09-20 at 7 20 06 AM](https://github.com/user-attachments/assets/f722d19b-9cf9-4b31-bf5b-6f34f0efc212)
