### PR TITLE
Enhance titan waist balance

### DIFF
--- a/designs/titan/i18n/en.json
+++ b/designs/titan/i18n/en.json
@@ -88,6 +88,26 @@
       "t": "Waist ease",
       "d": "Controls the amount of ease at your waist"
     },
+    "waistAngle":  {
+      "t": "Waistband angle",
+      "d": "Change the angle of the waistband when viewed from the side"
+    },
+    "useWaistAngleFor": {
+      "t": "Use waistband angle for",
+      "d": "Apply the waistband angle to the front, back or both"
+    },
+    "useWaistAngleFor.both": {
+      "t": "Both",
+      "d": "Apply the waistband angle to the front and back"
+    },
+     "useWaistAngleFor.backOnly": {
+      "t": "Back",
+      "d": "Apply the waistband angle only to the back"
+    },
+     "useWaistAngleFor.frontOnly": {
+      "t": "Front",
+      "d": "Apply the waistband angle only to the front"
+    },
     "grainlinePosition": {
       "t": "Grainline position",
       "d": "Controls the horizontal position of the leg relative to the seat"

--- a/designs/titan/src/back.mjs
+++ b/designs/titan/src/back.mjs
@@ -200,7 +200,7 @@ function titanBack({
       // Revert back to the previous rotation.
       for (const i of rotate) {
         points[i] = saved[i]
-  }
+      }
       points.fork = saved.fork
       points.forkCp2 = saved.forkCp2
     }
@@ -238,24 +238,31 @@ function titanBack({
     points.styleWaistIn = points.waistIn.clone()
     points.styleWaistOut = points.waistOut.clone()
   }
+
   // Now angle the waist (if requested)
   // create a backup of the unangled position, for use in dependent patterns
-  points.styleWaistInNoAngle = points.styleWaistIn.clone()  
-  if (options.waistAngle != 0 && (options.useWaistAngleFor === 'both' || options.useWaistAngleFor === 'backOnly') ) {
+  points.styleWaistInNoAngle = points.styleWaistIn.clone()
+  if (
+    options.waistAngle !== 0 &&
+    (options.useWaistAngleFor === 'both' || options.useWaistAngleFor === 'backOnly')
+  ) {
     // calculate how much to add/subtract
     // assume that from the crossSeamCurveStart upwards, the crotch seam will be vertical
     // base of the triangle is then horizontal distance from crossSeamCurveStart to fork
     let triangleBase, triangleHeight
-    // use positive value for triangleBase: positive angle means higher back 
+    // use positive value for triangleBase: positive angle means higher back
     triangleBase = points.fork.dx(points.crossSeamCurveStart)
     // length of opposite side is length of adjacent side times tangent of the angle
-    triangleHeight = Math.tan(options.waistAngle * Math.PI/180) * triangleBase
-       
+    triangleHeight = Math.tan((options.waistAngle * Math.PI) / 180) * triangleBase
+
     // top of cross seam is a straight line, so just extend
-    points.styleWaistIn = points.crossSeamCurveStart.shiftOutwards(points.styleWaistIn,triangleHeight)
-    
+    points.styleWaistIn = points.crossSeamCurveStart.shiftOutwards(
+      points.styleWaistIn,
+      triangleHeight
+    )
+
     // report the change in height
-    log.info(['additionalHeightCenterBack',units(triangleHeight)])
+    log.info(['additionalHeightCenterBack', units(triangleHeight)])
   }
   // Adapt the vertical placement of the seat control point to the lowered waist
   points.seatOutCp2.y = points.seatOut.y - points.styleWaistOut.dy(points.seatOut) / 2
@@ -447,13 +454,9 @@ export const back = {
     fitKnee: { bool: false, menu: 'style' },
     waistAngle: { deg: 0, min: -20, max: 20, menu: 'style' },
     useWaistAngleFor: {
-      dflt: "both",
-      list: [
-        "both",
-        "backOnly",
-        "frontOnly",
-      ],
-      menu: 'style'
+      dflt: 'both',
+      list: ['both', 'backOnly', 'frontOnly'],
+      menu: 'style',
     },
 
     // Advanced

--- a/sites/orgdocs/docs/designs/titan/options/usewaistanglefor/readme.mdx
+++ b/sites/orgdocs/docs/designs/titan/options/usewaistanglefor/readme.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Use waistband angle for'
+---
+
+Determines if the Waistband angle setting is applied to the back part, the front part or both.
+
+Note that applying the setting to only one of the parts can create an angle at the sideseam.

--- a/sites/orgdocs/docs/designs/titan/options/waistangle/readme.mdx
+++ b/sites/orgdocs/docs/designs/titan/options/waistangle/readme.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Waistband angle'
+---
+
+Controls the angle of the waistband when the garment is viewed from the side.
+
+Increasing this option will raise the back of the pants and lower the waistband in the front.
+This is ideal for those with a curvy body who want the waistband to sit below the belly in the front, but above the butt in the back.
+
+If you're setting the waistband angle to a larger value, it's also a good idea to increase the waist height to make sure you've got enough coverage in the front.


### PR DESCRIPTION
This is a follow-up to #3493 and #1102 and adds the missing documentation and i18n strings for titan. (I haven't added documentation for all titan based designs, since that would be a lot of dumb copy-paste. As suggested before, it would be good in option documentation could be inherited by child designs somehow.)

This also adds a small feature that tries to calculate the optimal waistband angle based on the measurements and flags it to the user. (This flag message can be disabled by designs who don't want to use it, e.g. because they want to hardcode a waistband angle or do their own adjustments.) The formula is based on this sketch:

![image](https://github.com/user-attachments/assets/854728fe-6c21-47fc-bcf7-e18dba4981a3)

It's tested with the curated measurements, and my measurements, though, and seems to give reasonable results based on how curvy the bodies are. I haven't made a mock though or did large-scale testing.

For reference, the suggested angles for the measurement sets are:
* Elanor: 0° (not needed)
* Vanessa: 13.18°
* Ghislain: 0° (not needed)
* Joost: 2.88°
* My measurements: 3.8°
with my measurements definitely needing some adjustments as discussed on Discord.

This commit also contains minor code format fixes.