### PR TITLE
fix(shared): Provide control to menu items to allow User Experience circles to be filled

### DIFF
--- a/sites/shared/components/workbench/menus/shared/menu-item.mjs
+++ b/sites/shared/components/workbench/menus/shared/menu-item.mjs
@@ -193,10 +193,10 @@ export const MenuItemGroup = ({
     const ItemIcon = item.icon
       ? item.icon
       : item.isGroup
-      ? GroupIcon
-      : Icon
-      ? Icon
-      : () => <span role="img">fixme-icon</span>
+        ? GroupIcon
+        : Icon
+          ? Icon
+          : () => <span role="img">fixme-icon</span>
     const Value = item.isGroup
       ? () => (
           <div className="flex flex-row gap-2 items-center font-medium">
@@ -205,10 +205,10 @@ export const MenuItemGroup = ({
           </div>
         )
       : isDesignOptionsGroup
-      ? values[optionType(item)]
-      : values[itemName]
-      ? values[itemName]
-      : () => <span>¯\_(ツ)_/¯</span>
+        ? values[optionType(item)]
+        : values[itemName]
+          ? values[itemName]
+          : () => <span>¯\_(ツ)_/¯</span>
 
     return [
       <div className="flex flex-row items-center justify-between w-full" key="a">
@@ -223,6 +223,7 @@ export const MenuItemGroup = ({
             t={t}
             changed={wasChanged(currentValues[itemName], item)}
             design={design}
+            control={control}
           />
         </div>
       </div>,


### PR DESCRIPTION
Fixes #7037 

(I added only the one, new `control` line. The other indent spacing code changes were made by `prettier`.)

![Screenshot 2024-10-10 at 12 06 05 PM](https://github.com/user-attachments/assets/001f40a3-fa4f-41b5-bf1d-c501f2027f77)
![Screenshot 2024-10-10 at 12 06 30 PM](https://github.com/user-attachments/assets/e2d34a78-009b-46fa-916c-4ced5ecdfef7)
