### PR TITLE
Fix build problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint-plugin-markdown": "^5.0.0",
     "eslint-plugin-mongo": "^1.0.5",
     "eslint-plugin-yaml": "^0.5.0",
+    "execa": "^9.3.1",
     "husky": "^9.0.10",
     "js-yaml": "^4.0.0",
     "lerna": "^8.0.0",

--- a/sites/org/next.config.mjs
+++ b/sites/org/next.config.mjs
@@ -1,7 +1,7 @@
 import configBuilder from '../shared/config/next.mjs'
 import i18nConfig from './next-i18next.config.js'
 import { banner } from '../../scripts/banner.mjs'
-import withBundleAnalyzer from '@next/bundle-analyzer'
+// import withBundleAnalyzer from '@next/bundle-analyzer'
 
 let config = configBuilder({ site: 'org' })
 config.i18n = i18nConfig.i18n
@@ -32,6 +32,6 @@ config.eslint = {
 
 // To run the bundle analyzer, run:
 // ANALYZE=true yarn build
-if (process.env.ANALYZE) config = withBundleAnalyzer(config)(config)
+// if (process.env.ANALYZE) config = withBundleAnalyzer(config)(config)
 
 export default config

--- a/sites/shared/components/mdx/index.mjs
+++ b/sites/shared/components/mdx/index.mjs
@@ -19,8 +19,6 @@ import { MeasieImage } from 'shared/components/measurements/image.mjs'
 // Dev/Org jargon
 import { Term as SharedTerm, termList } from 'shared/components/jargon.mjs'
 import { jargon, site } from 'site/prebuild/jargon.mjs'
-// Dev web of trust
-import { WebOfTrustMap, WebOfTrustTable } from '../../../dev/components/web-of-trust.mjs'
 export const Term = ({ children }) => <SharedTerm {...{ jargon, children, site }} />
 export const TermList = termList(jargon, site)
 
@@ -70,8 +68,6 @@ export const components = (site = 'org', slug = []) => {
       ...extra,
       Method: HttpMethod,
       StatusCode: HttpStatusCode,
-      WebOfTrustTable,
-      WebOfTrustMap,
     }
 
   const specific = {}


### PR DESCRIPTION
- Remove references to Web of Trust components that are gone
- Specify execa version explicitly, otherwise you get a random old version from some dependency and versions below 6.0.0 have compatibility issues
- Get rid of @next/bundle-analyzer as it seems to cause build issues and even adding a dependency doesn't seem to work reliably :shrug: 