### PR TITLE
Prevent missing settings object causing exceptions when opening design editor

### DIFF
--- a/packages/react/components/Editor/index.mjs
+++ b/packages/react/components/Editor/index.mjs
@@ -92,6 +92,11 @@ export const Editor = ({ config = {}, design = false, preload = {}, setTitle = f
         }
       : { ...state, _: { ...ephemeralState, missingMeasurements } }
 
+  /*
+   * Ensure the settings object is always present, so we don't have to do null checks everywhere
+   */
+  passDownState.settings = passDownState.settings || {}
+
   return (
     <div className="flex flex-row items-top">
       {editorConfig.withAside ? <AsideViewMenu update={update} state={passDownState} /> : null}


### PR DESCRIPTION
Potential fix for the crash accessing `state.settings` in `DesignOptionsMenu.mjs` when opening https://v4.freesewing.org/editor/#s={%22design%22%3A%22hi%22%2C%22view%22%3A%22draft%22}

This could possibly be also fixed in `DesignOptionsMenu.mjs` instead, but there seem to be a lot of code locations where `settings` is potentially accessed.