### PR TITLE
fix(.gitignore): Ignore nx/workspace-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ sites/*/package-lock.json
 
 # Nx cache
 .nx/cache
+.nx/workspace-data
 
 # Docusaurus cache
 .docusaurus


### PR DESCRIPTION
Before:
```sh
% git status -u
On branch develop
Your branch is up to date with 'origin/develop'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.nx/workspace-data/58AA42CE-3558-5D47-B9C9-26F06263EF49.db
	.nx/workspace-data/58AA42CE-3558-5D47-B9C9-26F06263EF49.db-shm
	.nx/workspace-data/58AA42CE-3558-5D47-B9C9-26F06263EF49.db-wal
	.nx/workspace-data/d/daemon.log
	.nx/workspace-data/file-map.json
	.nx/workspace-data/lockfile.hash
	.nx/workspace-data/nx_files.nxt
	.nx/workspace-data/parsed-lock-file.json
	.nx/workspace-data/project-graph.json

nothing added to commit but untracked files present (use "git add" to track)
```