### PR TITLE
Fix Simon Shirt Cuff Cutting Instructions

### DIFF
--- a/designs/simon/src/shared.mjs
+++ b/designs/simon/src/shared.mjs
@@ -129,7 +129,10 @@ export const draftBarrelCuff = (part) => {
 export const decorateBarrelCuff = (part) => {
   const { macro, store, snippets, Snippet, points, measurements, options, Point } = part.shorthand()
   // Cutlist
-  store.cutlist.setCut({ cut: 4, from: 'fabric' })
+  store.cutlist.setCut([
+    { cut: 4, from: 'fabric' },
+    { cut: 2, from: 'interfacing' },
+  ])
 
   // Title
   points.title = new Point(points.bottomRight.x / 2, points.bottomRight.y / 2)
@@ -188,7 +191,10 @@ export const draftFrenchCuff = (part) => {
 export const decorateFrenchCuff = (part) => {
   const { macro, store, snippets, Snippet, points, measurements, options, Point } = part.shorthand()
   // Cutlist
-  store.cutlist.setCut({ cut: 4, from: 'fabric' })
+  store.cutlist.setCut([
+    { cut: 4, from: 'fabric' },
+    { cut: 2, from: 'interfacing' },
+  ])
 
   // Title
   points.title = new Point(points.bottomRight.x / 2, points.bottomRight.y / 2)


### PR DESCRIPTION
Add "Cut 2 from interfacing" to the cutting instructions on the Simon shirt cuffs pattern. The cutting instructions in the documentation say to cut 2 from interfacing.

Bug report: https://github.com/freesewing/freesewing/issues/7366

Before:
<img width="1317" alt="Screenshot 2025-03-12 at 5 27 24 AM" src="https://github.com/user-attachments/assets/2defd5e5-124d-4ecb-9c4b-46cbee22c115" />

After:
![Screenshot 2025-03-22 at 8 23 20 PM](https://github.com/user-attachments/assets/44117915-e41e-493e-8c46-61a69ca46969)

cutting instructions:
<img width="713" alt="Image" src="https://github.com/user-attachments/assets/d16cdc2f-2a61-4455-99db-8248172d1e53" />
