### PR TITLE
enhancement(huey): Add pocket opening size option

### DIFF
--- a/designs/huey/i18n/en.json
+++ b/designs/huey/i18n/en.json
@@ -33,6 +33,10 @@
       "t": "Pocket height",
       "d": "Controls the height of the pocket"
     },
+    "pocketOpening": {
+      "t": "Pocket opening",
+      "d": "Controls the opening size of the pocket"
+    },
     "hoodHeight": {
       "t": "Hood height",
       "d": "Controls the height of the hood"

--- a/designs/huey/src/front.mjs
+++ b/designs/huey/src/front.mjs
@@ -37,7 +37,7 @@ function draftHueyFront({
   points.pocketTopRight = points.pocketCfTop.shift(0, points.hem.x * options.pocketWidth)
   points.pocketTip = new Point(
     points.pocketTopRight.x * 1.2,
-    points.pocketTopRight.y + (points.hem.y - points.pocketTopRight.y) * 0.9
+    points.pocketTopRight.y + (points.hem.y - points.pocketTopRight.y) * options.pocketOpening
   )
   points.pocketHem = new Point(
     points.pocketTopRight.x + points.pocketTopRight.dx(points.pocketTip) / 2,
@@ -134,6 +134,7 @@ export const front = {
     pocket: { bool: true, menu: 'style' },
     pocketHeight: { pct: 30, min: 25, max: 35, menu: 'style' },
     pocketWidth: { pct: 60, min: 50, max: 70, menu: 'style' },
+    pocketOpening: { pct: 90, min: 60, max: 90, menu: 'style' },
   },
   draft: draftHueyFront,
 }

--- a/markdown/org/docs/designs/huey/options/pocketopening/en.md
+++ b/markdown/org/docs/designs/huey/options/pocketopening/en.md
@@ -1,0 +1,7 @@
+---
+title: "Pocket opening"
+---
+
+<!-- ![Pocket opening](./pocketopening.svg) -->
+
+Controls the opening size of the front pocket.


### PR DESCRIPTION
This PR adds a pocket opening size option to Huey. The default is 90%, the same as the current design, so there is no default change in the design.

On Discord, a user mentioned that the Huey pocket was somewhat shallow because of the opening, making it easier for items to fall out of the pocket.
https://discord.com/channels/698854858052075530/698854858496802868/1287918139627147287
discord://discord.com/channels/698854858052075530/698854858496802868/1287918139627147287

![Screenshot 2024-09-26 at 5 24 27 AM](https://github.com/user-attachments/assets/7eaced0b-063a-4295-a7fd-5af10c950e70)
![Screenshot 2024-09-26 at 5 23 15 AM](https://github.com/user-attachments/assets/a5b387ee-cb53-4122-9906-7f334ccc663d)