### PR TITLE
fix(org): Add missing space after thanksMsg2

### DIFF
--- a/sites/org/pages/patrons/thanks.mjs
+++ b/sites/org/pages/patrons/thanks.mjs
@@ -34,7 +34,7 @@ const PatronsJoinPage = ({ page }) => {
           <h5>{t('patrons:watchYourInbox')}</h5>
           <p>{t('patrons:thanksMsg1')}</p>
           <p>
-            {t('patrons:thanksMsg2')}
+            {t('patrons:thanksMsg2')}{' '}
             <a
               href="mailto:joost@freesewing.org"
               className="font-bold underline decoration-2 hover:decoration-4"


### PR DESCRIPTION
This should hopefully add the space missing between the thanksMsg2 and the email address after it.