### PR TITLE
fix(hugo): Add Collar Ease option to allow neck opening size adjustments

### DIFF
--- a/designs/hugo/src/back.mjs
+++ b/designs/hugo/src/back.mjs
@@ -34,6 +34,8 @@ function hugoBack({
   const neckOpening = new Path()
     .move(points.cbNeck)
     .curve(points.cbNeck, points.neckCp2, points.neck)
+  const length = neckOpening.length() * 2
+  store.set('front_neck_len', length)
   points.raglanTipBack = neckOpening.shiftFractionAlong(0.7)
   const neckOpeningParts = neckOpening.split(points.raglanTipBack)
   // Paths

--- a/designs/hugo/src/front.mjs
+++ b/designs/hugo/src/front.mjs
@@ -61,6 +61,8 @@ function hugoFront({
   const neckOpening = new Path()
     .move(points.cfNeck)
     .curve(points.cfNeckCp1, points.neckCp2, points.neck)
+  const length = neckOpening.length() * 2
+  store.set('back_neck_len', length)
   points.raglanTipFront = neckOpening.shiftFractionAlong(0.8)
   const neckOpeningParts = neckOpening.split(points.raglanTipFront)
 

--- a/designs/hugo/src/options.mjs
+++ b/designs/hugo/src/options.mjs
@@ -1,4 +1,3 @@
-export const collarEase = 0.05
 export const armholeDepthFactor = 0.5
 export const shoulderEase = 0
 export const shoulderSlopeReduction = 0
@@ -14,3 +13,4 @@ export const lengthBonus = { pct: 10, min: 0, max: 20, menu: 'style' }
 export const sleeveLengthBonus = { pct: 2, min: 0, max: 10, menu: 'style' }
 export const ribbingHeight = { pct: 10, min: 4, max: 20, menu: 'style' }
 export const pocketWidth = { pct: 50, min: 35, max: 65, menu: 'style' }
+export const collarEase = { pct: 15, min: 0, max: 40, menu: 'fit' }

--- a/designs/hugo/src/sleeve.mjs
+++ b/designs/hugo/src/sleeve.mjs
@@ -17,6 +17,8 @@ function hugoSleeve({
   options,
   measurements,
   macro,
+  log,
+  units,
   part,
 }) {
   // Top of raglan sleeve
@@ -232,6 +234,44 @@ function hugoSleeve({
     to: points.wristRight,
     y: points.wristLeft.y + 15 + sa,
   })
+
+  /*
+   *  Check neck opening size and warn if necessary.
+   */
+  const sleeve_neck_len =
+    new Path()
+      .move(points.raglanTipBack)
+      .curve(points.raglanTipBackCp2, points.raglanTopCp1, points.raglanTop)
+      .curve(points.raglanTopCp2, points.raglanTipFrontCp1, points.raglanTipFront)
+      .length() * 2
+
+  const neck_opening = store.get('front_neck_len') + store.get('back_neck_len') + sleeve_neck_len
+  const diff = measurements.head - neck_opening
+  const discrepancy = diff / measurements.head
+  const warning_limit = 0.04
+  let label = ' bigger than '
+  if (diff > 0) label = ' smaller than '
+
+  log.info(
+    ': ' +
+      units(neck_opening) +
+      ' neck opening is ' +
+      units(Math.abs(diff)) +
+      label +
+      ' than ' +
+      units(measurements.head) +
+      ' head circumference, with Collar Ease set to ' +
+      (options.collarEase * 100).toFixed(0) +
+      '%.'
+  )
+
+  if (discrepancy > warning_limit) {
+    log.warn(
+      'Please check and adjust Collar Ease option setting ' +
+        'as needed to ensure neck opening is large enough to accommodate ' +
+        'head circumference.'
+    )
+  }
 
   return part
 }

--- a/sites/orgdocs/docs/designs/hugo/options/collarease/collarease.svg
+++ b/sites/orgdocs/docs/designs/hugo/options/collarease/collarease.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1000.0001"
+   height="570"
+   viewBox="0 0 264.58335 150.8125"
+   version="1.1"
+   id="svg562"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="collarease.svg">
+  <defs
+     id="defs556">
+    <marker
+       style="overflow:visible"
+       id="Arrow1MstartQR"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#ff5b77;fill-rule:evenodd;stroke:#ff5b77;stroke-width:1.00000003pt;marker-start:none"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5084" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend3"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5087"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff5b77;fill-rule:evenodd;stroke:#ff5b77;stroke-width:1.00000003pt;marker-start:none"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker53"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#ff5b77;fill-rule:evenodd;stroke:#ff5b77;stroke-width:1.00000003pt;marker-start:none"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path51" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker57"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path55"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff5b77;fill-rule:evenodd;stroke:#ff5b77;stroke-width:1.00000003pt;marker-start:none"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.8101934"
+     inkscape:cx="643.91418"
+     inkscape:cy="184.47717"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     showguides="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata559">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-47.625)">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       style="fill:#808080;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 54.1423,55.951664 41.911976,57.89133 41.479965,72.528929 88.376337,70.286566 90.362996,57.874273 78.243784,55.951664 c -2.227828,2.394111 -6.970559,2.235652 -12.047084,2.235652 -5.836933,0.03682 -9.857971,0.124718 -12.0544,-2.235652 z"
+       id="inside"
+       inkscape:connector-curvature="0" />
+    <path
+       id="primary1"
+       style="fill:#404040;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 54.365069,55.951664 -24.994326,3.963971 c 0.172338,1.737552 3.199375,16.991043 3.199375,24.085049 0.437121,18.491896 -1.180108,20.477076 -2.081846,24.079736 2.059602,15.42627 -0.19137,23.36576 -0.19859,37.43095 0,15.45988 -2.473168,37.24966 -2.818075,41.08324 l 77.888383,0.1366 c -0.34465,-3.83357 -1.77452,-24.63877 -1.77452,-40.09865 0,-21.75303 -1.51285,-35.46062 -1.51285,-40.89932 -2.227137,-3.85782 -3.165523,-15.233969 -2.405677,-24.110942 0,-7.094007 3.614267,-19.969111 3.786587,-21.706663 L 78.466544,55.951664 C 76.238715,58.345775 79.8041,67.655702 66.41946,67.700859 53.034819,67.746011 56.561498,58.312034 54.365069,55.951664 Z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccsccccsc" />
+    <path
+       id="primary2"
+       style="fill:#404040;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 29.976678,59.796959 c 4.038677,5.842073 7.195097,34.945535 2.259218,43.712951 -3.300515,29.05614 -11.777082,63.63539 -14.767163,87.13685 -7.17153,0.38249 -9.8107924,0.34584 -14.4503455,-1.16564 C 3.325709,152.0588 11.092508,115.43576 19.69795,80.932692 22.337969,70.842832 26.664555,59.796959 29.976678,59.796959 Z m 73.645182,0 c -4.038678,5.842073 -7.195093,34.945535 -2.25922,43.712951 3.30052,29.05614 11.77708,63.63539 14.76716,87.13685 7.17153,0.38249 9.8108,0.34584 14.45035,-1.16564 -0.30732,-37.42232 -8.07412,-74.04536 -16.67956,-108.548428 -2.64002,-10.08986 -6.96661,-21.135733 -10.27873,-21.135733 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path973"
+       d="m 182.5973,56.623458 -9.28477,1.267872 -0.43201,14.637599 46.89637,-2.242363 1.98666,-12.412293 -8.70857,-1.560874 c -2.22783,2.394111 -10.3812,1.873917 -15.45772,1.873917 -5.83694,0.03682 -12.80353,0.796512 -14.99996,-1.563858 z"
+       style="fill:#808080;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       sodipodi:nodetypes="cccccccsccccsc"
+       inkscape:connector-curvature="0"
+       d="m 182.35499,56.623458 -21.58369,3.292177 c 0.17234,1.737552 3.19938,16.991043 3.19938,24.085049 0.43712,18.491896 -1.18011,20.477076 -2.08185,24.079736 2.0596,15.42627 -0.19137,23.36576 -0.19859,37.43095 0,15.45988 -2.47317,37.24966 -2.81808,41.08324 l 77.88839,0.1366 c -0.34465,-3.83357 -1.77452,-24.63877 -1.77452,-40.09865 0,-21.75303 -1.51285,-35.46062 -1.51285,-40.89932 -2.22714,-3.85782 -3.16553,-15.233969 -2.40568,-24.110942 0,-7.094007 3.61427,-19.969111 3.78659,-21.706663 l -22.04143,-3.600996 c -2.22783,2.394111 -1.608,12.997189 -14.99264,13.042346 -13.38464,0.04515 -13.2686,-10.373157 -15.46503,-12.733527 z"
+       style="fill:#404040;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path975" />
+    <path
+       sodipodi:nodetypes="cccccccccccc"
+       inkscape:connector-curvature="0"
+       d="m 161.37724,59.796959 c 4.03867,5.842073 7.19509,34.945535 2.25921,43.712951 -3.30051,29.05614 -11.77708,63.63539 -14.76716,87.13685 -7.17153,0.38249 -9.81079,0.34584 -14.45034,-1.16564 0.30732,-37.42232 8.07412,-74.04536 16.67956,-108.548428 2.64002,-10.08986 6.9666,-21.135733 10.27873,-21.135733 z m 73.64518,0 c -4.03868,5.842073 -7.1951,34.945535 -2.25922,43.712951 3.30052,29.05614 11.77708,63.63539 14.76716,87.13685 7.17153,0.38249 9.8108,0.34584 14.45035,-1.16564 -0.30732,-37.42232 -8.07412,-74.04536 -16.67956,-108.548428 -2.64002,-10.08986 -6.96661,-21.135733 -10.27873,-21.135733 z"
+       style="fill:#404040;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path977" />
+  </g>
+</svg>

--- a/sites/orgdocs/docs/designs/hugo/options/collarease/readme.mdx
+++ b/sites/orgdocs/docs/designs/hugo/options/collarease/readme.mdx
@@ -1,0 +1,12 @@
+---
+title: 'Collar ease'
+---
+
+![Collar ease](collarease.svg)
+
+Controls the amount of ease at your collar/neck and the size
+of the neck opening..
+
+Hugo uses the neck circumference measurement rather than head
+circumference to produce the neck opening size when generating patterns.
+Use this option to adjust the neck opening size if needed.


### PR DESCRIPTION
Fixes #7114

1. This PR changes the Collar Ease design option default from 5% to 15%.
2. It also exposes Collar Ease in the UI, allowing customers to change the setting. The min is 0% and the max is 40%.
3. A log info message is added to let customers know the neck opening size and to make it easy for them to compare it to their head circumference.
4. A log warn message is added if the neck opening size is notably smaller than the head circumference.