### PR TITLE
Fix the cutting instructions for the Simon Yoke

### DIFF
--- a/designs/simon/src/yoke.mjs
+++ b/designs/simon/src/yoke.mjs
@@ -1,10 +1,24 @@
 import { back } from './back.mjs'
 import { splitYoke } from './options.mjs'
 
-function simonYoke({ sa, Point, points, Path, paths, Snippet, snippets, macro, options, part }) {
+function simonYoke({
+  sa,
+  Point,
+  points,
+  Path,
+  paths,
+  Snippet,
+  snippets,
+  macro,
+  options,
+  store,
+  part,
+}) {
   for (const id in paths) {
     if (['backCollar', 'backArmhole', 'backArmholeYoke'].indexOf(id) === -1) delete part.paths[id]
   }
+
+  store.cutlist.setCut({ cut: 2, from: 'fabric' })
 
   // Paths
   paths.saBase = new Path().move(points.cbYoke).line(points.armholeYokeSplitPreBoxpleat)


### PR DESCRIPTION
- Previously it said to cut 1 on the fold, which is wrong. You don't cut the yoke on the fold, it's two pieces.
- Now it says to cut 2 mirrored from main fabric, which is correct.

Bug report that I submitted: https://github.com/freesewing/freesewing/issues/7365

before:
<img width="974" alt="yoke" src="https://github.com/user-attachments/assets/ca31dc3c-2a69-4ded-bedd-eec3417feb94" />


after:
![Screenshot 2025-03-21 at 10 37 23 PM](https://github.com/user-attachments/assets/15a9bd66-c793-4959-9d81-47f804663d56)
