### PR TITLE
fix(shared): Change print settings to user experience level 1

### DIFF
--- a/sites/shared/components/workbench/views/print/config.mjs
+++ b/sites/shared/components/workbench/views/print/config.mjs
@@ -23,7 +23,7 @@ export const loadPrintConfig = (units) => {
   const defaults = defaultPrintSettings(units)
   const config = {
     size: {
-      control: 2,
+      control: 1,
       list: sizes,
       dflt: defaults.size,
       choiceTitles: {},
@@ -31,7 +31,7 @@ export const loadPrintConfig = (units) => {
       icon: PageSizeIcon,
     },
     orientation: {
-      control: 2,
+      control: 1,
       list: ['portrait', 'landscape'],
       choiceTitles: {
         portrait: 'portrait',
@@ -45,7 +45,7 @@ export const loadPrintConfig = (units) => {
       icon: PageOrientationIcon,
     },
     margin: {
-      control: 2,
+      control: 1,
       min: units === 'imperial' ? 0.25 : 0.5,
       max: 2.5,
       step: units === 'imperial' ? 0.125 : 0.1,
@@ -53,12 +53,12 @@ export const loadPrintConfig = (units) => {
       icon: PageMarginIcon,
     },
     coverPage: {
-      control: 3,
+      control: 1,
       dflt: defaults.coverPage,
       icon: CoverPageIcon,
     },
     cutlist: {
-      control: 3,
+      control: 1,
       dflt: defaults.cutlist,
       icon: CuttingLayoutIcon,
     },


### PR DESCRIPTION
This PR changes the control levels for all Print Settings to User Experience level 1, in the Print Layout view.

On Discord a user experienced confusion when clicking on "Print Settings" did not reveal any settings as expected. It turned out that their User Experience level was set to 1 and the configured control levels for all print settings were level 2 and higher.
https://discord.com/channels/698854858052075530/1293352270943092798/1293352270943092798
discord://discord.com/channels/698854858052075530/1293352270943092798/1293352270943092798

I am interpreting the situation as a bug, with the root cause being that the print settings control levels are misconfigured. Instead, the correct situation is that all print settings should be level 1. This is my reasoning:
- In the Print Layout view:
  - There is no place to see your User Experience level.
  - There is no way to change User Experience level.
- Only 2 other views have elements that are gated by User Experience.
  - One is the main Pattern Editor view which shows User Experience in the header and has a UI Settings right menu to allow User Experience to be changed.
  - The other is the Time Design view which has a UI Settings right menu to allow User Experience to be changed.
  - All other views allow access to all elements. If you have a high enough User Experience level to see/access the view, you also have access to all elements on the view.
- Access to the Print Layout view itself is set at User Experience level 1.
- Therefore, User Experience level 1 users should have access to all the print settings.

_(An alternate interpretation might be that we confirm that print settings are intended to be restricted by User Experience levels higher than 1. If that is the case, we might want to change the page to add "UI Settings" to the right menu, to allow users to change their User Experience levels. We might want to add "missing settings?" information similar to what is on the Pattern Editor view. Finally, we might want to rethink the User Experience levels for each individual print setting. For example, it seems that changing Page Size should be something that even User Experience level 1 users should have access to.)_