### PR TITLE
Fix and improve path intersection methods

### DIFF
--- a/packages/core/src/utils.mjs
+++ b/packages/core/src/utils.mjs
@@ -585,7 +585,7 @@ export function pctBasedOn(measurement) {
  * @param {Point} from - First Point on the line
  * @param {Point} to - Second Point on the line
  * @param {Point} check - Point to check
- * @param {float} preciesion - How precise we should check
+ * @param {float} precision - How precise we should check
  * @return {bool} result - True of the Point is on the line, false when not
  */
 export function pointOnBeam(from, to, check, precision = 1e6) {
@@ -658,7 +658,7 @@ export function curveParameterFromPoint(start, cp1, cp2, end, check) {
  * @param {Point} from - Start of the line segment
  * @param {Point} to - End of the line segment
  * @param {Point} check - Point to check
- * @param {float} preciesion - How precise we should check
+ * @param {float} precision - How precise we should check
  * @return {bool} result - True of the Point is on the line segment, false when not
  */
 export function pointOnLine(from, to, check, precision = 1e6) {

--- a/packages/core/tests/path.test.mjs
+++ b/packages/core/tests/path.test.mjs
@@ -603,6 +603,17 @@ describe('Path', () => {
     expect(round(intersections[5].y)).to.equal(93.31)
   })
 
+  it('Should find an intersection with a beam', () => {
+    const test = new Path()
+      .move(new Point(300, 400))
+      .line(new Point(300, 380))
+      .curve(new Point(350, 200), new Point(350, 100), new Point(350, 0))
+    let intersectsBeam = test.intersectsBeam(new Point(0, 370), new Point(100, 370))
+    expect(intersectsBeam.length).to.equal(1)
+    expect(round(intersectsBeam[0].x)).to.equal(302.75)
+    expect(round(intersectsBeam[0].y)).to.equal(370)
+  })
+
   it('Should throw an error when running path.intersect on an identical path', () => {
     const test = new Path()
     expect(() => test.intersects(test)).to.throw()

--- a/packages/core/tests/utils.test.mjs
+++ b/packages/core/tests/utils.test.mjs
@@ -48,6 +48,24 @@ describe('Utils', () => {
     expect(linesIntersect(a, b, c, d)).to.equal(false)
   })
 
+  it('Should detect parallel vertical lines', () => {
+    let a = new Point(10, 20.234)
+    let b = new Point(10, 20)
+    let c = new Point(90, 40)
+    let d = new Point(90, 45.123)
+    expect(beamsIntersect(a, b, c, d)).to.equal(false)
+    expect(linesIntersect(a, b, c, d)).to.equal(false)
+  })
+
+  it('Should detect almost parallel vertical lines', () => {
+    let a = new Point(10, 20.234)
+    let b = new Point(10, 20)
+    let c = new Point(360, 40)
+    let d = new Point(360.00000000000006, 45.123)
+    expect(beamsIntersect(a, b, c, d)).to.equal(false)
+    expect(linesIntersect(a, b, c, d)).to.equal(false)
+  })
+
   it('Should detect vertical lines', () => {
     let a = new Point(10, 20)
     let b = new Point(10, 90)

--- a/sites/dev/docs/reference/api/path/intersects/readme.mdx
+++ b/sites/dev/docs/reference/api/path/intersects/readme.mdx
@@ -17,7 +17,7 @@ for more information.
 ## Signature
 
 ```
-array|false path.intersects(Path path)
+array path.intersects(Path path)
 ```
 
 

--- a/sites/dev/docs/reference/api/path/intersectsbeam/readme.mdx
+++ b/sites/dev/docs/reference/api/path/intersectsbeam/readme.mdx
@@ -1,0 +1,56 @@
+---
+title: Path.intersectsBeam()
+---
+
+The `Path.intersectsBeam()` method returns the Point object(s) where the path
+intersects with an endless line (beam).
+
+:::warning
+
+This method can sometimes fail to find intersections in some curves
+due to a limitation in an underlying Bézier library.
+Please see [Bug #3367](https://github.com/freesewing/freesewing/issues/3367)
+for more information.
+
+:::
+
+## Signature
+
+```js
+array path.intersectsBeam(Point a, Point b)
+```
+
+<Example caption="Example of the Path.intersectsBeam() method">
+
+```js
+;({ Point, points, Path, paths, snippets, Snippet, getId, part }) => {
+  points.A = new Point(45, 60)
+  points.B = new Point(10, 30)
+  points.BCp2 = new Point(40, 20)
+  points.C = new Point(90, 30)
+  points.CCp1 = new Point(50, -30)
+
+  points.beamA = new Point(55, 30)
+  points.beamB = new Point(0, 55)
+
+  paths.demo1 = new Path().move(points.A).line(points.B).curve(points.BCp2, points.CCp1, points.C)
+
+  paths.beam = new Path().move(points.beamA).line(points.beamB).addClass('dashed')
+
+  for (let p of paths.demo1.intersectsBeam(points.beamA, points.beamB)) {
+    snippets[getId()] = new Snippet('notch', p)
+  }
+
+  return part
+}
+```
+
+</Example>
+
+## Notes
+
+This method works similar to `path.intersectsX(...)` and `path.intersectsY(...)`,
+but here the intersecting beam doesn't have to be horizontally or vertically.
+
+If you need intersections with a limited line instead of a beam,
+use something like `path.intersects(new Path.move(pointA).line(pointB))` instead.

--- a/sites/dev/docs/reference/api/path/intersectsx/readme.mdx
+++ b/sites/dev/docs/reference/api/path/intersectsx/readme.mdx
@@ -17,7 +17,7 @@ for more information.
 ## Signature
 
 ```js
-array|false path.intersectsX(float x)
+array path.intersectsX(float x)
 ```
 
 ## Example

--- a/sites/dev/docs/reference/api/path/intersectsy/readme.mdx
+++ b/sites/dev/docs/reference/api/path/intersectsy/readme.mdx
@@ -17,7 +17,7 @@ for more information.
 ## Signature
 
 ```js
-array|false path.intersectsY(float y)
+array path.intersectsY(float y)
 ```
 
 ## Example

--- a/sites/dev/docs/reference/api/utils/beamintersectsline/readme.mdx
+++ b/sites/dev/docs/reference/api/utils/beamintersectsline/readme.mdx
@@ -1,0 +1,45 @@
+---
+title: utils.beamIntersectsLine()
+---
+
+The `utils.beamIntersectsLine()` function finds the intersection between an endless
+line (beam) and a (limited) line segment. Returns a [Point](/reference/api/point) object for the
+intersection, or `false` if the beam doesn't intersect the line.
+
+The first two points in the parameter list form the beam, the last two points form the line.
+
+## Signature
+
+```js
+Point | false utils.beamIntersectsLine(
+  Point beamA,
+  Point beamB,
+  Point lineA,
+  Point lineB
+)
+```
+
+## Example
+
+<Example caption="A Utils.beamIntersectsLine() example">
+
+```js
+;({ Point, points, Path, paths, Snippet, snippets, utils, part }) => {
+  points.A = new Point(45, 20)
+  points.B = new Point(60, 15)
+  points.C = new Point(10, 10)
+  points.D = new Point(50, 40)
+
+  paths.AB = new Path().move(points.A).line(points.B).addClass('dotted')
+  paths.CD = new Path().move(points.C).line(points.D)
+
+  snippets.x = new Snippet(
+    'notch',
+    utils.beamIntersectsLine(points.A, points.B, points.C, points.D)
+  )
+
+  return part
+}
+```
+
+</Example>

--- a/sites/dev/docs/reference/api/utils/beamsintersect/readme.mdx
+++ b/sites/dev/docs/reference/api/utils/beamsintersect/readme.mdx
@@ -19,7 +19,7 @@ Point | false utils.beamsIntersect(
 
 ## Example
 
-<Example caption="A Utils.beamIntersect() example">
+<Example caption="A Utils.beamsIntersect() example">
 ```js
 ({ Point, points, Path, paths, Snippet, snippets, utils, part }) => {
 


### PR DESCRIPTION
This is mostly a general collection of fixes and improvements that I discovered why working on the seam allowance macro.

- Add path.intersectsBeam() method
- Add utils.beamIntersectsLine() method
- Simplify calculation and improve precision on beam intersections. A beam intersection situation between two parallel vertical lines going in opposite direction was not detected properly
- Document return types properly
- beamIntersectsCurve now uses the proper function from Bezier library instead of emulating it by constructing a huge line
- docs: path.intersect... methods never return false, they simply return an empty array in case of no intersection. This behavior is unfortunately not consistent between methods, but let's at least document the current behavior.

Note: This might affect compatibility as the detection of (almost) parallel paths in beam intersections and curve-beam intersections is now more reliable and possibly less/more tolerant. Patterns that relied on the previously incorrect behavior might fail in new ways. See #7128 for an example. I recommend to only push this for a major update. An alternative might be to have two version of the methods for compatibility reasons.  (like maybe two versions of the utils class)