### PR TITLE
fix(gozer): Adjust position of eyes

### DIFF
--- a/designs/gozer/src/ghost.mjs
+++ b/designs/gozer/src/ghost.mjs
@@ -2,15 +2,17 @@ export const ghost = {
   name: 'gozer.ghost',
   measurements: ['hpsToWaistBack', 'waistToFloor', 'head'],
   draft: ({ measurements, Point, points, Snippet, snippets, sa, macro, part }) => {
-    const eyeSize = measurements.head * 0.0416
+    const eyeSize = measurements.head * (1 / 24)
+    const eyeLine = measurements.head / 2.25
+    const eyeOffset = measurements.head * (1 / 12.7)
     const size =
       measurements.hpsToWaistBack + measurements.waistToFloor + measurements.head / Math.PI
 
     points.middle = new Point(0, 0).addCircle(size, 'fabric')
 
-    points.eyeLine = points.middle.shift(270, measurements.head / Math.PI / 2)
-    points.eyeLeft = points.eyeLine.shift(180, measurements.head * 0.13)
-    points.eyeRight = points.eyeLine.shift(0, measurements.head * 0.13)
+    points.eyeLine = points.middle.shift(270, eyeLine)
+    points.eyeLeft = points.eyeLine.shift(180, eyeOffset)
+    points.eyeRight = points.eyeLine.shift(0, eyeOffset)
     points.left = new Point(-1 * size, 0)
     points.right = new Point(size, 0)
 


### PR DESCRIPTION
Fixes #7059

Changes:
1. Eye line distance from top of head increased from `head circumference / 6.28` to `head circumference / 2.25`.
2. Pupil-to-pupil width decreased from from `head circumference * 0.13` to about `head circumference * 0.079` (1  /  12.7).

(Eye size is unchanged, but I changed how the value was written to `1 / 24` instead of `0.0416` for improved understandability.)

I have not constructed a test garment for these changes. However, the generated pattern has the eyeline at 25.33 cm and the pupil-to-pupil width at 8.98 cm, close to the desired values I estimated using my 57 cm head as a model.

![Screenshot 2024-09-20 at 12 23 32 PM](https://github.com/user-attachments/assets/946a0e0c-5208-4605-98c9-f10940c5b310)
![Screenshot 2024-09-20 at 12 23 08 PM](https://github.com/user-attachments/assets/95c9ae23-cf9a-4426-84b4-6168c68f613f)

Because PR #6087 will change the positions of the logo and title, this PR ignores the fact that currently they are not optimally placed.