### PR TITLE
fix(orgdocs): Use bare key for option menus without translations

### DIFF
--- a/sites/orgdocs/src/theme/MDXComponents/design-info.mjs
+++ b/sites/orgdocs/src/theme/MDXComponents/design-info.mjs
@@ -48,7 +48,7 @@ const Option = ({ id, option, design, i18n }) =>
 
 const OptionGroup = ({ id, group, design, i18n }) => (
   <li key={id}>
-    <b>{optionGroupTranslations[id]}</b>
+    <b>{optionGroupTranslations[id] || id}</b>
     <ul className="list list-inside list-disc pl-2">
       {Object.entries(group).map(([sid, entry]) =>
         entry.isGroup ? (


### PR DESCRIPTION
(The real fix for this type of situation would be to add the missing translation string. However, this PR adds a quality-of-life improvement by displaying the bare translation key instead.)

![Screenshot 2024-10-23 at 7 28 51 AM](https://github.com/user-attachments/assets/78bf4834-e2da-4f4c-9618-5832f231c424)
![Screenshot 2024-10-23 at 7 32 27 AM](https://github.com/user-attachments/assets/c884043c-6a22-4e76-983f-ed21482f541b)
