### PR TITLE
fix(shared): Remove dev site config from search

### DIFF
--- a/sites/shared/prebuild/search.mjs
+++ b/sites/shared/prebuild/search.mjs
@@ -1,6 +1,5 @@
 import { collection } from '../../org/hooks/use-design.mjs'
 import { siteConfig as orgConfig } from '../../org/site.config.mjs'
-import { siteConfig as devConfig } from '../../dev/site.config.mjs'
 import { algoliaClient, indexSettings } from './algolia.mjs'
 import fs from 'fs'
 import path from 'path'
@@ -9,7 +8,6 @@ import strip from 'strip-markdown'
 
 const siteConfig = {
   org: orgConfig,
-  dev: devConfig,
 }
 
 export const loadMdText = async ({


### PR DESCRIPTION
Fixes an error preventing the org development environment from running:

```sh
% yarn start
yarn run v1.22.22
$ yarn prebuild && yarn dev
$ node --conditions=internal --experimental-json-modules ./prebuild.mjs
node:internal/modules/esm/resolve:265
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../sites/dev/site.config.mjs' imported from .../sites/shared/prebuild/search.mjs
    at finalizeResolution (node:internal/modules/esm/resolve:265:11)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1169:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:540:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:509:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:239:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:96:40)
    at link (node:internal/modules/esm/module_job:95:36) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///.../sites/dev/site.config.mjs'
}

Node.js v20.17.0
error Command failed with exit code 1.
```