### PR TITLE
fix(simone): Hide buttonFreeLength option when bustAlignedButtons is even

### DIFF
--- a/designs/simone/src/fba-front.mjs
+++ b/designs/simone/src/fba-front.mjs
@@ -442,6 +442,13 @@ export const fbaFront = {
       menu: 'style.closure',
     },
     lengthBonus: { pct: 25, min: -4, max: 60, menu: 'fit' },
+    buttonFreeLength: {
+      pct: 2,
+      min: -10,
+      max: 15,
+      menu: (settings, mergedOptions) =>
+        mergedOptions.bustAlignedButtons === 'even' ? false : 'style.closure',
+    },
   },
   draft: simoneFbaFront,
 }


### PR DESCRIPTION
Fixes #7058

![Screenshot 2024-11-23 at 9 22 31 PM](https://github.com/user-attachments/assets/023bdbeb-6dba-4799-8ffe-a33c3b518712)
![Screenshot 2024-11-23 at 9 22 25 PM](https://github.com/user-attachments/assets/f9ba25e5-1a8e-4720-b132-15aa0429e433)
![Screenshot 2024-11-23 at 9 22 19 PM](https://github.com/user-attachments/assets/c99aa170-4c0b-4eed-a84f-f58badead2ee)
