### PR TITLE
fix(config): Add exports to react-components package

### DIFF
--- a/config/exceptions.yaml
+++ b/config/exceptions.yaml
@@ -32,7 +32,7 @@ packageJson:
     author: AlfaLyr (https://github.com/alfalyr)
   i18n:
     private: true
-  jane: 
+  jane:
     author: SeaZeeZee (https://github.com/SeaZeeZee)
   lab:
     private: true
@@ -73,6 +73,16 @@ packageJson:
     files:
       - index.json
       - package.json
+  react-components:
+    exports: {
+      ".": {
+        "internal": "./src/index.mjs",
+        "default": "./dist/index.mjs"
+      },
+      "./linedrawings": "./src/linedrawings/index.mjs",
+      "./pattern": "./src/pattern/index.mjs",
+      "./xray": "./src/pattern-xray/index.mjs"
+    }
   rehype-hightlight-lines:
     private: true
   sandy:


### PR DESCRIPTION
Fixes #7206 .

(The problem was actually fixed in the repository via PR #7208 . However, Issue #7206 still re-occurs every time `yarn reconfigure` is run. This PR fixes the `yarn reconfigure` issue.)