### PR TITLE
fix(plugin-annontations) Logo position tweaked

### DIFF
--- a/plugins/plugin-annotations/src/logo.mjs
+++ b/plugins/plugin-annotations/src/logo.mjs
@@ -7,6 +7,6 @@ export const logoDefs = [
     def: (scale) =>
       `<g id="logo" transform="scale(${
         2 * scale
-      }) translate(-23 -36)"><path class="logo" fill="currentColor" d="${logoPath}"/></g>`,
+      }) translate(-12.55 -18)"><path class="logo" fill="currentColor" d="${logoPath}"/></g>`,
   },
 ]


### PR DESCRIPTION
The shared path causes the logo to be offset differently so to fix this making a slight tweak to the translate.
Before
![image](https://github.com/user-attachments/assets/89fac76a-a197-47ca-a4e2-32b5235a4ecb)

After
![image](https://github.com/user-attachments/assets/2c98ff55-ec79-494a-bc52-f3a56b4fa802)

Designs after Oct 2023 will need to be checked as they may have been drafted with.