### PR TITLE
fix(docs): Add git requirement to pattern design tutorial

### DIFF
--- a/sites/dev/docs/tutorials/pattern-design/part1/readme.mdx
+++ b/sites/dev/docs/tutorials/pattern-design/part1/readme.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Part 1: Prerequisites"
+title: 'Part 1: Prerequisites'
 ---
 
 In this first part, I will get your up and running with the FreeSewing
@@ -10,18 +10,18 @@ this section. If not, I have good news and bad news (and then some more good
 news) for you.
 
 The good news is that JavaScript is an easy language to pick up. It is also a
-very popular and versatile language and the skills you learn here will serve 
+very popular and versatile language and the skills you learn here will serve
 you well.
 
-The bad news is that the JavaScript ecosystem is vast, and unfortunately 
+The bad news is that the JavaScript ecosystem is vast, and unfortunately
 somewhat fractured. Most of the problems people need help with are not so much
 in the code itself, but rather getting everything to work together.
 This is true not just for FreeSewing, but pretty much all modern JavaScript.
 
-But, no need to despair, FreeSewing provides a development environment that 
+But, no need to despair, FreeSewing provides a development environment that
 will take care of all of this for you. So you can focus on designing patterns.
 
-If you have NodeJS on your system, getting that development environment up 
+If you have NodeJS on your system, getting that development environment up
 and running takes only a single command:
 
 ```sh
@@ -31,3 +31,15 @@ npx @freesewing/new-design
 If you don't have NodeJS on your system --- or if you're not sure what
 NodeJS is to begin with --- read on to learn how to install it.
 
+:::danger[Windows users also need to install `git`]
+
+Temporarily, the `git` command line utility is also a requirement for
+running the FreeSewing development environment.
+Linux and Mac systems come with `git` pre-installed,
+but Windows users will need to install it manually.
+
+Please see the
+[Getting started on Windows](https://freesewing.dev/tutorials/getting-started-windows#install-wsl)
+tutorial for instructions on how to install `git` on a Windows system.
+
+:::


### PR DESCRIPTION
Eventually #6827 will be fixed and `git` will no longer be a requirement for `npx @freesewing/new-design`. However, until then this PR documents this requirement and provides guidance for Windows users (who are the ones most affected by the issue).

(The only edits I made were to add the new Admonition at the end. All the other edits were done by `prettier`.)

![Screenshot 2024-11-23 at 5 27 50 PM](https://github.com/user-attachments/assets/853481c9-bb3a-4630-a44d-ef7a2631492b)
